### PR TITLE
PARQUET-501: Add OutputStream abstract interface, refactor encoding code paths

### DIFF
--- a/example/parquet-dump-schema.cc
+++ b/example/parquet-dump-schema.cc
@@ -35,7 +35,7 @@ int main(int argc, char** argv) {
   std::string filename = argv[1];
 
   parquet_cpp::ParquetFileReader reader;
-  parquet_cpp::LocalFile file;
+  parquet_cpp::LocalFileSource file;
 
   file.Open(filename);
   if (!file.is_open()) {

--- a/example/parquet_reader.cc
+++ b/example/parquet_reader.cc
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
   }
 
   parquet_cpp::ParquetFileReader reader;
-  parquet_cpp::LocalFile file;
+  parquet_cpp::LocalFileSource file;
 
   file.Open(filename);
   if (!file.is_open()) {

--- a/src/parquet/column/serialized-page.cc
+++ b/src/parquet/column/serialized-page.cc
@@ -21,7 +21,6 @@
 
 #include "parquet/exception.h"
 #include "parquet/thrift/util.h"
-#include "parquet/util/input_stream.h"
 
 using parquet::PageType;
 
@@ -52,7 +51,7 @@ std::shared_ptr<Page> SerializedPageReader::NextPage() {
   // Loop here because there may be unhandled page types that we skip until
   // finding a page that we do know what to do with
   while (true) {
-    int bytes_read = 0;
+    int64_t bytes_read = 0;
     const uint8_t* buffer = stream_->Peek(DATA_PAGE_SIZE, &bytes_read);
     if (bytes_read == 0) {
       return std::shared_ptr<Page>(nullptr);

--- a/src/parquet/column/serialized-page.h
+++ b/src/parquet/column/serialized-page.h
@@ -27,7 +27,7 @@
 
 #include "parquet/column/page.h"
 #include "parquet/compression/codec.h"
-#include "parquet/util/input_stream.h"
+#include "parquet/util/input.h"
 #include "parquet/thrift/parquet_types.h"
 
 namespace parquet_cpp {

--- a/src/parquet/encodings/encodings.h
+++ b/src/parquet/encodings/encodings.h
@@ -23,6 +23,7 @@
 #include "parquet/exception.h"
 #include "parquet/types.h"
 
+#include "parquet/util/output.h"
 #include "parquet/util/rle-encoding.h"
 #include "parquet/util/bit-stream-utils.inline.h"
 
@@ -82,14 +83,9 @@ class Encoder {
 
   virtual ~Encoder() {}
 
-  // TODO(wesm): use an output stream
-
   // Subclasses should override the ones they support
-  //
-  // @returns: the number of bytes written to dst
-  virtual size_t Encode(const T* src, int num_values, uint8_t* dst) {
+  virtual void Encode(const T* src, int num_values, OutputStream* dst) {
     throw ParquetException("Encoder does not implement this type.");
-    return 0;
   }
 
   const parquet::Encoding::type encoding() const { return encoding_; }

--- a/src/parquet/encodings/plain-encoding-test.cc
+++ b/src/parquet/encodings/plain-encoding-test.cc
@@ -43,15 +43,18 @@ TEST(BooleanTest, TestEncodeDecode) {
   PlainEncoder<Type::BOOLEAN> encoder(nullptr);
   PlainDecoder<Type::BOOLEAN> decoder(nullptr);
 
-  std::vector<uint8_t> encode_buffer(nbytes);
+  InMemoryOutputStream dst;
+  encoder.Encode(draws, nvalues, &dst);
 
-  size_t encoded_bytes = encoder.Encode(draws, nvalues, &encode_buffer[0]);
-  ASSERT_EQ(nbytes, encoded_bytes);
+  std::vector<uint8_t> encode_buffer;
+  dst.Transfer(&encode_buffer);
+
+  ASSERT_EQ(nbytes, encode_buffer.size());
 
   std::vector<uint8_t> decode_buffer(nbytes);
   const uint8_t* decode_data = &decode_buffer[0];
 
-  decoder.SetData(nvalues, &encode_buffer[0], encoded_bytes);
+  decoder.SetData(nvalues, &encode_buffer[0], encode_buffer.size());
   size_t values_decoded = decoder.Decode(&decode_buffer[0], nvalues);
   ASSERT_EQ(nvalues, values_decoded);
 

--- a/src/parquet/reader-test.cc
+++ b/src/parquet/reader-test.cc
@@ -25,6 +25,7 @@
 #include "parquet/reader.h"
 #include "parquet/column/reader.h"
 #include "parquet/column/scanner.h"
+#include "parquet/util/input.h"
 
 using std::string;
 
@@ -47,7 +48,7 @@ class TestAllTypesPlain : public ::testing::Test {
   void TearDown() {}
 
  protected:
-  LocalFile file_;
+  LocalFileSource file_;
   ParquetFileReader reader_;
 };
 

--- a/src/parquet/reader.h
+++ b/src/parquet/reader.h
@@ -27,53 +27,12 @@
 #include "parquet/thrift/parquet_types.h"
 
 #include "parquet/types.h"
-
 #include "parquet/schema/descriptor.h"
+#include "parquet/util/input.h"
 
 namespace parquet_cpp {
 
 class ColumnReader;
-
-class FileLike {
- public:
-  virtual ~FileLike() {}
-
-  virtual void Close() = 0;
-  virtual size_t Size() = 0;
-  virtual size_t Tell() = 0;
-  virtual void Seek(size_t pos) = 0;
-
-  // Returns actual number of bytes read
-  virtual size_t Read(size_t nbytes, uint8_t* out) = 0;
-};
-
-
-class LocalFile : public FileLike {
- public:
-  LocalFile() : file_(nullptr), is_open_(false) {}
-  virtual ~LocalFile();
-
-  void Open(const std::string& path);
-
-  virtual void Close();
-  virtual size_t Size();
-  virtual size_t Tell();
-  virtual void Seek(size_t pos);
-
-  // Returns actual number of bytes read
-  virtual size_t Read(size_t nbytes, uint8_t* out);
-
-  bool is_open() const { return is_open_;}
-  const std::string& path() const { return path_;}
-
- private:
-  void CloseFile();
-
-  std::string path_;
-  FILE* file_;
-  bool is_open_;
-};
-
 class ParquetFileReader;
 
 class RowGroupReader {
@@ -112,7 +71,7 @@ class ParquetFileReader {
 
   // This class does _not_ take ownership of the file. You must manage its
   // lifetime separately
-  void Open(FileLike* buffer);
+  void Open(RandomAccessSource* buffer);
 
   void Close();
 
@@ -150,7 +109,7 @@ class ParquetFileReader {
   // Row group index -> RowGroupReader
   std::unordered_map<int, std::shared_ptr<RowGroupReader> > row_group_readers_;
 
-  FileLike* buffer_;
+  RandomAccessSource* buffer_;
 };
 
 

--- a/src/parquet/util/CMakeLists.txt
+++ b/src/parquet/util/CMakeLists.txt
@@ -27,11 +27,13 @@ install(FILES
   macros.h
   rle-encoding.h
   stopwatch.h
-  input_stream.h
+  input.h
+  output.h
   DESTINATION include/parquet/util)
 
 add_library(parquet_util STATIC
-  input_stream.cc
+  input.cc
+  output.cc
   cpu-info.cc
 )
 
@@ -54,4 +56,5 @@ if(PARQUET_BUILD_TESTS)
 endif()
 
 ADD_PARQUET_TEST(bit-util-test)
+ADD_PARQUET_TEST(output-test)
 ADD_PARQUET_TEST(rle-test)

--- a/src/parquet/util/input.h
+++ b/src/parquet/util/input.h
@@ -15,14 +15,62 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef PARQUET_INPUT_STREAM_H
-#define PARQUET_INPUT_STREAM_H
+#ifndef PARQUET_UTIL_INPUT_H
+#define PARQUET_UTIL_INPUT_H
 
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace parquet_cpp {
+
+// ----------------------------------------------------------------------
+// Random access input (e.g. file-like)
+
+// Random
+class RandomAccessSource {
+ public:
+  virtual ~RandomAccessSource() {}
+
+  virtual void Close() = 0;
+  virtual size_t Size() = 0;
+  virtual size_t Tell() = 0;
+  virtual void Seek(size_t pos) = 0;
+
+  // Returns actual number of bytes read
+  virtual size_t Read(size_t nbytes, uint8_t* out) = 0;
+};
+
+
+class LocalFileSource : public RandomAccessSource {
+ public:
+  LocalFileSource() : file_(nullptr), is_open_(false) {}
+  virtual ~LocalFileSource();
+
+  void Open(const std::string& path);
+
+  virtual void Close();
+  virtual size_t Size();
+  virtual size_t Tell();
+  virtual void Seek(size_t pos);
+
+  // Returns actual number of bytes read
+  virtual size_t Read(size_t nbytes, uint8_t* out);
+
+  bool is_open() const { return is_open_;}
+  const std::string& path() const { return path_;}
+
+ private:
+  void CloseFile();
+
+  std::string path_;
+  FILE* file_;
+  bool is_open_;
+};
+
+// ----------------------------------------------------------------------
+// Streaming input interfaces
 
 // Interface for the column reader to get the bytes. The interface is a stream
 // interface, meaning the bytes in order and once a byte is read, it does not
@@ -35,11 +83,11 @@ class InputStream {
   // Since the position is not advanced, calls to this function are idempotent.
   // The buffer returned to the caller is still owned by the input stream and must
   // stay valid until the next call to Peek() or Read().
-  virtual const uint8_t* Peek(int num_to_peek, int* num_bytes) = 0;
+  virtual const uint8_t* Peek(int64_t num_to_peek, int64_t* num_bytes) = 0;
 
   // Identical to Peek(), except the current position in the stream is advanced by
   // *num_bytes.
-  virtual const uint8_t* Read(int num_to_read, int* num_bytes) = 0;
+  virtual const uint8_t* Read(int64_t num_to_read, int64_t* num_bytes) = 0;
 
   virtual ~InputStream() {}
 
@@ -51,8 +99,8 @@ class InputStream {
 class InMemoryInputStream : public InputStream {
  public:
   InMemoryInputStream(const uint8_t* buffer, int64_t len);
-  virtual const uint8_t* Peek(int num_to_peek, int* num_bytes);
-  virtual const uint8_t* Read(int num_to_read, int* num_bytes);
+  virtual const uint8_t* Peek(int64_t num_to_peek, int64_t* num_bytes);
+  virtual const uint8_t* Read(int64_t num_to_read, int64_t* num_bytes);
 
  private:
   const uint8_t* buffer_;
@@ -67,8 +115,8 @@ class ScopedInMemoryInputStream : public InputStream {
   explicit ScopedInMemoryInputStream(int64_t len);
   uint8_t* data();
   int64_t size();
-  virtual const uint8_t* Peek(int num_to_peek, int* num_bytes);
-  virtual const uint8_t* Read(int num_to_read, int* num_bytes);
+  virtual const uint8_t* Peek(int64_t num_to_peek, int64_t* num_bytes);
+  virtual const uint8_t* Read(int64_t num_to_read, int64_t* num_bytes);
 
  private:
   std::vector<uint8_t> buffer_;
@@ -77,4 +125,4 @@ class ScopedInMemoryInputStream : public InputStream {
 
 } // namespace parquet_cpp
 
-#endif // PARQUET_INPUT_STREAM_H
+#endif // PARQUET_UTIL_INPUT_H

--- a/src/parquet/util/output-test.cc
+++ b/src/parquet/util/output-test.cc
@@ -15,22 +15,30 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef PARQUET_PARQUET_H
-#define PARQUET_PARQUET_H
-
-#include <exception>
-#include <cstdint>
-#include <cstring>
 #include <memory>
-#include <string>
-#include <unordered_map>
-#include <vector>
 
-#include "parquet/exception.h"
-#include "parquet/reader.h"
-#include "parquet/column/reader.h"
+#include <gtest/gtest.h>
 
-#include "parquet/util/input.h"
 #include "parquet/util/output.h"
+#include "parquet/util/test-common.h"
 
-#endif
+namespace parquet_cpp {
+
+TEST(TestInMemoryOutputStream, Basics) {
+  std::unique_ptr<InMemoryOutputStream> stream(new InMemoryOutputStream(8));
+
+  std::vector<uint8_t> data = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+
+  stream->Write(&data[0], 4);
+  ASSERT_EQ(4, stream->Tell());
+  stream->Write(&data[4], data.size() - 4);
+
+  std::vector<uint8_t> out;
+  stream->Transfer(&out);
+
+  test::assert_vector_equal(data, out);
+
+  ASSERT_EQ(0, stream->Tell());
+}
+
+} // namespace parquet_cpp

--- a/src/parquet/util/output.cc
+++ b/src/parquet/util/output.cc
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/util/output.h"
+
+#include <algorithm>
+#include <cstring>
+#include <sstream>
+
+#include "parquet/exception.h"
+
+namespace parquet_cpp {
+
+// ----------------------------------------------------------------------
+// In-memory output stream
+
+static constexpr int64_t IN_MEMORY_DEFAULT_CAPACITY = 1024;
+
+InMemoryOutputStream::InMemoryOutputStream(int64_t initial_capacity) :
+    size_(0),
+    capacity_(initial_capacity) {
+  if (initial_capacity == 0) {
+    initial_capacity = IN_MEMORY_DEFAULT_CAPACITY;
+  }
+  buffer_.resize(initial_capacity);
+}
+
+InMemoryOutputStream::InMemoryOutputStream() :
+    InMemoryOutputStream(IN_MEMORY_DEFAULT_CAPACITY) {}
+
+uint8_t* InMemoryOutputStream::Head() {
+  return &buffer_[size_];
+}
+
+void InMemoryOutputStream::Write(const uint8_t* data, int64_t length) {
+  if (size_ + length > capacity_) {
+    int64_t new_capacity = capacity_ * 2;
+    while (new_capacity < size_ + length) {
+      new_capacity *= 2;
+    }
+    buffer_.resize(new_capacity);
+    capacity_ = new_capacity;
+  }
+  memcpy(Head(), data, length);
+  size_ += length;
+}
+
+int64_t InMemoryOutputStream::Tell() {
+  return size_;
+}
+
+void InMemoryOutputStream::Transfer(std::vector<uint8_t>* out) {
+  buffer_.resize(size_);
+  buffer_.swap(*out);
+  size_ = 0;
+  capacity_ = buffer_.size();
+}
+
+} // namespace parquet_cpp

--- a/src/parquet/util/output.h
+++ b/src/parquet/util/output.h
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef PARQUET_UTIL_OUTPUT_H
+#define PARQUET_UTIL_OUTPUT_H
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace parquet_cpp {
+
+// ----------------------------------------------------------------------
+// Output stream classes
+
+// Abstract output stream
+class OutputStream {
+ public:
+  // Close the output stream
+  virtual void Close() = 0;
+
+  // Return the current position in the output stream relative to the start
+  virtual int64_t Tell() = 0;
+
+  // Copy bytes into the output stream
+  virtual void Write(const uint8_t* data, int64_t length) = 0;
+};
+
+
+// An output stream that is an in-memory
+class InMemoryOutputStream : public OutputStream {
+ public:
+  InMemoryOutputStream();
+  explicit InMemoryOutputStream(int64_t initial_capacity);
+
+  // Close is currently a no-op with the in-memory stream
+  virtual void Close() {}
+
+  virtual int64_t Tell();
+
+  virtual void Write(const uint8_t* data, int64_t length);
+
+  // Hand off the in-memory data to a (preferably-empty) std::vector owner
+  void Transfer(std::vector<uint8_t>* out);
+
+ private:
+  // Mutable pointer to the current write position in the stream
+  uint8_t* Head();
+
+  std::vector<uint8_t> buffer_;
+  int64_t size_;
+  int64_t capacity_;
+};
+
+} // namespace parquet_cpp
+
+#endif // PARQUET_UTIL_OUTPUT_H

--- a/src/parquet/util/test-common.h
+++ b/src/parquet/util/test-common.h
@@ -29,6 +29,16 @@ namespace parquet_cpp {
 namespace test {
 
 template <typename T>
+static inline void assert_vector_equal(const vector<T>& left,
+    const vector<T>& right) {
+  ASSERT_EQ(left.size(), right.size());
+
+  for (size_t i = 0; i < left.size(); ++i) {
+    ASSERT_EQ(left[i], right[i]) << i;
+  }
+}
+
+template <typename T>
 static inline bool vector_equal(const vector<T>& left, const vector<T>& right) {
   if (left.size() != right.size()) {
     return false;
@@ -45,6 +55,19 @@ static inline bool vector_equal(const vector<T>& left, const vector<T>& right) {
   }
 
   return true;
+}
+
+template <typename T>
+static vector<T> slice(const vector<T>& values, size_t start, size_t end) {
+  if (end < start) {
+    return vector<T>(0);
+  }
+
+  vector<T> out(end - start);
+  for (size_t i = start; i < end; ++i) {
+    out[i - start] = values[i];
+  }
+  return out;
 }
 
 static inline vector<bool> flip_coins_seed(size_t n, double p, uint32_t seed) {


### PR DESCRIPTION
I also did a bit of tidying / reorganization and giving interfaces more descriptive names. 