### PR TITLE
PARQUET-500: Add gcov build options and add instructions for generating and uploading code coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,9 +233,8 @@ if ("${PARQUET_GENERATE_COVERAGE}")
     # This should be fixed in llvm 3.4 with http://llvm.org/viewvc/llvm-project?view=revision&revision=184666
     message(SEND_ERROR "Cannot currently generate coverage with clang")
   endif()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -DCOVERAGE_BUILD")
   message(STATUS "Configuring build for gcov")
-
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 --coverage")
   # For coverage to work properly, we need to use static linkage. Otherwise,
   # __gcov_flush() doesn't properly flush coverage from every module.
   # See http://stackoverflow.com/questions/28164543/using-gcov-flush-within-a-library-doesnt-force-the-other-modules-to-yield-gc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ project(parquet-cpp)
 if (NOT "$ENV{PARQUET_GCC_ROOT}" STREQUAL "")
   set(GCC_ROOT $ENV{PARQUET_GCC_ROOT})
   set(CMAKE_C_COMPILER ${GCC_ROOT}/bin/gcc)
+  set(GCOV_PATH ${GCC_ROOT}/bin/gcov)
+  set(CMAKE_CXX_COMPILER ${GCC_ROOT}/bin/g++)
   set(CMAKE_CXX_COMPILER ${GCC_ROOT}/bin/g++)
 endif()
 
@@ -220,6 +222,31 @@ set(PARQUET_MIN_TEST_LIBS
   parquet)
 set(PARQUET_TEST_LINK_LIBS ${PARQUET_MIN_TEST_LIBS})
 
+#############################################################
+# Code coverage
+
+# Adapted from Apache Kudu (incubating)
+if ("${PARQUET_GENERATE_COVERAGE}")
+  if("${CMAKE_CXX_COMPILER}" MATCHES ".*clang.*")
+    # There appears to be some bugs in clang 3.3 which cause code coverage
+    # to have link errors, not locating the llvm_gcda_* symbols.
+    # This should be fixed in llvm 3.4 with http://llvm.org/viewvc/llvm-project?view=revision&revision=184666
+    message(SEND_ERROR "Cannot currently generate coverage with clang")
+  endif()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -DCOVERAGE_BUILD")
+  message(STATUS "Configuring build for gcov")
+
+  # For coverage to work properly, we need to use static linkage. Otherwise,
+  # __gcov_flush() doesn't properly flush coverage from every module.
+  # See http://stackoverflow.com/questions/28164543/using-gcov-flush-within-a-library-doesnt-force-the-other-modules-to-yield-gc
+  if("${PARQUET_LINK}" STREQUAL "a")
+    message("Using static linking for coverage build")
+    set(PARQUET_LINK "s")
+  elseif("${PARQUET_LINK}" STREQUAL "d")
+    message(SEND_ERROR "Cannot use coverage with static linking")
+  endif()
+endif()
+
 ############################################################
 # Library config
 
@@ -279,4 +306,5 @@ add_custom_target(clean-all
 # installation
 
 install(TARGETS parquet
+  ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,7 @@ if ("${PARQUET_GENERATE_COVERAGE}")
     message("Using static linking for coverage build")
     set(PARQUET_LINK "s")
   elseif("${PARQUET_LINK}" STREQUAL "d")
-    message(SEND_ERROR "Cannot use coverage with static linking")
+    message(SEND_ERROR "Cannot use coverage with dynamic linking")
   endif()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ For codecov.io (using the provided project token -- be sure to keep this
 private):
 
 ```
+cd coverage_artifacts
 codecov --token $PARQUET_CPP_CODECOV_TOKEN --gcov-args '\-l' --root $PARQUET_ROOT
 ```
 
@@ -152,10 +153,9 @@ For coveralls, install `cpp_coveralls`:
 pip install cpp_coveralls
 ```
 
-Now, you can run the coveralls upload script:
+And the coveralls upload script:
 
 ```
-cd coverage_artifacts
 coveralls -t $PARQUET_CPP_COVERAGE_TOKEN --gcov-options '\-l' -r $PARQUET_ROOT --exclude $PARQUET_ROOT/thirdparty --exclude $PARQUET_ROOT/build --exclude $NATIVE_TOOLCHAIN --exclude $PARQUET_ROOT/src/parquet/thrift
 ```
 

--- a/README.md
+++ b/README.md
@@ -117,14 +117,10 @@ encoding should operate on batches of values rather than a single value.
 
 ## Code Coverage
 
-To build with `gcov` code coverage and upload results to http://coveralls.io,
-here are some instructions. First, install `cpp_coveralls`:
+To build with `gcov` code coverage and upload results to http://coveralls.io or
+http://codecov.io, here are some instructions.
 
-```
-pip install cpp_coveralls
-```
-
-Now build the project with coverage and run the test suite
+First, build the project with coverage and run the test suite
 
 ```
 cd $PARQUET_HOME
@@ -135,21 +131,34 @@ make -j4
 ctest
 ```
 
-The `gcov` artifacts are not located in a place that works well with
-`cpp_coveralls`, so there is a helper script you need to run
+The `gcov` artifacts are not located in a place that works well with either
+coveralls or codecov, so there is a helper script you need to run
 
 ```
 mkdir coverage_artifacts
 python ../build-support/collect_coverage.py CMakeFiles/parquet.dir/src/ coverage_artifacts
 ```
 
-Now, you can run the coveralls upload script (using the provided project token
--- be sure to keep this private).
+For codecov.io (using the provided project token -- be sure to keep this
+private):
+
+```
+codecov --token $PARQUET_CPP_CODECOV_TOKEN --gcov-args '\-l' --root $PARQUET_ROOT
+```
+
+For coveralls, install `cpp_coveralls`:
+
+```
+pip install cpp_coveralls
+```
+
+Now, you can run the coveralls upload script:
 
 ```
 cd coverage_artifacts
 coveralls -t $PARQUET_CPP_COVERAGE_TOKEN --gcov-options '\-l' -r $PARQUET_ROOT --exclude $PARQUET_ROOT/thirdparty --exclude $PARQUET_ROOT/build --exclude $NATIVE_TOOLCHAIN --exclude $PARQUET_ROOT/src/parquet/thrift
 ```
+
 
 Note that `gcov` throws off artifacts from the STL, so I excluded my toolchain
 root stored in `$NATIVE_TOOLCHAIN` to avoid a cluttered coverage report.

--- a/README.md
+++ b/README.md
@@ -114,3 +114,42 @@ For error handling, this project uses exceptions.
 In general, many of the APIs at the layers are interface based for extensibility. To
 minimize the cost of virtual calls, the APIs should be batch-centric. For example,
 encoding should operate on batches of values rather than a single value.
+
+## Code Coverage
+
+To build with `gcov` code coverage and upload results to http://coveralls.io,
+here are some instructions. First, install `cpp_coveralls`:
+
+```
+pip install cpp_coveralls
+```
+
+Now build the project with coverage and run the test suite
+
+```
+cd $PARQUET_HOME
+mkdir coverage-build
+cd coverage-build
+cmake -DPARQUET_GENERATE_COVERAGE=1
+make -j4
+ctest
+```
+
+The `gcov` artifacts are not located in a place that works well with
+`cpp_coveralls`, so there is a helper script you need to run
+
+```
+mkdir coverage_artifacts
+python ../build-support/collect_coverage.py CMakeFiles/parquet.dir/src/ coverage_artifacts
+```
+
+Now, you can run the coveralls upload script (using the provided project token
+-- be sure to keep this private).
+
+```
+cd coverage_artifacts
+coveralls -t $PARQUET_CPP_COVERAGE_TOKEN --gcov-options '\-l' -r $PARQUET_ROOT --exclude $PARQUET_ROOT/thirdparty --exclude $PARQUET_ROOT/build --exclude $NATIVE_TOOLCHAIN --exclude $PARQUET_ROOT/src/parquet/thrift
+```
+
+Note that `gcov` throws off artifacts from the STL, so I excluded my toolchain
+root stored in `$NATIVE_TOOLCHAIN` to avoid a cluttered coverage report.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ cd $PARQUET_HOME
 mkdir coverage-build
 cd coverage-build
 cmake -DPARQUET_GENERATE_COVERAGE=1
-make -j4
+make -j$PARALLEL
 ctest
 ```
 

--- a/build-support/collect_coverage.py
+++ b/build-support/collect_coverage.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import os.path as osp
+import shutil
+import sys
+
+
+def is_coverage_file(path):
+    return path.endswith('gcno') or path.endswith('gcda')
+
+
+def copy_files(path, outpath='.'):
+    for root, dirs, files in os.walk(path):
+        for fname in files:
+            if not is_coverage_file(fname):
+                continue
+            relpath = osp.join(root, fname)
+            dstpath = '_'.join((root.replace(path, '').replace('/', '_'),
+                                fname))
+
+            shutil.copy(relpath, osp.join(outpath, dstpath))
+
+if __name__ == '__main__':
+    path = sys.argv[1]
+    outpath = sys.argv[2]
+    copy_files(path, outpath)


### PR DESCRIPTION
Since web-based coverage sites rely on a private token, we won't want to include coverage builds in Travis CI for now, but I figured out the magical incantations to perform a manual coverage run and upload it to either coveralls or codecov. See the results here:

https://coveralls.io/builds/4993369
https://codecov.io/github/wesm/parquet-cpp?ref=fbd0a7b949aa1c8648af8335c37916cab9d0438b

I much prefer the codecov.io site UX and it feels a lot more responsive.

If we can enable apache/parquet-cpp in codecov.io I can periodically run coverage builds from master if that helps, and we can add a badge to the project README.

Small TODO here: in PARQUET-447 we'll want to clean up the compiler flags (e.g. optimization needs to be disabled for coverage runs). 