### PR TITLE
PARQUET-538: Improve ColumnReader Tests

### DIFF
--- a/src/parquet/column/CMakeLists.txt
+++ b/src/parquet/column/CMakeLists.txt
@@ -25,3 +25,4 @@ install(FILES
 
 ADD_PARQUET_TEST(column-reader-test)
 ADD_PARQUET_TEST(levels-test)
+ADD_PARQUET_TEST(scanner-test)

--- a/src/parquet/column/column-reader-test.cc
+++ b/src/parquet/column/column-reader-test.cc
@@ -99,8 +99,8 @@ class TestPrimitiveReader : public ::testing::Test {
     int32_t batch_size = 8;
     size_t batch = 0;
     // This will cover both the cases
-    // 1) batch_size < page_size (multiple ReadBatch form a single page)
-    // 2) batch_size > page_size (read from multiple pages)
+    // 1) batch_size < page_size (multiple ReadBatch from a single page)
+    // 2) batch_size > page_size (BatchRead from multiple pages)
     do {
       batch = reader->ReadBatch(batch_size, &dresult[0] + batch_actual,
           &rresult[0] + batch_actual, &vresult[0] + total_values_read, &values_read);

--- a/src/parquet/column/column-reader-test.cc
+++ b/src/parquet/column/column-reader-test.cc
@@ -76,7 +76,7 @@ class TestPrimitiveReader : public ::testing::Test {
     values_.resize(num_values_);
     random_numbers(num_values_, seed, std::numeric_limits<int32_t>::min(),
        std::numeric_limits<int32_t>::max(), values_.data());
-    RandomPaginate<Type::INT32, int32_t>(d, values_, def_levels_, max_def_level_,
+    Paginate<Type::INT32, int32_t>(d, values_, def_levels_, max_def_level_,
         rep_levels_, max_rep_level_, levels_per_page, values_per_page, pages_);
   }
 

--- a/src/parquet/column/column-reader-test.cc
+++ b/src/parquet/column/column-reader-test.cc
@@ -80,7 +80,7 @@ class TestPrimitiveReader : public ::testing::Test {
         rep_levels_, max_rep_level_, levels_per_page, values_per_page, pages_);
   }
 
-  void InitReader(const ColumnDescriptor *d) {
+  void InitReader(const ColumnDescriptor* d) {
     std::unique_ptr<PageReader> pager_;
     pager_.reset(new test::MockPageReader(pages_));
     reader_ = ColumnReader::Make(d, std::move(pager_));

--- a/src/parquet/column/column-reader-test.cc
+++ b/src/parquet/column/column-reader-test.cc
@@ -44,195 +44,113 @@ namespace test {
 
 class TestPrimitiveReader : public ::testing::Test {
  public:
-  void SetUp() {}
+  void init_def_levels() {
+    num_values_ = 0;
+    def_levels_.resize(num_levels_);
+    random_levels(num_levels_, 0, max_def_level_, def_levels_.data());
+    for (int i = 0; i < num_levels_; i++) {
+      if (def_levels_[i] == max_def_level_) num_values_++;
+    }
+  }
 
-  void TearDown() {}
+  void init_rep_levels() {
+    rep_levels_.resize(num_levels_);
+    random_levels(num_levels_, 0, max_rep_level_, rep_levels_.data());
+  }
 
-  void InitReader(const ColumnDescriptor* descr) {
+  void init_values() {
+    values_.resize(num_values_);
+    random_numbers(num_values_, 0, values_.data());
+  }
+
+  void init_reader() {
+    std::shared_ptr<DataPage> page = MakeDataPage<Type::INT32>(values_, def_levels_,
+        max_def_level_, rep_levels_, max_rep_level_);
+    pages_.push_back(page);
     pager_.reset(new test::MockPageReader(pages_));
-    reader_ = ColumnReader::Make(descr, std::move(pager_));
+    reader_ = ColumnReader::Make(descr_, std::move(pager_));
+  }
+
+  void check_results() {
+    vector<int32_t> vresult(num_values_, -1);
+    vector<int16_t> dresult(num_levels_, -1);
+    vector<int16_t> rresult(num_levels_, -1);
+    size_t values_read = 0;
+    size_t total_values_read = 0;
+
+    Int32Reader* reader = static_cast<Int32Reader*>(reader_.get());
+    int offset = num_levels_ / 2;
+    size_t batch_actual = reader->ReadBatch(num_levels_, &dresult[0], &rresult[0],
+        &vresult[0], &values_read);
+    total_values_read += values_read;
+    batch_actual += reader->ReadBatch(offset, &dresult[0] + offset, &rresult[0] + offset,
+        &vresult[0] + values_read, &values_read);
+    total_values_read += values_read;
+
+    ASSERT_EQ(num_levels_, batch_actual);
+    ASSERT_EQ(num_values_, total_values_read);
+
+    ASSERT_TRUE(vector_equal(values_, vresult));
+    if (max_def_level_ > 0) {
+      ASSERT_TRUE(vector_equal(def_levels_, dresult));
+    }
+    if (max_rep_level_ > 0) {
+      ASSERT_TRUE(vector_equal(rep_levels_, rresult));
+    }
+  }
+
+  void execute() {
+    init_values();
+    init_reader();
+    check_results();
   }
 
  protected:
-  std::shared_ptr<ColumnReader> reader_;
-  std::unique_ptr<PageReader> pager_;
+  int num_levels_;
+  int num_values_;
+  int16_t max_def_level_;
+  int16_t max_rep_level_;
+  const ColumnDescriptor *descr_;
   vector<shared_ptr<Page> > pages_;
+  std::unique_ptr<PageReader> pager_;
+  std::shared_ptr<ColumnReader> reader_;
+  vector<int32_t> values_;
+  vector<int16_t> def_levels_;
+  vector<int16_t> rep_levels_;
 };
 
-
 TEST_F(TestPrimitiveReader, TestInt32FlatRequired) {
-  vector<int32_t> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-
-  std::shared_ptr<DataPage> page = MakeDataPage<Type::INT32>(values, {}, 0,
-    {}, 0);
-  pages_.push_back(page);
-
+  num_levels_ = num_values_ = 1000;
+  max_def_level_ = 0;
+  max_rep_level_ = 0;
   NodePtr type = schema::Int32("a", Repetition::REQUIRED);
-  ColumnDescriptor descr(type, 0, 0);
-  InitReader(&descr);
-
-  Int32Reader* reader = static_cast<Int32Reader*>(reader_.get());
-
-  vector<int32_t> result(10, -1);
-
-  size_t values_read = 0;
-  size_t batch_actual = reader->ReadBatch(10, nullptr, nullptr,
-      &result[0], &values_read);
-  ASSERT_EQ(10, batch_actual);
-  ASSERT_EQ(10, values_read);
-
-  ASSERT_TRUE(vector_equal(result, values));
+  const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
+  descr_ = &descr;
+  execute();
 }
 
-
 TEST_F(TestPrimitiveReader, TestInt32FlatOptional) {
-  vector<int32_t> values = {1, 2, 3, 4, 5};
-  vector<int16_t> def_levels = {1, 0, 0, 1, 1, 0, 0, 0, 1, 1};
-
-  std::shared_ptr<DataPage> page = MakeDataPage<Type::INT32>(values, def_levels, 1,
-    {}, 0);
-
-  pages_.push_back(page);
-
-  NodePtr type = schema::Int32("a", Repetition::OPTIONAL);
-  ColumnDescriptor descr(type, 1, 0);
-  InitReader(&descr);
-
-  Int32Reader* reader = static_cast<Int32Reader*>(reader_.get());
-
-  size_t values_read = 0;
-  size_t batch_actual = 0;
-
-  vector<int32_t> vresult(3, -1);
-  vector<int16_t> dresult(5, -1);
-
-  batch_actual = reader->ReadBatch(5, &dresult[0], nullptr,
-      &vresult[0], &values_read);
-  ASSERT_EQ(5, batch_actual);
-  ASSERT_EQ(3, values_read);
-
-  ASSERT_TRUE(vector_equal(vresult, slice(values, 0, 3)));
-  ASSERT_TRUE(vector_equal(dresult, slice(def_levels, 0, 5)));
-
-  batch_actual = reader->ReadBatch(5, &dresult[0], nullptr,
-      &vresult[0], &values_read);
-  ASSERT_EQ(5, batch_actual);
-  ASSERT_EQ(2, values_read);
-
-  ASSERT_TRUE(vector_equal(slice(vresult, 0, 2), slice(values, 3, 5)));
-  ASSERT_TRUE(vector_equal(dresult, slice(def_levels, 5, 10)));
-
-  // EOS, pass all nullptrs to check for improper writes. Do not segfault /
-  // core dump
-  batch_actual = reader->ReadBatch(5, nullptr, nullptr,
-      nullptr, &values_read);
-  ASSERT_EQ(0, batch_actual);
-  ASSERT_EQ(0, values_read);
+  num_levels_ = 1000;
+  max_def_level_ = 4;
+  max_rep_level_ = 0;
+  NodePtr type = schema::Int32("b", Repetition::OPTIONAL);
+  const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
+  descr_ = &descr;
+  init_def_levels();
+  execute();
 }
 
 TEST_F(TestPrimitiveReader, TestInt32FlatRepeated) {
-  vector<int32_t> values = {1, 2, 3, 4, 5};
-  vector<int16_t> def_levels = {2, 1, 1, 2, 2, 1, 1, 2, 2, 1};
-  vector<int16_t> rep_levels = {0, 1, 1, 0, 0, 1, 1, 0, 0, 1};
-
-  std::shared_ptr<DataPage> page = MakeDataPage<Type::INT32>(values,
-      def_levels, 2, rep_levels, 1);
-
-  pages_.push_back(page);
-
-  NodePtr type = schema::Int32("a", Repetition::REPEATED);
-  ColumnDescriptor descr(type, 2, 1);
-  InitReader(&descr);
-
-  Int32Reader* reader = static_cast<Int32Reader*>(reader_.get());
-
-  size_t values_read = 0;
-  size_t batch_actual = 0;
-
-  vector<int32_t> vresult(3, -1);
-  vector<int16_t> dresult(5, -1);
-  vector<int16_t> rresult(5, -1);
-
-  batch_actual = reader->ReadBatch(5, &dresult[0], &rresult[0],
-      &vresult[0], &values_read);
-  ASSERT_EQ(5, batch_actual);
-  ASSERT_EQ(3, values_read);
-
-  ASSERT_TRUE(vector_equal(vresult, slice(values, 0, 3)));
-  ASSERT_TRUE(vector_equal(dresult, slice(def_levels, 0, 5)));
-  ASSERT_TRUE(vector_equal(rresult, slice(rep_levels, 0, 5)));
-
-  batch_actual = reader->ReadBatch(5, &dresult[0], &rresult[0],
-      &vresult[0], &values_read);
-  ASSERT_EQ(5, batch_actual);
-  ASSERT_EQ(2, values_read);
-
-  ASSERT_TRUE(vector_equal(slice(vresult, 0, 2), slice(values, 3, 5)));
-  ASSERT_TRUE(vector_equal(dresult, slice(def_levels, 5, 10)));
-  ASSERT_TRUE(vector_equal(rresult, slice(rep_levels, 5, 10)));
-
-  // EOS, pass all nullptrs to check for improper writes. Do not segfault /
-  // core dump
-  batch_actual = reader->ReadBatch(5, nullptr, nullptr,
-      nullptr, &values_read);
-  ASSERT_EQ(0, batch_actual);
-  ASSERT_EQ(0, values_read);
+  num_levels_ = 1000;
+  max_def_level_ = 4;
+  max_rep_level_ = 2;
+  NodePtr type = schema::Int32("c", Repetition::REPEATED);
+  const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
+  descr_ = &descr;
+  init_def_levels();
+  init_rep_levels();
+  execute();
 }
 
-TEST_F(TestPrimitiveReader, TestInt32FlatRepeatedMultiplePages) {
-  vector<int32_t> values[2] = {{1, 2, 3, 4, 5},
-    {6, 7, 8, 9, 10}};
-  vector<int16_t> def_levels[2] = {{2, 1, 1, 2, 2, 1, 1, 2, 2, 1},
-    {2, 2, 1, 2, 1, 1, 2, 1, 2, 1}};
-  vector<int16_t> rep_levels[2] = {{0, 1, 1, 0, 0, 1, 1, 0, 0, 1},
-    {0, 0, 1, 0, 1, 1, 0, 1, 0, 1}};
-
-  std::shared_ptr<DataPage> page;
-
-  for (int i = 0; i < 4; i++) {
-    page = MakeDataPage<Type::INT32>(values[i % 2],
-        def_levels[i % 2], 2, rep_levels[i % 2], 1);
-    pages_.push_back(page);
-  }
-
-  NodePtr type = schema::Int32("a", Repetition::REPEATED);
-  ColumnDescriptor descr(type, 2, 1);
-  InitReader(&descr);
-
-  Int32Reader* reader = static_cast<Int32Reader*>(reader_.get());
-
-  size_t values_read = 0;
-  size_t batch_actual = 0;
-
-  vector<int32_t> vresult(3, -1);
-  vector<int16_t> dresult(5, -1);
-  vector<int16_t> rresult(5, -1);
-
-  for (int i = 0; i < 4; i++) {
-    batch_actual = reader->ReadBatch(5, &dresult[0], &rresult[0],
-        &vresult[0], &values_read);
-    ASSERT_EQ(5, batch_actual);
-    ASSERT_EQ(3, values_read);
-
-    ASSERT_TRUE(vector_equal(vresult, slice(values[i % 2], 0, 3)));
-    ASSERT_TRUE(vector_equal(dresult, slice(def_levels[i % 2], 0, 5)));
-    ASSERT_TRUE(vector_equal(rresult, slice(rep_levels[i % 2], 0, 5)));
-
-    batch_actual = reader->ReadBatch(5, &dresult[0], &rresult[0],
-        &vresult[0], &values_read);
-    ASSERT_EQ(5, batch_actual);
-    ASSERT_EQ(2, values_read);
-
-    ASSERT_TRUE(vector_equal(slice(vresult, 0, 2), slice(values[i % 2], 3, 5)));
-    ASSERT_TRUE(vector_equal(dresult, slice(def_levels[i % 2], 5, 10)));
-    ASSERT_TRUE(vector_equal(rresult, slice(rep_levels[i % 2], 5, 10)));
-  }
-  // EOS, pass all nullptrs to check for improper writes. Do not segfault /
-  // core dump
-  batch_actual = reader->ReadBatch(5, nullptr, nullptr,
-      nullptr, &values_read);
-  ASSERT_EQ(0, batch_actual);
-  ASSERT_EQ(0, values_read);
-}
 } // namespace test
 } // namespace parquet_cpp

--- a/src/parquet/column/reader.h
+++ b/src/parquet/column/reader.h
@@ -169,7 +169,6 @@ inline size_t TypedColumnReader<TYPE>::ReadBatch(int32_t batch_size, int16_t* de
     if (!HasNext() || batch_size == 0) {
       break;
     }
-
     int current_batch_size = std::min(batch_size, num_buffered_values_);
     batch_size -= current_batch_size;
 
@@ -179,7 +178,8 @@ inline size_t TypedColumnReader<TYPE>::ReadBatch(int32_t batch_size, int16_t* de
 
     // If the field is required and non-repeated, there are no definition levels
     if (descr_->max_definition_level() > 0) {
-      num_def_levels = ReadDefinitionLevels(current_batch_size, def_levels + level_offset);
+      num_def_levels = ReadDefinitionLevels(current_batch_size,
+          def_levels + level_offset);
       // TODO(wesm): this tallying of values-to-decode can be performed with better
       // cache-efficiency if fused with the level decoding.
       for (size_t i = 0; i < num_def_levels; ++i) {
@@ -194,7 +194,8 @@ inline size_t TypedColumnReader<TYPE>::ReadBatch(int32_t batch_size, int16_t* de
 
     // Not present for non-repeated fields
     if (descr_->max_repetition_level() > 0) {
-      num_rep_levels = ReadRepetitionLevels(current_batch_size, rep_levels + level_offset);
+      num_rep_levels = ReadRepetitionLevels(current_batch_size,
+          rep_levels + level_offset);
       if (num_def_levels != num_rep_levels) {
         throw ParquetException("Number of decoded rep / def levels did not match");
       }

--- a/src/parquet/column/reader.h
+++ b/src/parquet/column/reader.h
@@ -170,8 +170,6 @@ inline size_t TypedColumnReader<TYPE>::ReadBatch(int32_t batch_size, int16_t* de
       break;
     }
     int current_batch_size = std::min(batch_size, num_buffered_values_);
-    batch_size -= current_batch_size;
-
     size_t num_def_levels = 0;
     size_t num_rep_levels = 0;
     size_t values_to_read = 0;
@@ -202,12 +200,14 @@ inline size_t TypedColumnReader<TYPE>::ReadBatch(int32_t batch_size, int16_t* de
     }
 
     current_values_read = ReadValues(values_to_read, values + value_offset);
-    total_values += std::max(num_def_levels, current_values_read);
-    level_offset += current_batch_size;
-    value_offset += *values_read;
+    size_t current_values = std::max(num_def_levels, current_values_read);
+    batch_size -= current_values;
+    total_values += current_values;
+    num_decoded_values_ += current_values;
+    level_offset += current_values;
+    value_offset += current_values_read;
     *values_read += current_values_read;
   }
-  num_decoded_values_ += total_values;
   return total_values;
 }
 

--- a/src/parquet/column/scanner-test.cc
+++ b/src/parquet/column/scanner-test.cc
@@ -52,7 +52,7 @@ bool operator==(const ByteArray& a, const ByteArray& b) {
 
 static int FLBA_LENGTH = 12;
 bool operator==(const FixedLenByteArray& a, const FixedLenByteArray& b) {
- return 0 == memcmp(a.ptr, a.ptr, FLBA_LENGTH);
+  return 0 == memcmp(a.ptr, a.ptr, FLBA_LENGTH);
 }
 
 namespace test {
@@ -140,11 +140,15 @@ class TestFlatScanner : public ::testing::Test {
 
   void InitDescriptors(std::shared_ptr<ColumnDescriptor>& d1,
       std::shared_ptr<ColumnDescriptor>& d2, std::shared_ptr<ColumnDescriptor>& d3) {
-    NodePtr type = schema::PrimitiveNode::Make("c1", Repetition::REQUIRED, static_cast<Type::type>(TYPE));
+    NodePtr type;
+    type = schema::PrimitiveNode::Make("c1", Repetition::REQUIRED,
+        static_cast<Type::type>(TYPE));
     d1.reset(new ColumnDescriptor(type, 0, 0));
-    type = schema::PrimitiveNode::Make("c2", Repetition::OPTIONAL, static_cast<Type::type>(TYPE));
+    type = schema::PrimitiveNode::Make("c2", Repetition::OPTIONAL,
+        static_cast<Type::type>(TYPE));
     d2.reset(new ColumnDescriptor(type, 4, 0));
-    type = schema::PrimitiveNode::Make("c3", Repetition::REPEATED, static_cast<Type::type>(TYPE));
+    type = schema::PrimitiveNode::Make("c3", Repetition::REPEATED,
+        static_cast<Type::type>(TYPE));
     d3.reset(new ColumnDescriptor(type, 4, 2));
   }
 
@@ -152,7 +156,6 @@ class TestFlatScanner : public ::testing::Test {
     std::shared_ptr<ColumnDescriptor> d1;
     std::shared_ptr<ColumnDescriptor> d2;
     std::shared_ptr<ColumnDescriptor> d3;
-    
     InitDescriptors(d1, d2, d3);
     // evaluate REQUIRED pages
     Execute(num_pages, num_levels, d1.get());
@@ -193,7 +196,8 @@ template<>
 void TestFlatScanner<Type::FIXED_LEN_BYTE_ARRAY, FLBA>::InitValues() {
   size_t nbytes = num_values_ * FLBA_LENGTH;
   data_buffer_.resize(nbytes);
-  random_fixed_byte_array(num_values_, 0, data_buffer_.data(), FLBA_LENGTH, values_.data());
+  random_fixed_byte_array(num_values_, 0, data_buffer_.data(), FLBA_LENGTH,
+      values_.data());
 }
 
 template<>

--- a/src/parquet/column/scanner-test.cc
+++ b/src/parquet/column/scanner-test.cc
@@ -131,7 +131,8 @@ class TestFlatScanner : public ::testing::Test {
     rep_levels_.clear();
   }
 
-  void Execute(int num_pages, int levels_page, int batch_size, const ColumnDescriptor *d) {
+  void Execute(int num_pages, int levels_page, int batch_size,
+      const ColumnDescriptor *d) {
     MakePages(d, num_pages, levels_page);
     InitScanner(d);
     CheckResults(batch_size);

--- a/src/parquet/column/scanner-test.cc
+++ b/src/parquet/column/scanner-test.cc
@@ -1,0 +1,256 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "parquet/types.h"
+#include "parquet/column/page.h"
+#include "parquet/column/scanner.h"
+#include "parquet/column/test-util.h"
+#include "parquet/schema/descriptor.h"
+#include "parquet/schema/types.h"
+#include "parquet/util/test-common.h"
+
+using std::string;
+using std::vector;
+using std::shared_ptr;
+
+namespace parquet_cpp {
+
+using schema::NodePtr;
+
+bool operator==(const Int96& a, const Int96& b) {
+  return a.value[0] == b.value[0] &&
+    a.value[1] == b.value[1] &&
+    a.value[2] == b.value[2];
+}
+
+bool operator==(const ByteArray& a, const ByteArray& b) {
+  return a.len == b.len && 0 == memcmp(a.ptr, a.ptr, a.len);
+}
+
+static int FLBA_LENGTH = 12;
+bool operator==(const FixedLenByteArray& a, const FixedLenByteArray& b) {
+ return 0 == memcmp(a.ptr, a.ptr, FLBA_LENGTH);
+}
+
+namespace test {
+
+template <int TYPE, typename T>
+class TestFlatScanner : public ::testing::Test {
+ public:
+  void InitValues() {
+    random_numbers(num_values_, 0, std::numeric_limits<T>::min(),
+        std::numeric_limits<T>::max(), values_.data());
+  }
+
+  void MakePages(const ColumnDescriptor *d, int num_pages, int levels_per_page) {
+    num_levels_ = levels_per_page * num_pages;
+    num_values_ = 0;
+    uint32_t seed = 0;
+    int16_t zero = 0;
+    int16_t max_def_level = d->max_definition_level();
+    int16_t max_rep_level = d->max_repetition_level();
+    vector<int> values_per_page(num_pages, levels_per_page);
+    // Create definition levels
+    if (max_def_level > 0) {
+      def_levels_.resize(num_levels_);
+      random_numbers(num_levels_, seed, zero, max_def_level, def_levels_.data());
+      for (int p = 0; p < num_pages; p++) {
+        int num_values_per_page = 0;
+        for (int i = 0; i < levels_per_page; i++) {
+          if (def_levels_[i + p * levels_per_page] == max_def_level) {
+            num_values_per_page++;
+            num_values_++;
+          }
+        }
+        values_per_page[p] = num_values_per_page;
+      }
+    } else {
+      num_values_ = num_levels_;
+    }
+    // Create repitition levels
+    if (max_rep_level > 0) {
+      rep_levels_.resize(num_levels_);
+      random_numbers(num_levels_, seed, zero, max_rep_level, rep_levels_.data());
+    }
+    // Create values
+    values_.resize(num_values_);
+    InitValues();
+    //values_.insert(values_.begin(), draws_, draws_ + num_values_);
+    Paginate<TYPE, T>(d, values_, def_levels_, max_def_level,
+        rep_levels_, max_rep_level, levels_per_page, values_per_page, pages_);
+  }
+
+  void InitScanner(const ColumnDescriptor *d) {
+    std::unique_ptr<PageReader> pager(new test::MockPageReader(pages_));
+    scanner_ = Scanner::Make(ColumnReader::Make(d, std::move(pager)));
+  }
+
+  void CheckResults() {
+    TypedScanner<TYPE>* scanner = reinterpret_cast<TypedScanner<TYPE>* >(scanner_.get());
+    T val;
+    bool is_null;
+    size_t j = 0;
+    scanner->SetBatchSize(32);
+    for (size_t i = 0; i < num_levels_; i++) {
+      ASSERT_TRUE(scanner->NextValue(&val, &is_null)) << i <<"NV"<< j;
+      if (!is_null) {
+        ASSERT_EQ(values_[j++], val) << i <<"V"<< j;
+      }
+    }
+    ASSERT_EQ(num_values_, j);
+    ASSERT_FALSE(scanner->HasNext());
+  }
+
+  void Clear() {
+    pages_.clear();
+    values_.clear();
+    def_levels_.clear();
+    rep_levels_.clear();
+  }
+
+  void Execute(int num_pages, int levels_page, const ColumnDescriptor *d) {
+    MakePages(d, num_pages, levels_page);
+    InitScanner(d);
+    CheckResults();
+    Clear();
+  }
+
+  void InitDescriptors(std::shared_ptr<ColumnDescriptor>& d1,
+      std::shared_ptr<ColumnDescriptor>& d2, std::shared_ptr<ColumnDescriptor>& d3) {
+    NodePtr type = schema::PrimitiveNode::Make("c1", Repetition::REQUIRED, static_cast<Type::type>(TYPE));
+    d1.reset(new ColumnDescriptor(type, 0, 0));
+    type = schema::PrimitiveNode::Make("c2", Repetition::OPTIONAL, static_cast<Type::type>(TYPE));
+    d2.reset(new ColumnDescriptor(type, 4, 0));
+    type = schema::PrimitiveNode::Make("c3", Repetition::REPEATED, static_cast<Type::type>(TYPE));
+    d3.reset(new ColumnDescriptor(type, 4, 2));
+  }
+
+  void ExecuteAll(int num_pages, int num_levels) {
+    std::shared_ptr<ColumnDescriptor> d1;
+    std::shared_ptr<ColumnDescriptor> d2;
+    std::shared_ptr<ColumnDescriptor> d3;
+    
+    InitDescriptors(d1, d2, d3);
+    // evaluate REQUIRED pages
+    Execute(num_pages, num_levels, d1.get());
+    // evaluate OPTIONAL pages
+    Execute(num_pages, num_levels, d2.get());
+    // evaluate REPEATED pages
+    Execute(num_pages, num_levels, d3.get());
+  }
+
+ protected:
+  int num_levels_;
+  int num_values_;
+  vector<shared_ptr<Page> > pages_;
+  std::shared_ptr<Scanner> scanner_;
+  vector<T> values_;
+  vector<int16_t> def_levels_;
+  vector<int16_t> rep_levels_;
+  vector<uint8_t> data_buffer_; // For BA and FLBA
+};
+
+template<>
+void TestFlatScanner<Type::INT96, Int96>::InitValues() {
+  random_Int96_numbers(num_values_, 0, std::numeric_limits<int32_t>::min(),
+      std::numeric_limits<int32_t>::max(), values_.data());
+}
+
+template<>
+void TestFlatScanner<Type::BYTE_ARRAY, ByteArray>::InitValues() {
+  int max_byte_array_len = 12;
+  int num_bytes = max_byte_array_len + sizeof(uint32_t);
+  size_t nbytes = num_values_ * num_bytes;
+  data_buffer_.resize(nbytes);
+  random_byte_array(num_values_, 0, data_buffer_.data(), values_.data(),
+      max_byte_array_len);
+}
+
+template<>
+void TestFlatScanner<Type::FIXED_LEN_BYTE_ARRAY, FLBA>::InitValues() {
+  size_t nbytes = num_values_ * FLBA_LENGTH;
+  data_buffer_.resize(nbytes);
+  random_fixed_byte_array(num_values_, 0, data_buffer_.data(), FLBA_LENGTH, values_.data());
+}
+
+template<>
+void TestFlatScanner<Type::FIXED_LEN_BYTE_ARRAY, FLBA>::InitDescriptors(
+    std::shared_ptr<ColumnDescriptor>& d1, std::shared_ptr<ColumnDescriptor>& d2,
+    std::shared_ptr<ColumnDescriptor>& d3) {
+  NodePtr type = schema::PrimitiveNode::MakeFLBA("c1", Repetition::REQUIRED,
+      FLBA_LENGTH, LogicalType::UTF8);
+  d1.reset(new ColumnDescriptor(type, 0, 0));
+  type = schema::PrimitiveNode::MakeFLBA("c2", Repetition::OPTIONAL,
+      FLBA_LENGTH, LogicalType::UTF8);
+  d2.reset(new ColumnDescriptor(type, 4, 0));
+  type = schema::PrimitiveNode::MakeFLBA("c3", Repetition::REPEATED,
+      FLBA_LENGTH, LogicalType::UTF8);
+  d3.reset(new ColumnDescriptor(type, 4, 2));
+}
+
+
+typedef TestFlatScanner<Type::INT32, int32_t> TestFlatInt32Scanner;
+typedef TestFlatScanner<Type::INT64, int64_t> TestFlatInt64Scanner;
+typedef TestFlatScanner<Type::INT96, Int96> TestFlatInt96Scanner;
+typedef TestFlatScanner<Type::BOOLEAN, bool> TestFlatBoolScanner;
+typedef TestFlatScanner<Type::FLOAT, float> TestFlatFloatScanner;
+typedef TestFlatScanner<Type::DOUBLE, double> TestFlatDoubleScanner;
+typedef TestFlatScanner<Type::BYTE_ARRAY, ByteArray> TestFlatByteArrayScanner;
+typedef TestFlatScanner<Type::FIXED_LEN_BYTE_ARRAY, FLBA> TestFlatFLBAScanner;
+
+static int num_levels_per_page = 100;
+static int num_pages = 20;
+
+TEST_F(TestFlatInt32Scanner, TestScanner) {
+  ExecuteAll(num_pages, num_levels_per_page);
+}
+
+TEST_F(TestFlatInt64Scanner, TestScanner) {
+  ExecuteAll(num_pages, num_levels_per_page);
+}
+
+TEST_F(TestFlatInt96Scanner, TestScanner) {
+  ExecuteAll(num_pages, num_levels_per_page);
+}
+
+TEST_F(TestFlatFloatScanner, TestScanner) {
+  ExecuteAll(num_pages, num_levels_per_page);
+}
+
+TEST_F(TestFlatDoubleScanner, TestScanner) {
+  ExecuteAll(num_pages, num_levels_per_page);
+}
+
+TEST_F(TestFlatByteArrayScanner, TestScanner) {
+  ExecuteAll(num_pages, num_levels_per_page);
+}
+
+TEST_F(TestFlatFLBAScanner, TestScanner) {
+  ExecuteAll(num_pages, num_levels_per_page);
+}
+
+} // namespace test
+} // namespace parquet_cpp

--- a/src/parquet/column/scanner.h
+++ b/src/parquet/column/scanner.h
@@ -57,7 +57,7 @@ class Scanner {
   virtual void PrintNext(std::ostream& out, int width) = 0;
 
   bool HasNext() {
-    return value_offset_ < values_buffered_ || reader_->HasNext();
+    return level_offset_ < levels_buffered_ || reader_->HasNext();
   }
 
   const ColumnDescriptor* descr() const {
@@ -122,7 +122,7 @@ class TypedScanner : public Scanner {
 
   // Returns true if there is a next value
   bool NextValue(T* val, bool* is_null) {
-    if (value_offset_ == values_buffered_) {
+    if (level_offset_ == levels_buffered_) {
       if (!HasNext()) {
         // Out of data pages
         return false;

--- a/src/parquet/column/scanner.h
+++ b/src/parquet/column/scanner.h
@@ -116,7 +116,7 @@ class TypedScanner : public Scanner {
     }
     *def_level = descr()->is_optional() ?
       def_levels_[level_offset_] : descr()->max_definition_level();
-    *rep_level = descr()->is_repeated() ? 
+    *rep_level = descr()->is_repeated() ?
       rep_levels_[level_offset_] : descr()->max_repetition_level();
     level_offset_++;
     return true;

--- a/src/parquet/column/test-util.h
+++ b/src/parquet/column/test-util.h
@@ -33,6 +33,7 @@
 // Depended on by SerializedPageReader test utilities for now
 #include "parquet/encodings/plain-encoding.h"
 #include "parquet/util/input.h"
+#include "parquet/util/test-common.h"
 
 namespace parquet_cpp {
 
@@ -96,14 +97,14 @@ class DataPageBuilder {
     have_rep_levels_ = true;
   }
 
-  void AppendValues(const std::vector<T>& values,
+  void AppendValues(const ColumnDescriptor *d, const std::vector<T>& values,
       Encoding::type encoding = Encoding::PLAIN) {
     if (encoding != Encoding::PLAIN) {
       ParquetException::NYI("only plain encoding currently implemented");
     }
     size_t bytes_to_encode = values.size() * sizeof(T);
 
-    PlainEncoder<TYPE> encoder(nullptr);
+    PlainEncoder<TYPE> encoder(d);
     encoder.Encode(&values[0], values.size(), sink_);
 
     num_values_ = std::max(static_cast<int32_t>(values.size()), num_values_);
@@ -165,7 +166,8 @@ class DataPageBuilder {
 };
 
 template <int TYPE, typename T>
-static std::shared_ptr<DataPage> MakeDataPage(const std::vector<T>& values,
+static std::shared_ptr<DataPage> MakeDataPage(const ColumnDescriptor *d,
+    const std::vector<T>& values,
     const std::vector<int16_t>& def_levels, int16_t max_def_level,
     const std::vector<int16_t>& rep_levels, int16_t max_rep_level) {
   size_t num_values = values.size();
@@ -181,7 +183,7 @@ static std::shared_ptr<DataPage> MakeDataPage(const std::vector<T>& values,
     page_builder.AppendDefLevels(def_levels, max_def_level);
   }
 
-  page_builder.AppendValues(values);
+  page_builder.AppendValues(d, values);
 
   auto buffer = page_stream.GetBuffer();
 
@@ -189,6 +191,36 @@ static std::shared_ptr<DataPage> MakeDataPage(const std::vector<T>& values,
       page_builder.encoding(),
       page_builder.def_level_encoding(),
       page_builder.rep_level_encoding());
+}
+
+template <int TYPE, typename T>
+static void RandomPaginate(const ColumnDescriptor *d, const std::vector<T>& values,
+    const std::vector<int16_t>& def_levels, int16_t max_def_level,
+    const std::vector<int16_t>& rep_levels, int16_t max_rep_level,
+    int num_levels_per_page, const std::vector<int>& values_per_page,
+    std::vector<std::shared_ptr<Page> >& pages) {
+  int num_pages = values_per_page.size();
+  int def_level_start = 0;
+  int def_level_end = 0;
+  int rep_level_start = 0;
+  int rep_level_end = 0;
+  int value_start = 0;
+  for (int i = 0; i < num_pages; i++) {
+    if (max_def_level > 0) {
+      def_level_start = i * num_levels_per_page;
+      def_level_end = (i + 1) * num_levels_per_page;
+    }
+    if (max_rep_level > 0) {
+      rep_level_start = i * num_levels_per_page;
+      rep_level_end = (i + 1) * num_levels_per_page;
+    }
+    std::shared_ptr<DataPage> page = MakeDataPage<TYPE>(d,
+        slice(values, value_start, value_start + values_per_page[i]),
+        slice(def_levels, def_level_start, def_level_end), max_def_level,
+        slice(rep_levels, rep_level_start, rep_level_end), max_rep_level);
+    pages.push_back(page);
+    value_start += values_per_page[i];
+  }
 }
 
 } // namespace test

--- a/src/parquet/column/test-util.h
+++ b/src/parquet/column/test-util.h
@@ -194,7 +194,7 @@ static std::shared_ptr<DataPage> MakeDataPage(const ColumnDescriptor *d,
 }
 
 template <int TYPE, typename T>
-static void RandomPaginate(const ColumnDescriptor *d, const std::vector<T>& values,
+static void Paginate(const ColumnDescriptor *d, const std::vector<T>& values,
     const std::vector<int16_t>& def_levels, int16_t max_def_level,
     const std::vector<int16_t>& rep_levels, int16_t max_rep_level,
     int num_levels_per_page, const std::vector<int>& values_per_page,

--- a/src/parquet/column/test-util.h
+++ b/src/parquet/column/test-util.h
@@ -210,7 +210,8 @@ static std::shared_ptr<DataPage> MakeDataPage(const ColumnDescriptor *d,
 }
 
 template <int TYPE, typename T>
-static void Paginate(const ColumnDescriptor *d, const std::vector<T>& values,
+static void Paginate(const ColumnDescriptor *d,
+    const std::vector<T>& values,
     const std::vector<int16_t>& def_levels, int16_t max_def_level,
     const std::vector<int16_t>& rep_levels, int16_t max_rep_level,
     int num_levels_per_page, const std::vector<int>& values_per_page,

--- a/src/parquet/column/test-util.h
+++ b/src/parquet/column/test-util.h
@@ -165,6 +165,22 @@ class DataPageBuilder {
   }
 };
 
+template<>
+void DataPageBuilder<Type::BOOLEAN>::AppendValues(const ColumnDescriptor *d,
+    const std::vector<bool>& values, Encoding::type encoding) {
+  if (encoding != Encoding::PLAIN) {
+    ParquetException::NYI("only plain encoding currently implemented");
+  }
+  size_t bytes_to_encode = values.size() * sizeof(bool);
+
+  PlainEncoder<Type::BOOLEAN> encoder(d);
+  encoder.Encode(values, values.size(), sink_);
+
+  num_values_ = std::max(static_cast<int32_t>(values.size()), num_values_);
+  encoding_ = encoding;
+  have_values_ = true;
+}
+
 template <int TYPE, typename T>
 static std::shared_ptr<DataPage> MakeDataPage(const ColumnDescriptor *d,
     const std::vector<T>& values,

--- a/src/parquet/encodings/plain-encoding-test.cc
+++ b/src/parquet/encodings/plain-encoding-test.cc
@@ -81,7 +81,8 @@ class EncodeDecode{
 
   void generate_data() {
     // seed the prng so failure is deterministic
-    random_numbers(num_values_, 0, draws_);
+    random_numbers(num_values_, 0, std::numeric_limits<T>::min(),
+       std::numeric_limits<T>::max(), draws_);
   }
 
   void encode_decode(ColumnDescriptor *d) {
@@ -127,6 +128,13 @@ template<>
 void EncodeDecode<bool, Type::BOOLEAN>::generate_data() {
   // seed the prng so failure is deterministic
   random_bools(num_values_, 0.5, 0, draws_);
+}
+
+template<>
+void EncodeDecode<Int96, Type::INT96>::generate_data() {
+  // seed the prng so failure is deterministic
+    random_Int96_numbers(num_values_, 0, std::numeric_limits<int32_t>::min(),
+       std::numeric_limits<int32_t>::max(), draws_);
 }
 
 template<>

--- a/src/parquet/encodings/plain-encoding-test.cc
+++ b/src/parquet/encodings/plain-encoding-test.cc
@@ -222,7 +222,7 @@ TEST(BAEncodeDecode, TestEncodeDecode) {
 TEST(FLBAEncodeDecode, TestEncodeDecode) {
   schema::NodePtr node;
   node = schema::PrimitiveNode::MakeFLBA("name", Repetition::OPTIONAL,
-      Type::FIXED_LEN_BYTE_ARRAY, flba_length, LogicalType::UTF8);
+      flba_length, LogicalType::UTF8);
   ColumnDescriptor d(node, 0, 0);
   EncodeDecode<FixedLenByteArray, Type::FIXED_LEN_BYTE_ARRAY> obj;
   obj.execute(num_values, &d);

--- a/src/parquet/encodings/plain-encoding-test.cc
+++ b/src/parquet/encodings/plain-encoding-test.cc
@@ -141,8 +141,9 @@ void EncodeDecode<Int96, Type::INT96>::verify_results() {
 template<>
 void EncodeDecode<ByteArray, Type::BYTE_ARRAY>::generate_data() {
   // seed the prng so failure is deterministic
-  int max_byte_array_len = 12 + sizeof(uint32_t);
-  size_t nbytes = num_values_ * max_byte_array_len;
+  int max_byte_array_len = 12;
+  int num_bytes = max_byte_array_len + sizeof(uint32_t);
+  size_t nbytes = num_values_ * num_bytes;
   data_buffer_.resize(nbytes);
   random_byte_array(num_values_, 0, data_buffer_.data(), draws_,
       max_byte_array_len);
@@ -168,7 +169,7 @@ void EncodeDecode<FLBA, Type::FIXED_LEN_BYTE_ARRAY>::generate_data() {
 
 template<>
 void EncodeDecode<FLBA, Type::FIXED_LEN_BYTE_ARRAY>::verify_results() {
-  for (size_t i = 0; i < 1000; ++i) {
+  for (size_t i = 0; i < num_values_; ++i) {
     ASSERT_EQ(0, memcmp(draws_[i].ptr, decode_buf_[i].ptr, flba_length)) << i;
   }
 }

--- a/src/parquet/reader-test.cc
+++ b/src/parquet/reader-test.cc
@@ -99,6 +99,7 @@ TEST_F(TestAllTypesPlain, TestFlatScannerInt32) {
   ASSERT_FALSE(scanner->NextValue(&val, &is_null));
 }
 
+
 TEST_F(TestAllTypesPlain, TestSetScannerBatchSize) {
   std::shared_ptr<RowGroupReader> group = reader_->RowGroup(0);
 
@@ -109,6 +110,7 @@ TEST_F(TestAllTypesPlain, TestSetScannerBatchSize) {
   scanner->SetBatchSize(1024);
   ASSERT_EQ(1024, scanner->batch_size());
 }
+
 
 TEST_F(TestAllTypesPlain, DebugPrintWorks) {
   std::stringstream ss;

--- a/src/parquet/reader-test.cc
+++ b/src/parquet/reader-test.cc
@@ -99,7 +99,6 @@ TEST_F(TestAllTypesPlain, TestFlatScannerInt32) {
   ASSERT_FALSE(scanner->NextValue(&val, &is_null));
 }
 
-
 TEST_F(TestAllTypesPlain, TestSetScannerBatchSize) {
   std::shared_ptr<RowGroupReader> group = reader_->RowGroup(0);
 
@@ -110,7 +109,6 @@ TEST_F(TestAllTypesPlain, TestSetScannerBatchSize) {
   scanner->SetBatchSize(1024);
   ASSERT_EQ(1024, scanner->batch_size());
 }
-
 
 TEST_F(TestAllTypesPlain, DebugPrintWorks) {
   std::stringstream ss;

--- a/src/parquet/schema/descriptor.h
+++ b/src/parquet/schema/descriptor.h
@@ -58,6 +58,18 @@ class ColumnDescriptor {
     return primitive_node_->name();
   }
 
+  bool is_required() const {
+    return max_definition_level_ == 0;
+  }
+
+  bool is_optional() const {
+    return max_definition_level_ > 0;
+  }
+
+  bool is_repeated() const {
+    return max_repetition_level_ > 0;
+  }
+
   int type_length() const;
 
  private:

--- a/src/parquet/schema/schema-descriptor-test.cc
+++ b/src/parquet/schema/schema-descriptor-test.cc
@@ -51,7 +51,7 @@ TEST(TestColumnDescriptor, TestAttrs) {
 
   // Test FIXED_LEN_BYTE_ARRAY
   node = PrimitiveNode::MakeFLBA("name", Repetition::OPTIONAL,
-      Type::FIXED_LEN_BYTE_ARRAY, 12, LogicalType::UTF8);
+      12, LogicalType::UTF8);
   descr = ColumnDescriptor(node, 4, 1);
 
   ASSERT_EQ(Type::FIXED_LEN_BYTE_ARRAY, descr.physical_type());

--- a/src/parquet/schema/types.h
+++ b/src/parquet/schema/types.h
@@ -183,10 +183,9 @@ class PrimitiveNode : public Node {
 
   // Alternate constructor for FIXED_LEN_BYTE_ARRAY (FLBA)
   static inline NodePtr MakeFLBA(const std::string& name,
-      Repetition::type repetition, Type::type type,
-      int32_t type_length,
+      Repetition::type repetition, int32_t type_length,
       LogicalType::type logical_type = LogicalType::NONE) {
-    NodePtr result = Make(name, repetition, type, logical_type);
+    NodePtr result = Make(name, repetition, Type::FIXED_LEN_BYTE_ARRAY, logical_type);
     static_cast<PrimitiveNode*>(result.get())->SetTypeLength(type_length);
     return result;
   }

--- a/src/parquet/util/test-common.h
+++ b/src/parquet/util/test-common.h
@@ -117,7 +117,7 @@ void random_bools(int n, double p, uint32_t seed, bool* out) {
 template <typename T>
 void random_numbers(int n, uint32_t seed, T min_value, T max_value, T* out) {
   std::mt19937 gen(seed);
-    std::uniform_int_distribution<T> d(min_value, max_value);
+  std::uniform_int_distribution<T> d(min_value, max_value);
   for (int i = 0; i < n; ++i) {
     out[i] = d(gen);
   }

--- a/src/parquet/util/test-common.h
+++ b/src/parquet/util/test-common.h
@@ -183,6 +183,15 @@ void random_byte_array(int n, uint32_t seed, uint8_t *buf,
     buf += out[i].len;
   }
 }
+
+void random_levels(int n, uint32_t seed, int16_t max_level, int16_t* out) {
+  std::mt19937 gen(seed);
+  std::uniform_int_distribution<uint16_t> d(0, max_level);
+  for (int i = 0; i < n; ++i) {
+    out[i] = d(gen);
+  }
+}
+
 } // namespace test
 } // namespace parquet_cpp
 

--- a/src/parquet/util/test-common.h
+++ b/src/parquet/util/test-common.h
@@ -106,16 +106,6 @@ void random_bytes(int n, uint32_t seed, std::vector<uint8_t>* out) {
   }
 }
 
-template <typename T>
-void random_numbers(int n, uint32_t seed, T* out) {
-  std::mt19937 gen(seed);
-    std::uniform_real_distribution<T> d(std::numeric_limits<T>::lowest(),
-        std::numeric_limits<T>::max());
-  for (int i = 0; i < n; ++i) {
-    out[i] = d(gen);
-  }
-}
-
 void random_bools(int n, double p, uint32_t seed, bool* out) {
   std::mt19937 gen(seed);
   std::bernoulli_distribution d(p);
@@ -124,31 +114,38 @@ void random_bools(int n, double p, uint32_t seed, bool* out) {
   }
 }
 
-template <>
-void random_numbers(int n, uint32_t seed, int32_t* out) {
+template <typename T>
+void random_numbers(int n, uint32_t seed, T min_value, T max_value, T* out) {
   std::mt19937 gen(seed);
-  std::uniform_int_distribution<int32_t> d(std::numeric_limits<int32_t>::lowest(),
-      std::numeric_limits<int32_t>::max());
+    std::uniform_int_distribution<T> d(min_value, max_value);
   for (int i = 0; i < n; ++i) {
     out[i] = d(gen);
   }
 }
 
 template <>
-void random_numbers(int n, uint32_t seed, int64_t* out) {
+void random_numbers(int n, uint32_t seed, float min_value, float max_value, float* out) {
   std::mt19937 gen(seed);
-  std::uniform_int_distribution<int64_t> d(std::numeric_limits<int64_t>::lowest(),
-      std::numeric_limits<int64_t>::max());
+  std::uniform_real_distribution<float> d(min_value, max_value);
   for (int i = 0; i < n; ++i) {
     out[i] = d(gen);
   }
 }
 
 template <>
-void random_numbers(int n, uint32_t seed, Int96* out) {
+void random_numbers(int n, uint32_t seed, double min_value, double max_value,
+    double* out) {
   std::mt19937 gen(seed);
-  std::uniform_int_distribution<uint32_t> d(std::numeric_limits<uint32_t>::lowest(),
-      std::numeric_limits<uint32_t>::max());
+  std::uniform_real_distribution<double> d(min_value, max_value);
+  for (int i = 0; i < n; ++i) {
+    out[i] = d(gen);
+  }
+}
+
+void random_Int96_numbers(int n, uint32_t seed, int32_t min_value, int32_t max_value,
+    Int96* out) {
+  std::mt19937 gen(seed);
+  std::uniform_int_distribution<int32_t> d(min_value, max_value);
   for (int i = 0; i < n; ++i) {
     out[i].value[0] = d(gen);
     out[i].value[1] = d(gen);
@@ -181,14 +178,6 @@ void random_byte_array(int n, uint32_t seed, uint8_t *buf,
       buf[j] = d2(gen) & 0xFF;
     }
     buf += out[i].len;
-  }
-}
-
-void random_levels(int n, uint32_t seed, int16_t max_level, int16_t* out) {
-  std::mt19937 gen(seed);
-  std::uniform_int_distribution<uint16_t> d(0, max_level);
-  for (int i = 0; i < n; ++i) {
-    out[i] = d(gen);
   }
 }
 


### PR DESCRIPTION
closes #43 and closes #50
This PR also implements
1) PARQUET-532: Null values detection needs to be fixed and tested
2) PARQUET-502: Scanner segfaults when its batch size is smaller than the number of rows
3) PARQUET-526: Add more complete unit test coverage for column Scanner implementations
4) PARQUET-531: Can't read past first page in a column