### PR TITLE
PARQUET-456: Finish gzip implementation and unit test all compressors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,5 @@ before_script:
 
 script:
 - make
-- >
-  if [ $TRAVIS_OS_NAME == linux ]; then
-    valgrind --tool=memcheck --leak-check=yes --error-exitcode=1 ctest;
-  fi
+- source $TRAVIS_BUILD_DIR/ci/run_tests.sh
 - make lint

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,12 @@ include_directories(SYSTEM ${LZ4_INCLUDE_DIR})
 add_library(lz4static STATIC IMPORTED)
 set_target_properties(lz4static PROPERTIES IMPORTED_LOCATION ${LZ4_STATIC_LIB})
 
+## ZLIB
+find_package(ZLIB REQUIRED)
+include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
+add_library(zlibstatic STATIC IMPORTED)
+set_target_properties(zlibstatic PROPERTIES IMPORTED_LOCATION ${ZLIB_LIBRARIES})
+
 ## GTest
 find_package(GTest REQUIRED)
 include_directories(SYSTEM ${GTEST_INCLUDE_DIR})

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,0 +1,5 @@
+if [ $TRAVIS_OS_NAME == "linux" ]; then
+  valgrind --tool=memcheck --leak-check=yes --error-exitcode=1 ctest;
+else
+  ctest;
+fi

--- a/cmake_modules/FindZLIB.cmake
+++ b/cmake_modules/FindZLIB.cmake
@@ -1,0 +1,92 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Tries to find ZLIB headers and libraries.
+#
+# Usage of this module as follows:
+#
+#  find_package(ZLIB)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  ZLIB_HOME - When set, this path is inspected instead of standard library
+#             locations as the root of the ZLIB installation.
+#             The environment variable ZLIB_HOME overrides this veriable.
+#
+# - Find ZLIB (zlib.h, libz.a, libz.so, and libz.so.1)
+# This module defines
+#  ZLIB_INCLUDE_DIR, directory containing headers
+#  ZLIB_LIBS, directory containing zlib libraries
+#  ZLIB_STATIC_LIB, path to libz.a
+#  ZLIB_SHARED_LIB, path to libz's shared library
+#  ZLIB_FOUND, whether zlib has been found
+
+if( NOT "$ENV{ZLIB_HOME}" STREQUAL "")
+    file( TO_CMAKE_PATH "$ENV{ZLIB_HOME}" _native_path )
+    list( APPEND _zlib_roots ${_native_path} )
+elseif ( ZLIB_HOME )
+    list( APPEND _zlib_roots ${ZLIB_HOME} )
+endif()
+
+# Try the parameterized roots, if they exist
+if ( _zlib_roots )
+    find_path( ZLIB_INCLUDE_DIR NAMES zlib.h
+        PATHS ${_zlib_roots} NO_DEFAULT_PATH
+        PATH_SUFFIXES "include" )
+    find_library( ZLIB_LIBRARIES NAMES z
+        PATHS ${_zlib_roots} NO_DEFAULT_PATH
+        PATH_SUFFIXES "" )
+else ()
+    find_path( ZLIB_INCLUDE_DIR NAMES zlib.h )
+    find_library( ZLIB_LIBRARIES NAMES z )
+endif ()
+
+
+if (ZLIB_INCLUDE_DIR AND ZLIB_LIBRARIES)
+  set(ZLIB_FOUND TRUE)
+  get_filename_component( ZLIB_LIBS ${ZLIB_LIBRARIES} DIRECTORY )
+  set(ZLIB_LIB_NAME libz)
+  set(ZLIB_STATIC_LIB ${ZLIB_LIBS}/${ZLIB_LIB_NAME}.a)
+  set(ZLIB_SHARED_LIB ${ZLIB_LIBS}/${ZLIB_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
+else ()
+  set(ZLIB_FOUND FALSE)
+endif ()
+
+if (ZLIB_FOUND)
+  if (NOT ZLIB_FIND_QUIETLY)
+    message(STATUS "Found the ZLIB library: ${ZLIB_LIBRARIES}")
+  endif ()
+else ()
+  if (NOT ZLIB_FIND_QUIETLY)
+    set(ZLIB_ERR_MSG "Could not find the ZLIB library. Looked in ")
+    if ( _zlib_roots )
+      set(ZLIB_ERR_MSG "${ZLIB_ERR_MSG} in ${_zlib_roots}.")
+    else ()
+      set(ZLIB_ERR_MSG "${ZLIB_ERR_MSG} system search paths.")
+    endif ()
+    if (ZLIB_FIND_REQUIRED)
+      message(FATAL_ERROR "${ZLIB_ERR_MSG}")
+    else (ZLIB_FIND_REQUIRED)
+      message(STATUS "${ZLIB_ERR_MSG}")
+    endif (ZLIB_FIND_REQUIRED)
+  endif ()
+endif ()
+
+mark_as_advanced(
+  ZLIB_INCLUDE_DIR
+  ZLIB_LIBS
+  ZLIB_LIBRARIES
+  ZLIB_STATIC_LIB
+  ZLIB_SHARED_LIB
+)

--- a/cmake_modules/FindZLIB.cmake
+++ b/cmake_modules/FindZLIB.cmake
@@ -46,7 +46,7 @@ if ( _zlib_roots )
         PATH_SUFFIXES "include" )
     find_library( ZLIB_LIBRARIES NAMES z
         PATHS ${_zlib_roots} NO_DEFAULT_PATH
-        PATH_SUFFIXES "" )
+        PATH_SUFFIXES "lib" )
 else ()
     find_path( ZLIB_INCLUDE_DIR NAMES zlib.h )
     find_library( ZLIB_LIBRARIES NAMES z )

--- a/setup_build_env.sh
+++ b/setup_build_env.sh
@@ -12,6 +12,7 @@ source thirdparty/versions.sh
 
 export SNAPPY_HOME=$BUILD_DIR/thirdparty/installed
 export LZ4_HOME=$BUILD_DIR/thirdparty/installed
+export ZLIB_HOME=$BUILD_DIR/thirdparty/installed
 # build script doesn't support building thrift on OSX
 if [ "$(uname)" != "Darwin" ]; then
   export THRIFT_HOME=$BUILD_DIR/thirdparty/installed

--- a/src/parquet/compression/CMakeLists.txt
+++ b/src/parquet/compression/CMakeLists.txt
@@ -33,3 +33,5 @@ set_target_properties(parquet_compression
 install(FILES
   codec.h
   DESTINATION include/parquet/compression)
+
+ADD_PARQUET_TEST(codec-test)

--- a/src/parquet/compression/CMakeLists.txt
+++ b/src/parquet/compression/CMakeLists.txt
@@ -18,10 +18,12 @@
 add_library(parquet_compression STATIC
   lz4-codec.cc
   snappy-codec.cc
+  gzip-codec.cc
 )
 target_link_libraries(parquet_compression
   lz4static
-  snappystatic)
+  snappystatic
+  zlibstatic)
 
 set_target_properties(parquet_compression
   PROPERTIES

--- a/src/parquet/compression/codec-test.cc
+++ b/src/parquet/compression/codec-test.cc
@@ -55,7 +55,7 @@ void CheckCodecRoundtrip(const vector<uint8_t>& data) {
       &compressed[0]);
   ASSERT_EQ(actual_size2, actual_size);
 
-  // decompress with c2
+  // decompress with c1
   c1.Decompress(compressed.size(), &compressed[0],
       decompressed.size(), &decompressed[0]);
 

--- a/src/parquet/compression/codec-test.cc
+++ b/src/parquet/compression/codec-test.cc
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "parquet/util/test-common.h"
+
+#include "parquet/compression/codec.h"
+
+using std::string;
+using std::vector;
+
+namespace parquet_cpp {
+
+void CheckCodecRoundtrip(Codec* codec, const vector<uint8_t>& data) {
+  int max_compressed_len = codec->MaxCompressedLen(data.size(), &data[0]);
+
+  std::vector<uint8_t> compressed(max_compressed_len);
+  int actual_size = codec->Compress(data.size(), &data[0], max_compressed_len,
+      &compressed[0]);
+  compressed.resize(actual_size);
+
+  std::vector<uint8_t> decompressed(data.size());
+  codec->Decompress(compressed.size(), &compressed[0],
+      decompressed.size(), &decompressed[0]);
+
+  ASSERT_TRUE(test::vector_equal(data, decompressed));
+}
+
+void CheckCodec(Codec* codec) {
+  int sizes[] = {10000, 100000};
+  for (int data_size : sizes) {
+    vector<uint8_t> data;
+    test::random_bytes(data_size, 1234, &data);
+    CheckCodecRoundtrip(codec, data);
+  }
+}
+
+TEST(TestCompressors, Snappy) {
+  SnappyCodec codec;
+  CheckCodec(&codec);
+}
+
+TEST(TestCompressors, Lz4) {
+  Lz4Codec codec;
+  CheckCodec(&codec);
+}
+
+TEST(TestCompressors, GZip) {
+  GZipCodec codec(GZipCodec::GZIP);
+  CheckCodec(&codec);
+}
+
+} // namespace parquet_cpp

--- a/src/parquet/compression/codec.h
+++ b/src/parquet/compression/codec.h
@@ -20,6 +20,8 @@
 
 #include <cstdint>
 
+#include <zlib.h>
+
 #include "parquet/exception.h"
 
 namespace parquet_cpp {
@@ -27,13 +29,13 @@ namespace parquet_cpp {
 class Codec {
  public:
   virtual ~Codec() {}
-  virtual void Decompress(int input_len, const uint8_t* input,
-      int output_len, uint8_t* output_buffer) = 0;
+  virtual void Decompress(int64_t input_len, const uint8_t* input,
+      int64_t output_len, uint8_t* output_buffer) = 0;
 
-  virtual int Compress(int input_len, const uint8_t* input,
-      int output_buffer_len, uint8_t* output_buffer) = 0;
+  virtual int64_t Compress(int64_t input_len, const uint8_t* input,
+      int64_t output_buffer_len, uint8_t* output_buffer) = 0;
 
-  virtual int MaxCompressedLen(int input_len, const uint8_t* input) = 0;
+  virtual int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input) = 0;
 
   virtual const char* name() const = 0;
 };
@@ -42,13 +44,13 @@ class Codec {
 // Snappy codec.
 class SnappyCodec : public Codec {
  public:
-  virtual void Decompress(int input_len, const uint8_t* input,
-      int output_len, uint8_t* output_buffer);
+  virtual void Decompress(int64_t input_len, const uint8_t* input,
+      int64_t output_len, uint8_t* output_buffer);
 
-  virtual int Compress(int input_len, const uint8_t* input,
-      int output_buffer_len, uint8_t* output_buffer);
+  virtual int64_t Compress(int64_t input_len, const uint8_t* input,
+      int64_t output_buffer_len, uint8_t* output_buffer);
 
-  virtual int MaxCompressedLen(int input_len, const uint8_t* input);
+  virtual int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input);
 
   virtual const char* name() const { return "snappy"; }
 };
@@ -56,13 +58,13 @@ class SnappyCodec : public Codec {
 // Lz4 codec.
 class Lz4Codec : public Codec {
  public:
-  virtual void Decompress(int input_len, const uint8_t* input,
-      int output_len, uint8_t* output_buffer);
+  virtual void Decompress(int64_t input_len, const uint8_t* input,
+      int64_t output_len, uint8_t* output_buffer);
 
-  virtual int Compress(int input_len, const uint8_t* input,
-      int output_buffer_len, uint8_t* output_buffer);
+  virtual int64_t Compress(int64_t input_len, const uint8_t* input,
+      int64_t output_buffer_len, uint8_t* output_buffer);
 
-  virtual int MaxCompressedLen(int input_len, const uint8_t* input);
+  virtual int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input);
 
   virtual const char* name() const { return "lz4"; }
 };
@@ -70,15 +72,27 @@ class Lz4Codec : public Codec {
 // GZip codec.
 class GZipCodec : public Codec {
  public:
-  virtual void Decompress(int input_len, const uint8_t* input,
-      int output_len, uint8_t* output_buffer);
+  /// Compression formats supported by the zlib library
+  enum Format {
+    ZLIB,
+    DEFLATE,
+    GZIP,
+  };
 
-  virtual int Compress(int input_len, const uint8_t* input,
-      int output_buffer_len, uint8_t* output_buffer);
+  explicit GZipCodec(Format format);
 
-  virtual int MaxCompressedLen(int input_len, const uint8_t* input);
+  virtual void Decompress(int64_t input_len, const uint8_t* input,
+      int64_t output_len, uint8_t* output_buffer);
+
+  virtual int64_t Compress(int64_t input_len, const uint8_t* input,
+      int64_t output_buffer_len, uint8_t* output_buffer);
+
+  virtual int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input);
 
   virtual const char* name() const { return "gzip"; }
+
+ private:
+  z_stream stream_;
 };
 
 } // namespace parquet_cpp

--- a/src/parquet/compression/codec.h
+++ b/src/parquet/compression/codec.h
@@ -67,6 +67,20 @@ class Lz4Codec : public Codec {
   virtual const char* name() const { return "lz4"; }
 };
 
+// GZip codec.
+class GZipCodec : public Codec {
+ public:
+  virtual void Decompress(int input_len, const uint8_t* input,
+      int output_len, uint8_t* output_buffer);
+
+  virtual int Compress(int input_len, const uint8_t* input,
+      int output_buffer_len, uint8_t* output_buffer);
+
+  virtual int MaxCompressedLen(int input_len, const uint8_t* input);
+
+  virtual const char* name() const { return "gzip"; }
+};
+
 } // namespace parquet_cpp
 
 #endif

--- a/src/parquet/compression/codec.h
+++ b/src/parquet/compression/codec.h
@@ -79,7 +79,7 @@ class GZipCodec : public Codec {
     GZIP,
   };
 
-  explicit GZipCodec(Format format);
+  explicit GZipCodec(Format format = GZIP);
 
   virtual void Decompress(int64_t input_len, const uint8_t* input,
       int64_t output_len, uint8_t* output_buffer);
@@ -92,7 +92,25 @@ class GZipCodec : public Codec {
   virtual const char* name() const { return "gzip"; }
 
  private:
+  // zlib is stateful and the z_stream state variable must be initialized
+  // before
   z_stream stream_;
+
+  // Realistically, this will always be GZIP, but we leave the option open to
+  // configure
+  Format format_;
+
+  // These variables are mutually exclusive. When the codec is in "compressor"
+  // state, compressor_initialized_ is true while decompressor_initialized_ is
+  // false. When it's decompressing, the opposite is true.
+  //
+  // Indeed, this is slightly hacky, but the alternative is having separate
+  // Compressor and Decompressor classes. If this ever becomes an issue, we can
+  // perform the refactoring then
+  void InitCompressor();
+  void InitDecompressor();
+  bool compressor_initialized_;
+  bool decompressor_initialized_;
 };
 
 } // namespace parquet_cpp

--- a/src/parquet/compression/gzip-codec.cc
+++ b/src/parquet/compression/gzip-codec.cc
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/compression/codec.h"
+
+#include <zlib.h>
+
+namespace parquet_cpp {
+
+void GZipCodec::Decompress(int input_len, const uint8_t* input,
+    int output_len, uint8_t* output_buffer) {
+  z_stream stream;
+  stream.zalloc = reinterpret_cast<alloc_func>(0);
+  stream.zfree = reinterpret_cast<free_func>(0);
+  stream.next_in = reinterpret_cast<Bytef*>(const_cast<uint8_t*>(input));
+  stream.avail_in = input_len;
+  stream.next_out = reinterpret_cast<Bytef*>(output_buffer);
+  stream.avail_out = output_len;
+  int rc = inflateInit2(&stream, 16+MAX_WBITS);
+  if (rc != Z_OK) {
+    throw ParquetException("zlib internal error.");
+  }
+  rc = inflate(&stream, Z_FINISH);
+  if (rc == Z_STREAM_END) {
+    rc = inflateEnd(&stream);
+  }
+  if (rc != Z_OK) {
+    throw ParquetException("Corrupt gzip compressed data.");
+  }
+}
+
+int GZipCodec::MaxCompressedLen(int input_len, const uint8_t* input) {
+  return compressBound(input_len);
+}
+
+int GZipCodec::Compress(int input_len, const uint8_t* input,
+    int output_buffer_len, uint8_t* output_buffer) {
+  uLongf dstLen = output_buffer_len;
+  int rc = compress2(reinterpret_cast<Bytef*>(output_buffer), &dstLen,
+      reinterpret_cast<const Bytef*>(input), input_len, 1);
+  return rc == Z_OK ? dstLen : input_len;
+}
+
+} // namespace parquet_cpp

--- a/src/parquet/compression/gzip-codec.cc
+++ b/src/parquet/compression/gzip-codec.cc
@@ -17,42 +17,85 @@
 
 #include "parquet/compression/codec.h"
 
-#include <zlib.h>
+#include <cstring>
+#include <sstream>
 
 namespace parquet_cpp {
 
-void GZipCodec::Decompress(int input_len, const uint8_t* input,
-    int output_len, uint8_t* output_buffer) {
-  z_stream stream;
-  stream.zalloc = reinterpret_cast<alloc_func>(0);
-  stream.zfree = reinterpret_cast<free_func>(0);
-  stream.next_in = reinterpret_cast<Bytef*>(const_cast<uint8_t*>(input));
-  stream.avail_in = input_len;
-  stream.next_out = reinterpret_cast<Bytef*>(output_buffer);
-  stream.avail_out = output_len;
-  int rc = inflateInit2(&stream, 16+MAX_WBITS);
+// These are magic numbers from zlib.h.  Not clear why they are not defined
+// there.
+static constexpr int WINDOW_BITS = 15;    // Maximum window size
+static constexpr int GZIP_CODEC = 16;     // Output Gzip.
+
+GZipCodec::GZipCodec(Format format) {
+  memset(&stream_, 0, sizeof(stream_));
+
+  int ret;
+  // Initialize to run specified format
+  int window_bits = WINDOW_BITS;
+  if (format == DEFLATE) {
+    window_bits = -window_bits;
+  } else if (format == GZIP) {
+    window_bits += GZIP_CODEC;
+  }
+  if ((ret = deflateInit2(&stream_, Z_DEFAULT_COMPRESSION, Z_DEFLATED,
+              window_bits, 9, Z_DEFAULT_STRATEGY)) != Z_OK) {
+    throw ParquetException("zlib deflateInit failed: " +
+        std::string(stream_.msg));
+  }
+}
+
+void GZipCodec::Decompress(int64_t input_len, const uint8_t* input,
+    int64_t output_len, uint8_t* output) {
+  stream_.zalloc = reinterpret_cast<alloc_func>(0);
+  stream_.zfree = reinterpret_cast<free_func>(0);
+  stream_.next_in = reinterpret_cast<Bytef*>(const_cast<uint8_t*>(input));
+  stream_.avail_in = input_len;
+  stream_.next_out = reinterpret_cast<Bytef*>(output);
+  stream_.avail_out = output_len;
+  int rc = inflateInit2(&stream_, 16+MAX_WBITS);
   if (rc != Z_OK) {
     throw ParquetException("zlib internal error.");
   }
-  rc = inflate(&stream, Z_FINISH);
+  rc = inflate(&stream_, Z_FINISH);
   if (rc == Z_STREAM_END) {
-    rc = inflateEnd(&stream);
+    rc = inflateEnd(&stream_);
   }
   if (rc != Z_OK) {
     throw ParquetException("Corrupt gzip compressed data.");
   }
 }
 
-int GZipCodec::MaxCompressedLen(int input_len, const uint8_t* input) {
-  return compressBound(input_len);
+int64_t GZipCodec::MaxCompressedLen(int64_t input_len, const uint8_t* input) {
+  // TODO(wesm): deal with zlib < 1.2.3 (see Impala codebase)
+  return deflateBound(&stream_, static_cast<uLong>(input_len));
 }
 
-int GZipCodec::Compress(int input_len, const uint8_t* input,
-    int output_buffer_len, uint8_t* output_buffer) {
-  uLongf dstLen = output_buffer_len;
-  int rc = compress2(reinterpret_cast<Bytef*>(output_buffer), &dstLen,
-      reinterpret_cast<const Bytef*>(input), input_len, 1);
-  return rc == Z_OK ? dstLen : input_len;
+int64_t GZipCodec::Compress(int64_t input_length, const uint8_t* input,
+    int64_t output_length, uint8_t* output) {
+  stream_.next_in = const_cast<Bytef*>(reinterpret_cast<const Bytef*>(input));
+  stream_.avail_in = input_length;
+  stream_.next_out = reinterpret_cast<Bytef*>(output);
+  stream_.avail_out = output_length;
+
+  int64_t ret = 0;
+  if ((ret = deflate(&stream_, Z_FINISH)) != Z_STREAM_END) {
+    if (ret == Z_OK) {
+      // will return Z_OK (and stream.msg NOT set) if stream.avail_out is too
+      // small
+      throw ParquetException("zlib deflate failed, output buffer to small");
+    }
+    std::stringstream ss;
+    ss << "zlib deflate failed: " << stream_.msg;
+    throw ParquetException(ss.str());
+  }
+
+  if (deflateReset(&stream_) != Z_OK) {
+    throw ParquetException("zlib deflateReset failed: " +
+        std::string(stream_.msg));
+  }
+
+  return output_length - stream_.avail_out;
 }
 
 } // namespace parquet_cpp

--- a/src/parquet/compression/lz4-codec.cc
+++ b/src/parquet/compression/lz4-codec.cc
@@ -21,21 +21,21 @@
 
 namespace parquet_cpp {
 
-void Lz4Codec::Decompress(int input_len, const uint8_t* input,
-      int output_len, uint8_t* output_buffer) {
-  int n = LZ4_decompress_fast(reinterpret_cast<const char*>(input),
+void Lz4Codec::Decompress(int64_t input_len, const uint8_t* input,
+      int64_t output_len, uint8_t* output_buffer) {
+  int64_t n = LZ4_decompress_fast(reinterpret_cast<const char*>(input),
       reinterpret_cast<char*>(output_buffer), output_len);
   if (n != input_len) {
     throw parquet_cpp::ParquetException("Corrupt lz4 compressed data.");
   }
 }
 
-int Lz4Codec::MaxCompressedLen(int input_len, const uint8_t* input) {
+int64_t Lz4Codec::MaxCompressedLen(int64_t input_len, const uint8_t* input) {
   return LZ4_compressBound(input_len);
 }
 
-int Lz4Codec::Compress(int input_len, const uint8_t* input,
-    int output_buffer_len, uint8_t* output_buffer) {
+int64_t Lz4Codec::Compress(int64_t input_len, const uint8_t* input,
+    int64_t output_buffer_len, uint8_t* output_buffer) {
   return LZ4_compress(reinterpret_cast<const char*>(input),
       reinterpret_cast<char*>(output_buffer), input_len);
 }

--- a/src/parquet/compression/snappy-codec.cc
+++ b/src/parquet/compression/snappy-codec.cc
@@ -21,20 +21,20 @@
 
 namespace parquet_cpp {
 
-void SnappyCodec::Decompress(int input_len, const uint8_t* input,
-      int output_len, uint8_t* output_buffer) {
+void SnappyCodec::Decompress(int64_t input_len, const uint8_t* input,
+      int64_t output_len, uint8_t* output_buffer) {
   if (!snappy::RawUncompress(reinterpret_cast<const char*>(input),
       static_cast<size_t>(input_len), reinterpret_cast<char*>(output_buffer))) {
     throw parquet_cpp::ParquetException("Corrupt snappy compressed data.");
   }
 }
 
-int SnappyCodec::MaxCompressedLen(int input_len, const uint8_t* input) {
+int64_t SnappyCodec::MaxCompressedLen(int64_t input_len, const uint8_t* input) {
   return snappy::MaxCompressedLength(input_len);
 }
 
-int SnappyCodec::Compress(int input_len, const uint8_t* input,
-    int output_buffer_len, uint8_t* output_buffer) {
+int64_t SnappyCodec::Compress(int64_t input_len, const uint8_t* input,
+    int64_t output_buffer_len, uint8_t* output_buffer) {
   size_t output_len;
   snappy::RawCompress(reinterpret_cast<const char*>(input),
       static_cast<size_t>(input_len), reinterpret_cast<char*>(output_buffer),

--- a/src/parquet/util/test-common.h
+++ b/src/parquet/util/test-common.h
@@ -95,6 +95,14 @@ static inline vector<bool> flip_coins(size_t n, double p) {
   return draws;
 }
 
+void random_bytes(int n, uint32_t seed, std::vector<uint8_t>* out) {
+  std::mt19937 gen(seed);
+  std::uniform_int_distribution<int> d(0, 255);
+
+  for (int i = 0; i < n; ++i) {
+    out->push_back(d(gen) & 0xFF);
+  }
+}
 
 } // namespace test
 

--- a/thirdparty/build_thirdparty.sh
+++ b/thirdparty/build_thirdparty.sh
@@ -16,6 +16,7 @@ else
   for arg in "$*"; do
     case $arg in
       "lz4")        F_LZ4=1 ;;
+      "zlib")       F_ZLIB=1 ;;
       "gtest")      F_GTEST=1 ;;
       "snappy")     F_SNAPPY=1 ;;
       "thrift")     F_THRIFT=1 ;;
@@ -71,6 +72,13 @@ fi
 if [ -n "$F_ALL" -o -n "$F_LZ4" ]; then
   cd $TP_DIR/$LZ4_BASEDIR/cmake_unofficial
   CFLAGS=-fPIC cmake -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX $LZ4_DIR
+  make -j$PARALLEL install
+fi
+
+# build zlib
+if [ -n "$F_ALL" -o -n "$F_ZLIB" ]; then
+  cd $TP_DIR/$ZLIB_BASEDIR
+  CFLAGS=-fPIC cmake -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX $ZLIB_DIR
   make -j$PARALLEL install
 fi
 

--- a/thirdparty/download_thirdparty.sh
+++ b/thirdparty/download_thirdparty.sh
@@ -33,3 +33,8 @@ if [ ! -d ${THRIFT_BASEDIR} ]; then
   echo "Fetching thrift"
   download_extract_and_cleanup $THRIFT_URL
 fi
+
+if [ ! -d ${ZLIB_BASEDIR} ]; then
+  echo "Fetching zlib"
+  download_extract_and_cleanup $ZLIB_URL
+fi

--- a/thirdparty/versions.sh
+++ b/thirdparty/versions.sh
@@ -13,3 +13,7 @@ THRIFT_BASEDIR=thrift-$THRIFT_VERSION
 GTEST_VERSION=1.7.0
 GTEST_URL="https://github.com/google/googletest/archive/release-${GTEST_VERSION}.tar.gz"
 GTEST_BASEDIR=googletest-release-$GTEST_VERSION
+
+ZLIB_VERSION=1.2.8
+ZLIB_URL=http://zlib.net/zlib-${ZLIB_VERSION}.tar.gz
+ZLIB_BASEDIR=zlib-${ZLIB_VERSION}


### PR DESCRIPTION
We should perhaps separate compression and decompression code (as in Impala) as gzip is more stateful than the other compressors. 

Closes #11 when merged. 