### PR TITLE
PARQUET-533: Add a Buffer abstraction, refactor input/output classes to be simpler using Buffers

### DIFF
--- a/src/parquet/column/column-reader-test.cc
+++ b/src/parquet/column/column-reader-test.cc
@@ -63,9 +63,8 @@ class TestPrimitiveReader : public ::testing::Test {
 TEST_F(TestPrimitiveReader, TestInt32FlatRequired) {
   vector<int32_t> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-  std::vector<uint8_t> buffer;
   std::shared_ptr<DataPage> page = MakeDataPage<Type::INT32>(values, {}, 0,
-    {}, 0, &buffer);
+    {}, 0);
   pages_.push_back(page);
 
   NodePtr type = schema::Int32("a", Repetition::REQUIRED);
@@ -90,9 +89,8 @@ TEST_F(TestPrimitiveReader, TestInt32FlatOptional) {
   vector<int32_t> values = {1, 2, 3, 4, 5};
   vector<int16_t> def_levels = {1, 0, 0, 1, 1, 0, 0, 0, 1, 1};
 
-  std::vector<uint8_t> buffer;
   std::shared_ptr<DataPage> page = MakeDataPage<Type::INT32>(values, def_levels, 1,
-    {}, 0, &buffer);
+    {}, 0);
 
   pages_.push_back(page);
 
@@ -137,9 +135,8 @@ TEST_F(TestPrimitiveReader, TestInt32FlatRepeated) {
   vector<int16_t> def_levels = {2, 1, 1, 2, 2, 1, 1, 2, 2, 1};
   vector<int16_t> rep_levels = {0, 1, 1, 0, 0, 1, 1, 0, 0, 1};
 
-  std::vector<uint8_t> buffer;
   std::shared_ptr<DataPage> page = MakeDataPage<Type::INT32>(values,
-      def_levels, 2, rep_levels, 1, &buffer);
+      def_levels, 2, rep_levels, 1);
 
   pages_.push_back(page);
 
@@ -190,12 +187,11 @@ TEST_F(TestPrimitiveReader, TestInt32FlatRepeatedMultiplePages) {
   vector<int16_t> rep_levels[2] = {{0, 1, 1, 0, 0, 1, 1, 0, 0, 1},
     {0, 0, 1, 0, 1, 1, 0, 1, 0, 1}};
 
-  std::vector<uint8_t> buffer[4];
   std::shared_ptr<DataPage> page;
 
   for (int i = 0; i < 4; i++) {
     page = MakeDataPage<Type::INT32>(values[i % 2],
-        def_levels[i % 2], 2, rep_levels[i % 2], 1, &buffer[i]);
+        def_levels[i % 2], 2, rep_levels[i % 2], 1);
     pages_.push_back(page);
   }
 

--- a/src/parquet/column/page.h
+++ b/src/parquet/column/page.h
@@ -27,6 +27,7 @@
 #include <string>
 
 #include "parquet/types.h"
+#include "parquet/util/buffer.h"
 
 namespace parquet_cpp {
 
@@ -39,9 +40,8 @@ namespace parquet_cpp {
 // here, both on the read and write path
 class Page {
  public:
-  Page(const uint8_t* buffer, int32_t buffer_size, PageType::type type) :
+  Page(const std::shared_ptr<Buffer>& buffer, PageType::type type) :
       buffer_(buffer),
-      buffer_size_(buffer_size),
       type_(type) {}
 
   PageType::type type() const {
@@ -50,29 +50,27 @@ class Page {
 
   // @returns: a pointer to the page's data
   const uint8_t* data() const {
-    return buffer_;
+    return buffer_->data();
   }
 
   // @returns: the total size in bytes of the page's data buffer
   int32_t size() const {
-    return buffer_size_;
+    return buffer_->size();
   }
 
  private:
-  const uint8_t* buffer_;
-  int32_t buffer_size_;
-
+  std::shared_ptr<Buffer> buffer_;
   PageType::type type_;
 };
 
 
 class DataPage : public Page {
  public:
-  DataPage(const uint8_t* buffer, int32_t buffer_size,
+  DataPage(const std::shared_ptr<Buffer>& buffer,
       int32_t num_values, Encoding::type encoding,
       Encoding::type definition_level_encoding,
       Encoding::type repetition_level_encoding) :
-      Page(buffer, buffer_size, PageType::DATA_PAGE),
+      Page(buffer, PageType::DATA_PAGE),
       num_values_(num_values),
       encoding_(encoding),
       definition_level_encoding_(definition_level_encoding),
@@ -119,12 +117,12 @@ class DataPage : public Page {
 
 class DataPageV2 : public Page {
  public:
-  DataPageV2(const uint8_t* buffer, int32_t buffer_size,
+  DataPageV2(const std::shared_ptr<Buffer>& buffer,
       int32_t num_values, int32_t num_nulls, int32_t num_rows,
       Encoding::type encoding,
       int32_t definition_levels_byte_length,
       int32_t repetition_levels_byte_length, bool is_compressed = false) :
-      Page(buffer, buffer_size, PageType::DATA_PAGE_V2),
+      Page(buffer, PageType::DATA_PAGE_V2),
       num_values_(num_values),
       num_nulls_(num_nulls),
       num_rows_(num_rows),
@@ -176,9 +174,9 @@ class DataPageV2 : public Page {
 
 class DictionaryPage : public Page {
  public:
-  DictionaryPage(const uint8_t* buffer, int32_t buffer_size,
+  DictionaryPage(const std::shared_ptr<Buffer>& buffer,
       int32_t num_values, Encoding::type encoding, bool is_sorted = false) :
-      Page(buffer, buffer_size, PageType::DICTIONARY_PAGE),
+      Page(buffer, PageType::DICTIONARY_PAGE),
       num_values_(num_values),
       encoding_(encoding),
       is_sorted_(is_sorted) {}

--- a/src/parquet/column/test-util.h
+++ b/src/parquet/column/test-util.h
@@ -167,8 +167,7 @@ class DataPageBuilder {
 template <int TYPE, typename T>
 static std::shared_ptr<DataPage> MakeDataPage(const std::vector<T>& values,
     const std::vector<int16_t>& def_levels, int16_t max_def_level,
-    const std::vector<int16_t>& rep_levels, int16_t max_rep_level,
-    std::vector<uint8_t>* out_buffer) {
+    const std::vector<int16_t>& rep_levels, int16_t max_rep_level) {
   size_t num_values = values.size();
 
   InMemoryOutputStream page_stream;
@@ -183,10 +182,10 @@ static std::shared_ptr<DataPage> MakeDataPage(const std::vector<T>& values,
   }
 
   page_builder.AppendValues(values);
-  page_stream.Transfer(out_buffer);
 
-  return std::make_shared<DataPage>(&(*out_buffer)[0], out_buffer->size(),
-      page_builder.num_values(),
+  auto buffer = page_stream.GetBuffer();
+
+  return std::make_shared<DataPage>(buffer, page_builder.num_values(),
       page_builder.encoding(),
       page_builder.def_level_encoding(),
       page_builder.rep_level_encoding());

--- a/src/parquet/file/file-deserialize-test.cc
+++ b/src/parquet/file/file-deserialize-test.cc
@@ -67,8 +67,7 @@ class TestPageSerde : public ::testing::Test {
       Compression::UNCOMPRESSED) {
     EndStream();
     std::unique_ptr<InputStream> stream;
-    stream.reset(new InMemoryInputStream(out_buffer_.data(),
-            out_buffer_.size()));
+    stream.reset(new InMemoryInputStream(out_buffer_));
     page_reader_.reset(new SerializedPageReader(std::move(stream), codec));
   }
 
@@ -89,19 +88,16 @@ class TestPageSerde : public ::testing::Test {
   }
 
   void ResetStream() {
-    out_buffer_.resize(0);
     out_stream_.reset(new InMemoryOutputStream());
   }
 
   void EndStream() {
-    out_stream_->Transfer(&out_buffer_);
+    out_buffer_ = out_stream_->GetBuffer();
   }
 
  protected:
   std::unique_ptr<InMemoryOutputStream> out_stream_;
-
-  // TODO(wesm): Owns the results of the output stream. To be refactored
-  std::vector<uint8_t> out_buffer_;
+  std::shared_ptr<Buffer> out_buffer_;
 
   std::unique_ptr<SerializedPageReader> page_reader_;
   parquet::PageHeader page_header_;

--- a/src/parquet/file/reader-internal.h
+++ b/src/parquet/file/reader-internal.h
@@ -72,10 +72,9 @@ class SerializedPageReader : public PageReader {
 // RowGroupReader::Contents implementation for the Parquet file specification
 class SerializedRowGroup : public RowGroupReader::Contents {
  public:
-  SerializedRowGroup(RandomAccessSource* source, const SchemaDescriptor* schema,
+  SerializedRowGroup(RandomAccessSource* source,
       const parquet::RowGroup* metadata) :
       source_(source),
-      schema_(schema),
       metadata_(metadata) {}
 
   virtual int num_columns() const;
@@ -84,7 +83,6 @@ class SerializedRowGroup : public RowGroupReader::Contents {
 
  private:
   RandomAccessSource* source_;
-  const SchemaDescriptor* schema_;
   const parquet::RowGroup* metadata_;
 };
 

--- a/src/parquet/file/reader.h
+++ b/src/parquet/file/reader.h
@@ -22,7 +22,6 @@
 #include <iosfwd>
 #include <memory>
 #include <string>
-#include <unordered_map>
 
 #include "parquet/column/page.h"
 #include "parquet/schema/descriptor.h"
@@ -63,9 +62,6 @@ class RowGroupReader {
   // This is declared in the .cc file so that we can hide compiled Thrift
   // headers from the public API and also more easily create test fixtures.
   std::unique_ptr<Contents> contents_;
-
-  // Column index -> ColumnReader
-  std::unordered_map<int, std::shared_ptr<ColumnReader> > column_readers_;
 };
 
 
@@ -99,7 +95,7 @@ class ParquetFileReader {
   void Close();
 
   // The RowGroupReader is owned by the FileReader
-  RowGroupReader* RowGroup(int i);
+  std::shared_ptr<RowGroupReader> RowGroup(int i);
 
   int num_columns() const;
   int64_t num_rows() const;
@@ -124,9 +120,6 @@ class ParquetFileReader {
 
   // The SchemaDescriptor is provided by the Contents impl
   const SchemaDescriptor* schema_;
-
-  // Row group index -> RowGroupReader
-  std::unordered_map<int, std::shared_ptr<RowGroupReader> > row_group_readers_;
 };
 
 

--- a/src/parquet/reader-test.cc
+++ b/src/parquet/reader-test.cc
@@ -56,7 +56,7 @@ TEST_F(TestAllTypesPlain, NoopConstructDestruct) {
 }
 
 TEST_F(TestAllTypesPlain, TestBatchRead) {
-  RowGroupReader* group = reader_->RowGroup(0);
+  std::shared_ptr<RowGroupReader> group = reader_->RowGroup(0);
 
   // column 0, id
   std::shared_ptr<Int32Reader> col =
@@ -84,7 +84,7 @@ TEST_F(TestAllTypesPlain, TestBatchRead) {
 }
 
 TEST_F(TestAllTypesPlain, TestFlatScannerInt32) {
-  RowGroupReader* group = reader_->RowGroup(0);
+  std::shared_ptr<RowGroupReader> group = reader_->RowGroup(0);
 
   // column 0, id
   std::shared_ptr<Int32Scanner> scanner(new Int32Scanner(group->Column(0)));
@@ -101,7 +101,7 @@ TEST_F(TestAllTypesPlain, TestFlatScannerInt32) {
 
 
 TEST_F(TestAllTypesPlain, TestSetScannerBatchSize) {
-  RowGroupReader* group = reader_->RowGroup(0);
+  std::shared_ptr<RowGroupReader> group = reader_->RowGroup(0);
 
   // column 0, id
   std::shared_ptr<Int32Scanner> scanner(new Int32Scanner(group->Column(0)));

--- a/src/parquet/util/CMakeLists.txt
+++ b/src/parquet/util/CMakeLists.txt
@@ -32,6 +32,7 @@ install(FILES
   DESTINATION include/parquet/util)
 
 add_library(parquet_util STATIC
+  buffer.cc
   input.cc
   output.cc
   cpu-info.cc
@@ -56,5 +57,6 @@ if(PARQUET_BUILD_TESTS)
 endif()
 
 ADD_PARQUET_TEST(bit-util-test)
+ADD_PARQUET_TEST(buffer-test)
 ADD_PARQUET_TEST(output-test)
 ADD_PARQUET_TEST(rle-test)

--- a/src/parquet/util/buffer.h
+++ b/src/parquet/util/buffer.h
@@ -1,0 +1,140 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef PARQUET_UTIL_BUFFER_H
+#define PARQUET_UTIL_BUFFER_H
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "parquet/util/macros.h"
+
+namespace parquet_cpp {
+
+// ----------------------------------------------------------------------
+// Buffer classes
+
+// Immutable API for a chunk of bytes which may or may not be owned by the
+// class instance
+class Buffer : public std::enable_shared_from_this<Buffer> {
+ public:
+  Buffer(const uint8_t* data, int64_t size) :
+      data_(data),
+      size_(size) {}
+
+  // An offset into data that is owned by another buffer, but we want to be
+  // able to retain a valid pointer to it even after other shared_ptr's to the
+  // parent buffer have been destroyed
+  Buffer(const std::shared_ptr<Buffer>& parent, int64_t offset, int64_t size);
+
+  std::shared_ptr<Buffer> get_shared_ptr() {
+    return shared_from_this();
+  }
+
+  // Return true if both buffers are the same size and contain the same bytes
+  // up to the number of compared bytes
+  bool Equals(const Buffer& other, int64_t nbytes) const {
+    return this == &other ||
+      (size_ >= nbytes && other.size_ >= nbytes &&
+          !memcmp(data_, other.data_, nbytes));
+  }
+
+  bool Equals(const Buffer& other) const {
+    return this == &other ||
+      (size_ == other.size_ && !memcmp(data_, other.data_, size_));
+  }
+
+  const uint8_t* data() const {
+    return data_;
+  }
+
+  int64_t size() const {
+    return size_;
+  }
+
+  // Returns true if this Buffer is referencing memory (possibly) owned by some
+  // other buffer
+  bool is_shared() const {
+    return static_cast<bool>(parent_);
+  }
+
+  const std::shared_ptr<Buffer> parent() const {
+    return parent_;
+  }
+
+ protected:
+  const uint8_t* data_;
+  int64_t size_;
+
+  // nullptr by default, but may be set
+  std::shared_ptr<Buffer> parent_;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(Buffer);
+};
+
+// A Buffer whose contents can be mutated. May or may not own its data.
+class MutableBuffer : public Buffer {
+ public:
+  MutableBuffer(uint8_t* data, int64_t size) :
+      Buffer(data, size) {
+    mutable_data_ = data;
+  }
+
+  uint8_t* mutable_data() {
+    return mutable_data_;
+  }
+
+  // Get a read-only view of this buffer
+  std::shared_ptr<Buffer> GetImmutableView();
+
+ protected:
+  MutableBuffer() :
+      Buffer(nullptr, 0),
+      mutable_data_(nullptr) {}
+
+  uint8_t* mutable_data_;
+};
+
+class ResizableBuffer : public MutableBuffer {
+ public:
+  virtual void Resize(int64_t new_size) = 0;
+
+ protected:
+  ResizableBuffer(uint8_t* data, int64_t size) :
+      MutableBuffer(data, size) {}
+};
+
+// A ResizableBuffer whose memory is owned by the class instance. For example,
+// for reading data out of files that you want to deallocate when this class is
+// garbage-collected
+class OwnedMutableBuffer : public ResizableBuffer {
+ public:
+  OwnedMutableBuffer();
+  virtual void Resize(int64_t new_size);
+
+ private:
+  // TODO: aligned allocations
+  std::vector<uint8_t> buffer_owner_;
+};
+
+} // namespace parquet_cpp
+
+#endif // PARQUET_UTIL_BUFFER_H

--- a/src/parquet/util/output.h
+++ b/src/parquet/util/output.h
@@ -19,11 +19,15 @@
 #define PARQUET_UTIL_OUTPUT_H
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #include "parquet/util/macros.h"
 
 namespace parquet_cpp {
+
+class Buffer;
+class ResizableBuffer;
 
 // ----------------------------------------------------------------------
 // Output stream classes
@@ -55,14 +59,14 @@ class InMemoryOutputStream : public OutputStream {
 
   virtual void Write(const uint8_t* data, int64_t length);
 
-  // Hand off the in-memory data to a (preferably-empty) std::vector owner
-  void Transfer(std::vector<uint8_t>* out);
+  // Return complete stream as Buffer
+  std::shared_ptr<Buffer> GetBuffer();
 
  private:
   // Mutable pointer to the current write position in the stream
   uint8_t* Head();
 
-  std::vector<uint8_t> buffer_;
+  std::shared_ptr<ResizableBuffer> buffer_;
   int64_t size_;
   int64_t capacity_;
 


### PR DESCRIPTION
I have also removed all RowGroupReader and ColumnReader caching until we have an idea of how the caching will help users while also keeping memory-use under control.

The goal with this patch is to encapsulate the "data pointer and size" concept and lightly abstract away buffer ownership. The particular motivation is being able to deal with both normal files (bytes arriving via `fread`) and memory-mapped files (copying of bytes into new memory not required). It also helps do away with a bunch of functions that write output into a `std::vector<uint8_t>` now in favor of the `OwnedMutableBuffer`. Feedback welcome; plenty more work that can be done here. 

Requires PARQUET-457. Will rebase once that's merged. 