### PR TITLE
PARQUET-513: Fail build if valgrind finds error during ctest, fix a core dump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,6 @@ script:
 - make
 - >
   if [ $TRAVIS_OS_NAME == linux ]; then
-    valgrind --tool=memcheck --leak-check=yes ctest;
+    valgrind --tool=memcheck --leak-check=yes --error-exitcode=1 ctest;
   fi
 - make lint

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,13 @@ if (NOT "$ENV{PARQUET_GCC_ROOT}" STREQUAL "")
   set(CMAKE_CXX_COMPILER ${GCC_ROOT}/bin/g++)
 endif()
 
+if ("$ENV{PARQUET_USE_CCACHE}")
+  set(CMAKE_C_COMPILER_ARG1 ${CMAKE_C_COMPILER})
+  set(CMAKE_CXX_COMPILER_ARG1 ${CMAKE_CXX_COMPILER})
+  set(CMAKE_C_COMPILER ccache)
+  set(CMAKE_CXX_COMPILER ccache)
+endif()
+
 # generate CTest input files
 enable_testing()
 

--- a/src/parquet/schema/schema-converter-test.cc
+++ b/src/parquet/schema/schema-converter-test.cc
@@ -125,7 +125,7 @@ TEST_F(TestSchemaConverter, NotEnoughChildren) {
   SchemaElement elt;
   std::vector<SchemaElement> elements;
   elements.push_back(NewGroup(name_, FieldRepetitionType::REPEATED, 2));
-  ASSERT_THROW(Convert(&elements[0], 2), ParquetException);
+  ASSERT_THROW(Convert(&elements[0], 1), ParquetException);
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
Also adds an option to use ccache with a custom gcc toolchain. 

Fixes an improper memory access stemming from a unit test that had a wrong parameter. 