### PR TITLE
PARQUET-520: Add MemoryMapSource and add unit tests for both it and LocalFileSource

### DIFF
--- a/example/parquet_reader.cc
+++ b/example/parquet_reader.cc
@@ -24,26 +24,30 @@ using namespace parquet_cpp;
 
 int main(int argc, char** argv) {
   if (argc > 3) {
-    std::cerr << "Usage: parquet_reader [--only-stats] <file>"
+    std::cerr << "Usage: parquet_reader [--only-stats] [--no-memory-map] <file>"
               << std::endl;
     return -1;
   }
 
   std::string filename;
   bool print_values = true;
+  bool memory_map = true;
 
   // Read command-line options
   char *param, *value;
   for (int i = 1; i < argc; i++) {
-    if ( (param = std::strstr(argv[i], "--only-stats")) ) {
+    if ((param = std::strstr(argv[i], "--only-stats"))) {
       print_values = false;
+    } else if ((param = std::strstr(argv[i], "--no-memory-map"))) {
+      memory_map = false;
     } else {
       filename = argv[i];
     }
   }
 
   try {
-    std::unique_ptr<ParquetFileReader> reader = ParquetFileReader::OpenFile(filename);
+    std::unique_ptr<ParquetFileReader> reader = ParquetFileReader::OpenFile(filename,
+        memory_map);
     reader->DebugPrint(std::cout, print_values);
   } catch (const std::exception& e) {
     std::cerr << "Parquet error: "

--- a/src/parquet/file/reader.cc
+++ b/src/parquet/file/reader.cc
@@ -68,7 +68,7 @@ ParquetFileReader::ParquetFileReader() : schema_(nullptr) {}
 ParquetFileReader::~ParquetFileReader() {}
 
 std::unique_ptr<ParquetFileReader> ParquetFileReader::OpenFile(const std::string& path) {
-  std::unique_ptr<LocalFileSource> file(new LocalFileSource());
+  std::unique_ptr<MemoryMapSource> file(new MemoryMapSource());
   file->Open(path);
 
   auto contents = SerializedFile::Open(std::move(file));

--- a/src/parquet/file/reader.cc
+++ b/src/parquet/file/reader.cc
@@ -67,8 +67,14 @@ RowGroupStatistics RowGroupReader::GetColumnStats(int i) const {
 ParquetFileReader::ParquetFileReader() : schema_(nullptr) {}
 ParquetFileReader::~ParquetFileReader() {}
 
-std::unique_ptr<ParquetFileReader> ParquetFileReader::OpenFile(const std::string& path) {
-  std::unique_ptr<MemoryMapSource> file(new MemoryMapSource());
+std::unique_ptr<ParquetFileReader> ParquetFileReader::OpenFile(const std::string& path,
+    bool memory_map) {
+  std::unique_ptr<LocalFileSource> file;
+  if (memory_map) {
+    file.reset(new MemoryMapSource());
+  } else {
+    file.reset(new LocalFileSource());
+  }
   file->Open(path);
 
   auto contents = SerializedFile::Open(std::move(file));

--- a/src/parquet/file/reader.h
+++ b/src/parquet/file/reader.h
@@ -89,7 +89,8 @@ class ParquetFileReader {
   ~ParquetFileReader();
 
   // API Convenience to open a serialized Parquet file on disk
-  static std::unique_ptr<ParquetFileReader> OpenFile(const std::string& path);
+  static std::unique_ptr<ParquetFileReader> OpenFile(const std::string& path,
+      bool memory_map = true);
 
   void Open(std::unique_ptr<Contents> contents);
   void Close();

--- a/src/parquet/util/CMakeLists.txt
+++ b/src/parquet/util/CMakeLists.txt
@@ -63,6 +63,6 @@ endif()
 
 ADD_PARQUET_TEST(bit-util-test)
 ADD_PARQUET_TEST(buffer-test)
+ADD_PARQUET_TEST(input-output-test)
 ADD_PARQUET_TEST(mem-pool-test)
-ADD_PARQUET_TEST(output-test)
 ADD_PARQUET_TEST(rle-test)

--- a/src/parquet/util/input.h
+++ b/src/parquet/util/input.h
@@ -58,7 +58,7 @@ class LocalFileSource : public RandomAccessSource {
   LocalFileSource() : file_(nullptr), is_open_(false) {}
   virtual ~LocalFileSource();
 
-  void Open(const std::string& path);
+  virtual void Open(const std::string& path);
 
   virtual void Close();
   virtual int64_t Size() const;
@@ -95,7 +95,7 @@ class MemoryMapSource : public LocalFileSource {
   virtual ~MemoryMapSource();
 
   virtual void Close();
-  void Open(const std::string& path);
+  virtual void Open(const std::string& path);
 
   virtual int64_t Tell() const;
   virtual void Seek(int64_t pos);

--- a/src/parquet/util/input.h
+++ b/src/parquet/util/input.h
@@ -73,12 +73,41 @@ class LocalFileSource : public RandomAccessSource {
   bool is_open() const { return is_open_;}
   const std::string& path() const { return path_;}
 
- private:
+ protected:
   void CloseFile();
 
   std::string path_;
   FILE* file_;
   bool is_open_;
+};
+
+class MemoryMapSource : public LocalFileSource {
+ public:
+  MemoryMapSource() :
+      LocalFileSource(),
+      data_(nullptr),
+      pos_(0) {}
+
+  virtual ~MemoryMapSource();
+
+  virtual void Close();
+  void Open(const std::string& path);
+
+  virtual int64_t Tell() const;
+  virtual void Seek(int64_t pos);
+
+  // Copy data from memory map into out (must be already allocated memory)
+  // @returns: actual number of bytes read
+  virtual int64_t Read(int64_t nbytes, uint8_t* out);
+
+  // Return a buffer referencing memory-map (no copy)
+  virtual std::shared_ptr<Buffer> Read(int64_t nbytes);
+
+ private:
+  void CloseFile();
+
+  uint8_t* data_;
+  int64_t pos_;
 };
 
 // ----------------------------------------------------------------------

--- a/src/parquet/util/input.h
+++ b/src/parquet/util/input.h
@@ -18,8 +18,8 @@
 #ifndef PARQUET_UTIL_INPUT_H
 #define PARQUET_UTIL_INPUT_H
 
-#include <stdio.h>
 #include <cstdint>
+#include <cstdio>
 #include <memory>
 #include <string>
 #include <vector>
@@ -73,8 +73,12 @@ class LocalFileSource : public RandomAccessSource {
   bool is_open() const { return is_open_;}
   const std::string& path() const { return path_;}
 
+  // Return the integer file descriptor
+  int file_descriptor() const;
+
  protected:
   void CloseFile();
+  void SeekFile(int64_t pos, int origin = SEEK_SET);
 
   std::string path_;
   FILE* file_;


### PR DESCRIPTION
I also added the `file_descriptor` API so that we can verify that dtors elsewhere successfully close open files. Closes #56 