### PR TITLE
PARQUET-455: Fix OS X / Clang compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
 
 before_script:
     - source $TRAVIS_BUILD_DIR/ci/before_script_travis.sh
-    - cmake $TRAVIS_BUILD_DIR
+    - cmake -DCMAKE_CXX_FLAGS="-Werror" $TRAVIS_BUILD_DIR
     - export PARQUET_TEST_DATA=$TRAVIS_BUILD_DIR/data
 
 script:

--- a/src/parquet/encodings/plain-encoding.h
+++ b/src/parquet/encodings/plain-encoding.h
@@ -156,7 +156,12 @@ class PlainEncoder<Type::BOOLEAN> : public Encoder<Type::BOOLEAN> {
   explicit PlainEncoder(const ColumnDescriptor* descr) :
       Encoder<Type::BOOLEAN>(descr, parquet::Encoding::PLAIN) {}
 
-  virtual size_t Encode(const std::vector<bool>& src, int num_values,
+  virtual size_t Encode(const bool* src, int num_values, uint8_t* dst) {
+    throw ParquetException("this API for encoding bools not implemented");
+    return 0;
+  }
+
+  size_t Encode(const std::vector<bool>& src, int num_values,
       uint8_t* dst) {
     size_t bytes_required = BitUtil::RoundUp(num_values, 8) / 8;
     BitWriter bit_writer(dst, bytes_required);

--- a/src/parquet/reader.cc
+++ b/src/parquet/reader.cc
@@ -199,7 +199,7 @@ void ParquetFileReader::ParseMetaData() {
 
   uint32_t metadata_len = *reinterpret_cast<uint32_t*>(footer_buffer);
   size_t metadata_start = filesize - FOOTER_SIZE - metadata_len;
-  if (metadata_start < 0) {
+  if (FOOTER_SIZE + metadata_len > filesize) {
     throw ParquetException("Invalid parquet file. File is less than file metadata size.");
   }
 


### PR DESCRIPTION
There actually was a legitimate bug fixed here for malformed Parquet files, but we are not yet in a position to write a decent test for it until PARQUET-497. I will make a note on that JIRA.

I also set our Travis CI build to fail on future compiler warnings. 

This also closes #15.