### PR TITLE
PARQUET-428: Support INT96 and FIXED_LEN_BYTE_ARRAY types

### DIFF
--- a/src/parquet/column_reader.cc
+++ b/src/parquet/column_reader.cc
@@ -187,6 +187,8 @@ std::shared_ptr<ColumnReader> ColumnReader::Make(const parquet::ColumnMetaData* 
       return std::make_shared<DoubleReader>(metadata, element, stream);
     case Type::BYTE_ARRAY:
       return std::make_shared<ByteArrayReader>(metadata, element, stream);
+    case Type::FIXED_LEN_BYTE_ARRAY:
+      return std::make_shared<FixedLenByteArrayReader>(metadata, element, stream);
     default:
       ParquetException::NYI("type reader not implemented");
   }

--- a/src/parquet/column_reader.h
+++ b/src/parquet/column_reader.h
@@ -159,6 +159,7 @@ typedef TypedColumnReader<parquet::Type::INT96> Int96Reader;
 typedef TypedColumnReader<parquet::Type::FLOAT> FloatReader;
 typedef TypedColumnReader<parquet::Type::DOUBLE> DoubleReader;
 typedef TypedColumnReader<parquet::Type::BYTE_ARRAY> ByteArrayReader;
+typedef TypedColumnReader<parquet::Type::FIXED_LEN_BYTE_ARRAY> FixedLenByteArrayReader;
 
 
 template <int TYPE>

--- a/src/parquet/encodings/plain-encoding.h
+++ b/src/parquet/encodings/plain-encoding.h
@@ -74,6 +74,22 @@ inline int PlainDecoder<parquet::Type::BYTE_ARRAY>::Decode(ByteArray* buffer,
   return max_values;
 }
 
+// Template specialization for FIXED_LEN_BYTE_ARRAY
+template <>
+inline int PlainDecoder<parquet::Type::FIXED_LEN_BYTE_ARRAY>::Decode(FixedLenByteArray* buffer,
+    int max_values) {
+  max_values = std::min(max_values, num_values_);
+  int len = schema_->type_length;
+  for (int i = 0; i < max_values; ++i) {
+    if (len_ < len) ParquetException::EofException();
+    buffer[i].ptr = data_;
+    data_ += len;
+    len_ -= len;
+  }
+  num_values_ -= max_values;
+  return max_values;
+}
+
 template <>
 class PlainDecoder<parquet::Type::BOOLEAN> : public Decoder<parquet::Type::BOOLEAN> {
  public:

--- a/src/parquet/util/compiler-util.h
+++ b/src/parquet/util/compiler-util.h
@@ -36,4 +36,25 @@
 
 #define PREFETCH(addr) __builtin_prefetch(addr)
 
+//macros to disable padding
+//these macros are portable across different compilers and platforms
+//[https://github.com/google/flatbuffers/blob/master/include/flatbuffers/flatbuffers.h#L1355]
+#if defined(_MSC_VER)
+  #define MANUALLY_ALIGNED_STRUCT(alignment) \
+    __pragma(pack(1)); \
+    struct __declspec(align(alignment))
+  #define STRUCT_END(name, size) \
+    __pragma(pack()); \
+    static_assert(sizeof(name) == size, "compiler breaks packing rules")
+#elif defined(__GNUC__) || defined(__clang__)
+  #define MANUALLY_ALIGNED_STRUCT(alignment) \
+    _Pragma("pack(1)") \
+    struct __attribute__((aligned(alignment)))
+  #define STRUCT_END(name, size) \
+    _Pragma("pack()") \
+    static_assert(sizeof(name) == size, "compiler breaks packing rules")
+#else
+  #error Unknown compiler, please define structure alignment macros
+#endif
+
 #endif // PARQUET_UTIL_COMPILER_UTIL_H


### PR DESCRIPTION
This PR adds support for INT96 and FIXED_LEN_BYTE_ARRAY types.
It modifies the examples and DebugPrint to handle these types.