### PR TITLE
Fix decoding of boolean columns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ include_directories(SYSTEM ${LZ4_INCLUDE_DIR})
 add_library(lz4static STATIC IMPORTED)
 set_target_properties(lz4static PROPERTIES IMPORTED_LOCATION ${LZ4_STATIC_LIB})
 
-SET(CMAKE_CXX_FLAGS "-msse4.2 -Wall -Wno-unused-value -Wno-unused-variable -Wno-sign-compare -Wno-unknown-pragmas")
+SET(CMAKE_CXX_FLAGS "-O3 -msse4.2 -Wall -Wno-unused-value -Wno-unused-variable -Wno-sign-compare -Wno-unknown-pragmas")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -ggdb")
 
 # Thrift requires these definitions for some types that we use


### PR DESCRIPTION
The parquet spec is misleading for "Plain, BOOLEAN" columns: it says: "BOOLEAN: Bit Packed, LSB first" but links to the description of the RLE encoding scheme which doesn't make sense in a PLAIN context.

The Java implementation uses plain bit-packed encoding, that is, one bit per row.  I tested this code change against parquet files produced by it.
