### PR TITLE
PARQUET-448: Add cmake options to not build tests and/or executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,19 @@ endif(NOT CMAKE_BUILD_TYPE)
 # set compile output directory
 string (TOLOWER ${CMAKE_BUILD_TYPE} BUILD_SUBDIR_NAME)
 
+# Top level cmake file, set options
+if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+  option(PARQUET_BUILD_TESTS
+	"Build the libparquet test suite"
+	ON)
+  option(PARQUET_BUILD_EXECUTABLES
+	"Build the libparquet executable CLI tools"
+	ON)
+endif()
+
 # If build in-source, create the latest symlink. If build out-of-source, which is
 # preferred, simply output the binaries in the build folder
-if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
+if (${CMAKE_SOURCE_DIR} STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
   set(BUILD_OUTPUT_ROOT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/build/${BUILD_SUBDIR_NAME}")
   # Link build/latest to the current build directory, to avoid developers
   # accidentally running the latest debug build when in fact they're building
@@ -84,7 +94,7 @@ endif()
 #
 # Arguments after the test name will be passed to set_tests_properties().
 function(ADD_PARQUET_TEST REL_TEST_NAME)
-  if(NO_TESTS)
+  if(NOT PARQUET_BUILD_TESTS)
     return()
   endif()
   get_filename_component(TEST_NAME ${REL_TEST_NAME} NAME_WE)
@@ -106,9 +116,9 @@ function(ADD_PARQUET_TEST REL_TEST_NAME)
   endif()
 endfunction()
 
-# A wrapper for add_dependencies() that is compatible with NO_TESTS.
+# A wrapper for add_dependencies() that is compatible with PARQUET_BUILD_TESTS.
 function(ADD_PARQUET_TEST_DEPENDENCIES REL_TEST_NAME)
-  if(NO_TESTS)
+  if(NOT PARQUET_BUILD_TESTS)
     return()
   endif()
   get_filename_component(TEST_NAME ${REL_TEST_NAME} NAME_WE)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -20,11 +20,13 @@ SET(LINK_LIBS
   snappystatic
   thriftstatic)
 
-add_executable(decode_benchmark decode_benchmark.cc)
-target_link_libraries(decode_benchmark ${LINK_LIBS})
+if (PARQUET_BUILD_EXECUTABLES)
+  add_executable(decode_benchmark decode_benchmark.cc)
+  target_link_libraries(decode_benchmark ${LINK_LIBS})
 
-add_executable(parquet_reader parquet_reader.cc)
-target_link_libraries(parquet_reader ${LINK_LIBS})
+  add_executable(parquet-dump-schema parquet-dump-schema.cc)
+  target_link_libraries(parquet-dump-schema ${LINK_LIBS})
 
-add_executable(parquet-dump-schema parquet-dump-schema.cc)
-target_link_libraries(parquet-dump-schema ${LINK_LIBS})
+  add_executable(parquet_reader parquet_reader.cc)
+  target_link_libraries(parquet_reader ${LINK_LIBS})
+endif()

--- a/src/parquet/util/CMakeLists.txt
+++ b/src/parquet/util/CMakeLists.txt
@@ -35,21 +35,22 @@ add_library(parquet_util STATIC
   cpu-info.cc
 )
 
-add_library(parquet_test_main
-  test_main.cc)
-
-if (APPLE)
-  target_link_libraries(parquet_test_main
-    gtest
-    dl)
-  set_target_properties(parquet_test_main
-        PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-else()
-  target_link_libraries(parquet_test_main
-    dl
-    gtest
-    pthread
-  )
+if(PARQUET_BUILD_TESTS)
+  add_library(parquet_test_main
+	test_main.cc)
+  if (APPLE)
+	target_link_libraries(parquet_test_main
+      gtest
+      dl)
+	set_target_properties(parquet_test_main
+      PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+  else()
+	target_link_libraries(parquet_test_main
+      dl
+      gtest
+      pthread
+	  )
+  endif()
 endif()
 
 ADD_PARQUET_TEST(bit-util-test)


### PR DESCRIPTION
This patch adds `PARQUET_BUILD_TESTS` and `PARQUET_BUILD_EXECUTABLES` options.

For example:

```
$ cmake -DPARQUET_BUILD_TESTS=OFF -DPARQUET_BUILD_EXECUTABLES=OFF ..
```

This will accelerate builds in 3rd-party use. When the library is more mature we can set the default for `PARQUET_BUILD_TESTS` to `OFF`