### PR TITLE
PARQUET-454: Fix inconsistencies with boolean PLAIN encoding

### DIFF
--- a/src/parquet/encodings/CMakeLists.txt
+++ b/src/parquet/encodings/CMakeLists.txt
@@ -24,3 +24,5 @@ install(FILES
   dictionary-encoding.h
   plain-encoding.h
   DESTINATION include/parquet/encodings)
+
+ADD_PARQUET_TEST(plain-encoding-test)

--- a/src/parquet/encodings/encodings.h
+++ b/src/parquet/encodings/encodings.h
@@ -20,10 +20,9 @@
 
 #include <cstdint>
 
+#include "parquet/exception.h"
 #include "parquet/types.h"
 
-#include "parquet/thrift/parquet_constants.h"
-#include "parquet/thrift/parquet_types.h"
 #include "parquet/util/rle-encoding.h"
 #include "parquet/util/bit-stream-utils.inline.h"
 

--- a/src/parquet/encodings/plain-encoding-test.cc
+++ b/src/parquet/encodings/plain-encoding-test.cc
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <cstdint>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "parquet/util/test-common.h"
+
+#include "parquet/encodings/encodings.h"
+
+using std::string;
+using std::vector;
+
+namespace parquet_cpp {
+
+namespace test {
+
+static vector<bool> flip_coins(size_t n, double p) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+
+  std::bernoulli_distribution d(p);
+
+  vector<bool> draws;
+  for (size_t i = 0; i < n; ++i) {
+    draws.push_back(d(gen));
+  }
+  return draws;
+}
+
+TEST(BooleanTest, TestEncodeDecode) {
+  // PARQUET-454
+
+  size_t nvalues = 100;
+  size_t nbytes = BitUtil::RoundUp(nvalues, 8) / 8;
+
+  vector<bool> draws = flip_coins(nvalues, 0.5);
+
+  PlainEncoder<Type::BOOLEAN> encoder(nullptr);
+  PlainDecoder<Type::BOOLEAN> decoder(nullptr);
+
+  std::vector<uint8_t> encode_buffer(nbytes);
+
+  size_t encoded_bytes = encoder.Encode(draws, nvalues, &encode_buffer[0]);
+  ASSERT_EQ(nbytes, encoded_bytes);
+
+  std::vector<uint8_t> decode_buffer(nbytes);
+  const uint8_t* decode_data = &decode_buffer[0];
+
+  decoder.SetData(nvalues, &encode_buffer[0], encoded_bytes);
+  size_t values_decoded = decoder.Decode(&decode_buffer[0], nvalues);
+  ASSERT_EQ(nvalues, values_decoded);
+
+  for (size_t i = 0; i < nvalues; ++i) {
+    ASSERT_EQ(BitUtil::GetArrayBit(decode_data, i), draws[i]) << i;
+  }
+}
+
+} // namespace test
+
+} // namespace parquet_cpp

--- a/src/parquet/encodings/plain-encoding-test.cc
+++ b/src/parquet/encodings/plain-encoding-test.cc
@@ -16,7 +16,6 @@
 // under the License.
 
 #include <cstdint>
-#include <random>
 #include <string>
 #include <vector>
 
@@ -32,26 +31,14 @@ namespace parquet_cpp {
 
 namespace test {
 
-static vector<bool> flip_coins(size_t n, double p) {
-  std::random_device rd;
-  std::mt19937 gen(rd());
-
-  std::bernoulli_distribution d(p);
-
-  vector<bool> draws;
-  for (size_t i = 0; i < n; ++i) {
-    draws.push_back(d(gen));
-  }
-  return draws;
-}
-
 TEST(BooleanTest, TestEncodeDecode) {
   // PARQUET-454
 
   size_t nvalues = 100;
   size_t nbytes = BitUtil::RoundUp(nvalues, 8) / 8;
 
-  vector<bool> draws = flip_coins(nvalues, 0.5);
+  // seed the prng so failure is deterministic
+  vector<bool> draws = flip_coins_seed(nvalues, 0.5, 0);
 
   PlainEncoder<Type::BOOLEAN> encoder(nullptr);
   PlainDecoder<Type::BOOLEAN> decoder(nullptr);

--- a/src/parquet/util/bit-util.h
+++ b/src/parquet/util/bit-util.h
@@ -270,6 +270,14 @@ class BitUtil {
     return v | (static_cast<T>(0x1) << bitpos);
   }
 
+  static inline bool GetArrayBit(const uint8_t* bits, size_t i) {
+    return bits[i / 8] & (1 << (i % 8));
+  }
+
+  static inline void SetArrayBit(uint8_t* bits, size_t i, bool is_set) {
+    bits[i / 8] |= (1 << (i % 8)) * is_set;
+  }
+
   // Set a specific bit to 0
   // Behavior when bitpos is negative is undefined
   template<typename T>

--- a/src/parquet/util/test-common.h
+++ b/src/parquet/util/test-common.h
@@ -19,6 +19,7 @@
 #define PARQUET_UTIL_TEST_COMMON_H
 
 #include <iostream>
+#include <random>
 #include <vector>
 
 using std::vector;
@@ -45,6 +46,32 @@ static inline bool vector_equal(const vector<T>& left, const vector<T>& right) {
 
   return true;
 }
+
+static inline vector<bool> flip_coins_seed(size_t n, double p, uint32_t seed) {
+  std::mt19937 gen(seed);
+  std::bernoulli_distribution d(p);
+
+  vector<bool> draws;
+  for (size_t i = 0; i < n; ++i) {
+    draws.push_back(d(gen));
+  }
+  return draws;
+}
+
+
+static inline vector<bool> flip_coins(size_t n, double p) {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+
+  std::bernoulli_distribution d(p);
+
+  vector<bool> draws;
+  for (size_t i = 0; i < n; ++i) {
+    draws.push_back(d(gen));
+  }
+  return draws;
+}
+
 
 } // namespace test
 


### PR DESCRIPTION
Requires PARQUET-485 (#32)

The boolean Encoding::PLAIN code path was using RleDecoder, inconsistent with
other implementations of Parquet. This patch adds an implementation of plain
encoding and uses BitReader instead of RleDecoder to decode plain-encoded
boolean data. Unit tests to verify.

Also closes PR #12. Thanks to @edani for reporting. 