### PR TITLE
PARQUET-481: Refactored and expanded reader-test and scanner-test.

### DIFF
--- a/src/parquet/column/CMakeLists.txt
+++ b/src/parquet/column/CMakeLists.txt
@@ -24,3 +24,4 @@ install(FILES
   DESTINATION include/parquet/column)
 
 ADD_PARQUET_TEST(column-reader-test)
+ADD_PARQUET_TEST(scanner-test)

--- a/src/parquet/column/scanner-test.cc
+++ b/src/parquet/column/scanner-test.cc
@@ -22,7 +22,7 @@
 
 #include <gtest/gtest.h>
 
-#include "parquet/column/reader.h"
+#include "parquet/column/scanner.h"
 #include "parquet/util/test-common.h"
 
 using std::string;
@@ -31,50 +31,38 @@ namespace parquet_cpp {
 
 namespace test {
 
-  TEST_P(TestReader, Metadata) {
-    reader_.ParseMetaData();
-  }
-
-  TEST_P(TestReader, DebugPrintWorks) {
-    std::stringstream ss;
-    reader_.DebugPrint(ss);
-    std::string result = ss.str();
-    ASSERT_TRUE(result.length() > 0);
-  }
-
-  TEST_P(TestReader, BatchReadInt32) {
+  TEST_P(TestReader, FlatScannerInt32) {
     ssize_t c = findColumn(Type::INT32);
     if (c >= 0) {
       RowGroupReader* group = reader_.RowGroup(0);
-      const parquet::ColumnMetaData* metadata = group->column_metadata(c);
-      int64_t rows = metadata->num_values;
+      int64_t rows = group->column_metadata(c)->num_values;
 
-      std::shared_ptr<Int32Reader> col =
-          std::dynamic_pointer_cast<Int32Reader>(group->Column(c));
+      std::shared_ptr<Int32Scanner> scanner =
+          std::make_shared<Int32Scanner>(group->Column(c));
 
-      int16_t def_levels[rows];
-      int16_t rep_levels[rows];
-      int32_t values[rows];
-
-      // Read all but last rows
-      ASSERT_TRUE(col->HasNext());
-      size_t values_read;
-      size_t levels_read =
-          col->ReadBatch(rows-1, def_levels, rep_levels, values, &values_read);
-      ASSERT_EQ(rows-1, levels_read);
-      size_t total_values_read = values_read;
-
-      // Now read past the end of the file
-      ASSERT_TRUE(col->HasNext());
-      levels_read = col->ReadBatch(2, def_levels, rep_levels, values, &values_read);
-      ASSERT_EQ(1, levels_read);
-      total_values_read += values_read;
-
-      ASSERT_FALSE(col->HasNext());
-
-      ASSERT_EQ(total_values_read, rows - metadata->statistics.null_count);
+      int32_t val;
+      bool is_null;
+      for (; rows > 0; rows--) {
+        scanner->NextValue(&val, &is_null);
+      }
+      ASSERT_FALSE(scanner->HasNext());
+      ASSERT_FALSE(scanner->NextValue(&val, &is_null));
     }
   }
+
+  TEST_P(TestReader, ScannerBatchSize) {
+    ssize_t c = findColumn(Type::INT32);
+    if (c >= 0) {
+      RowGroupReader* group = reader_.RowGroup(0);
+      std::shared_ptr<Int32Scanner> scanner =
+          std::make_shared<Int32Scanner>(group->Column(c));
+
+      ASSERT_EQ(128, scanner->batch_size());
+      scanner->SetBatchSize(1024);
+      ASSERT_EQ(1024, scanner->batch_size());
+    }
+  }
+
 
   INSTANTIATE_TEST_CASE_P(ReaderTest, TestReader,
       testing::Values(

--- a/src/parquet/column/scanner.h
+++ b/src/parquet/column/scanner.h
@@ -201,6 +201,7 @@ inline void TypedScanner<parquet::Type::FIXED_LEN_BYTE_ARRAY>::FormatValue(
   snprintf(buffer, bufsize, fmt.c_str(), result.c_str());
 }
 
+
 typedef TypedScanner<parquet::Type::BOOLEAN> BoolScanner;
 typedef TypedScanner<parquet::Type::INT32> Int32Scanner;
 typedef TypedScanner<parquet::Type::INT64> Int64Scanner;

--- a/src/parquet/reader.cc
+++ b/src/parquet/reader.cc
@@ -317,11 +317,6 @@ void ParquetFileReader::DebugPrint(std::ostream& stream, bool print_values) {
     do {
       hasRow = false;
       for (int c = 0; c < nColumns; ++c) {
-        if (scanners[c] == NULL) {
-          snprintf(buffer, bufsize, "%-" COL_WIDTH"s", " ");
-          stream << buffer;
-          continue;
-        }
         if (scanners[c]->HasNext()) {
           hasRow = true;
           scanners[c]->PrintNext(stream, 17);


### PR DESCRIPTION
Changes:
* Moved Scanner tests from reader-test.cc to scanner-test.cc
* Expanded both tests to run on multiple files.

This also resolves PARQUET-475 and PARQUET-502.