### PR TITLE
PARQUET-507: Reduce the runtime of rle-test

### DIFF
--- a/src/parquet/util/rle-test.cc
+++ b/src/parquet/util/rle-test.cc
@@ -318,14 +318,22 @@ TEST(BitRle, Flush) {
 // Test some random sequences.
 TEST(BitRle, Random) {
   int iters = 0;
-  while (iters < 1000) {
+
+  size_t niters = 500;
+  size_t ngroups = 1000;
+  size_t max_group_size = 16;
+  vector<int> values(ngroups + max_group_size);
+
+  while (iters < niters) {
     srand(iters++);
     if (iters % 10000 == 0) LOG(ERROR) << "Seed: " << iters;
-    vector<int> values;
     bool parity = 0;
-    for (int i = 0; i < 1000; ++i) {
+
+    values.resize(0);
+
+    for (int i = 0; i < ngroups; ++i) {
       int group_size = rand() % 20 + 1;  // NOLINT
-      if (group_size > 16) {
+      if (group_size > max_group_size) {
         group_size = 1;
       }
       for (int i = 0; i < group_size; ++i) {

--- a/src/parquet/util/rle-test.cc
+++ b/src/parquet/util/rle-test.cc
@@ -344,8 +344,6 @@ TEST(BitRle, Flush) {
 
 // Test some random sequences.
 TEST(BitRle, Random) {
-  int iters = 0;
-
   size_t niters = 50;
   size_t ngroups = 1000;
   size_t max_group_size = 16;
@@ -374,7 +372,7 @@ TEST(BitRle, Random) {
       }
       parity = !parity;
     }
-    if (!CheckRoundTrip(values, (iters % MAX_WIDTH) + 1)) {
+    if (!CheckRoundTrip(values, BitUtil::NumRequiredBits(values.size()))) {
       FAIL() << "failing seed: " << seed;
     }
   }

--- a/src/parquet/util/rle-test.cc
+++ b/src/parquet/util/rle-test.cc
@@ -351,7 +351,7 @@ TEST(BitRle, Random) {
 
   // prng setup
   std::random_device rd;
-  std::uniform_int_distribution<int> dist(1, std::numeric_limits<int>::max());
+  std::uniform_int_distribution<int> dist(1, 20);
 
   uint32_t seed = 0;
   for (int iter = 0; iter < niters; ++iter) {
@@ -363,7 +363,7 @@ TEST(BitRle, Random) {
     values.resize(0);
 
     for (int i = 0; i < ngroups; ++i) {
-      int group_size = dist(gen) % 20 + 1;  // NOLINT
+      int group_size = dist(gen);
       if (group_size > max_group_size) {
         group_size = 1;
       }


### PR DESCRIPTION
I twiddled this a bit to cut the runtime in half. I'd like to reduce it further but looking for feedback -- my preference would be to use system entropy (`std::random_device`) to seed the PRNG and print the seed on failure. So we could run far fewer tests (e.g. only 50 or 100 or so) and occasionally run into flakiness or failure if we refactor and break something internally. Thoughts?