### PR TITLE
PARQUET-542: Support custom memory allocators

### DIFF
--- a/src/parquet/api/io.h
+++ b/src/parquet/api/io.h
@@ -21,6 +21,7 @@
 #include "parquet/exception.h"
 #include "parquet/util/buffer.h"
 #include "parquet/util/input.h"
+#include "parquet/util/mem-allocator.h"
 #include "parquet/util/output.h"
 
 #endif // PARQUET_API_IO_H

--- a/src/parquet/column/reader.h
+++ b/src/parquet/column/reader.h
@@ -30,15 +30,17 @@
 #include "parquet/exception.h"
 #include "parquet/schema/descriptor.h"
 #include "parquet/types.h"
+#include "parquet/util/mem-allocator.h"
 
 namespace parquet_cpp {
 
 class ColumnReader {
  public:
-  ColumnReader(const ColumnDescriptor*, std::unique_ptr<PageReader>);
+  ColumnReader(const ColumnDescriptor*, std::unique_ptr<PageReader>,
+      MemoryAllocator* allocator = default_allocator());
 
   static std::shared_ptr<ColumnReader> Make(const ColumnDescriptor*,
-      std::unique_ptr<PageReader>);
+      std::unique_ptr<PageReader>, MemoryAllocator* allocator = default_allocator());
 
   // Returns true if there are still values in this column.
   bool HasNext() {
@@ -95,6 +97,8 @@ class ColumnReader {
   // The number of values from the current data page that have been decoded
   // into memory
   int num_decoded_values_;
+
+  MemoryAllocator* allocator_;
 };
 
 // API to read values from a single column. This is the main client facing API.
@@ -104,8 +108,8 @@ class TypedColumnReader : public ColumnReader {
   typedef typename type_traits<TYPE>::value_type T;
 
   TypedColumnReader(const ColumnDescriptor* schema,
-      std::unique_ptr<PageReader> pager) :
-      ColumnReader(schema, std::move(pager)),
+      std::unique_ptr<PageReader> pager, MemoryAllocator* allocator) :
+      ColumnReader(schema, std::move(pager), allocator),
       current_decoder_(NULL) {
   }
 

--- a/src/parquet/column/scanner.cc
+++ b/src/parquet/column/scanner.cc
@@ -25,24 +25,25 @@
 namespace parquet_cpp {
 
 std::shared_ptr<Scanner> Scanner::Make(std::shared_ptr<ColumnReader> col_reader,
-    int64_t batch_size) {
+    int64_t batch_size, MemoryAllocator* allocator) {
   switch (col_reader->type()) {
     case Type::BOOLEAN:
-      return std::make_shared<BoolScanner>(col_reader, batch_size);
+      return std::make_shared<BoolScanner>(col_reader, batch_size, allocator);
     case Type::INT32:
-      return std::make_shared<Int32Scanner>(col_reader, batch_size);
+      return std::make_shared<Int32Scanner>(col_reader, batch_size, allocator);
     case Type::INT64:
-      return std::make_shared<Int64Scanner>(col_reader, batch_size);
+      return std::make_shared<Int64Scanner>(col_reader, batch_size, allocator);
     case Type::INT96:
-      return std::make_shared<Int96Scanner>(col_reader, batch_size);
+      return std::make_shared<Int96Scanner>(col_reader, batch_size, allocator);
     case Type::FLOAT:
-      return std::make_shared<FloatScanner>(col_reader, batch_size);
+      return std::make_shared<FloatScanner>(col_reader, batch_size, allocator);
     case Type::DOUBLE:
-      return std::make_shared<DoubleScanner>(col_reader, batch_size);
+      return std::make_shared<DoubleScanner>(col_reader, batch_size, allocator);
     case Type::BYTE_ARRAY:
-      return std::make_shared<ByteArrayScanner>(col_reader, batch_size);
+      return std::make_shared<ByteArrayScanner>(col_reader, batch_size, allocator);
     case Type::FIXED_LEN_BYTE_ARRAY:
-      return std::make_shared<FixedLenByteArrayScanner>(col_reader, batch_size);
+      return std::make_shared<FixedLenByteArrayScanner>(col_reader,
+          batch_size, allocator);
     default:
       ParquetException::NYI("type reader not implemented");
   }

--- a/src/parquet/encodings/decoder.h
+++ b/src/parquet/encodings/decoder.h
@@ -22,6 +22,7 @@
 
 #include "parquet/exception.h"
 #include "parquet/types.h"
+#include "parquet/util/mem-allocator.h"
 
 namespace parquet_cpp {
 
@@ -54,8 +55,7 @@ class Decoder {
   const Encoding::type encoding() const { return encoding_; }
 
  protected:
-  explicit Decoder(const ColumnDescriptor* descr,
-      const Encoding::type& encoding)
+  explicit Decoder(const ColumnDescriptor* descr, const Encoding::type& encoding)
       : descr_(descr), encoding_(encoding), num_values_(0) {}
 
   // For accessing type-specific metadata, like FIXED_LEN_BYTE_ARRAY

--- a/src/parquet/encodings/delta-byte-array-encoding.h
+++ b/src/parquet/encodings/delta-byte-array-encoding.h
@@ -28,10 +28,11 @@ namespace parquet_cpp {
 
 class DeltaByteArrayDecoder : public Decoder<Type::BYTE_ARRAY> {
  public:
-  explicit DeltaByteArrayDecoder(const ColumnDescriptor* descr)
+  explicit DeltaByteArrayDecoder(const ColumnDescriptor* descr,
+      MemoryAllocator* allocator = default_allocator())
       : Decoder<Type::BYTE_ARRAY>(descr, Encoding::DELTA_BYTE_ARRAY),
-      prefix_len_decoder_(nullptr),
-      suffix_decoder_(nullptr) {
+      prefix_len_decoder_(nullptr, allocator),
+      suffix_decoder_(nullptr, allocator) {
   }
 
   virtual void SetData(int num_values, const uint8_t* data, int len) {

--- a/src/parquet/encodings/delta-length-byte-array-encoding.h
+++ b/src/parquet/encodings/delta-length-byte-array-encoding.h
@@ -29,10 +29,10 @@ namespace parquet_cpp {
 
 class DeltaLengthByteArrayDecoder : public Decoder<Type::BYTE_ARRAY> {
  public:
-  explicit DeltaLengthByteArrayDecoder(const ColumnDescriptor* descr)
-      : Decoder<Type::BYTE_ARRAY>(descr,
-          Encoding::DELTA_LENGTH_BYTE_ARRAY),
-      len_decoder_(nullptr) {
+  explicit DeltaLengthByteArrayDecoder(const ColumnDescriptor* descr,
+      MemoryAllocator* allocator = default_allocator()) :
+      Decoder<Type::BYTE_ARRAY>(descr, Encoding::DELTA_LENGTH_BYTE_ARRAY),
+      len_decoder_(nullptr, allocator) {
   }
 
   virtual void SetData(int num_values, const uint8_t* data, int len) {

--- a/src/parquet/encodings/dictionary-encoding.h
+++ b/src/parquet/encodings/dictionary-encoding.h
@@ -27,8 +27,10 @@
 #include "parquet/encodings/decoder.h"
 #include "parquet/encodings/encoder.h"
 #include "parquet/encodings/plain-encoding.h"
+#include "parquet/util/buffer.h"
 #include "parquet/util/cpu-info.h"
 #include "parquet/util/hash-util.h"
+#include "parquet/util/mem-allocator.h"
 #include "parquet/util/mem-pool.h"
 #include "parquet/util/rle-encoding.h"
 
@@ -42,9 +44,10 @@ class DictionaryDecoder : public Decoder<TYPE> {
   // Initializes the dictionary with values from 'dictionary'. The data in
   // dictionary is not guaranteed to persist in memory after this call so the
   // dictionary decoder needs to copy the data out if necessary.
-  explicit DictionaryDecoder(const ColumnDescriptor* descr)
-      : Decoder<TYPE>(descr, Encoding::RLE_DICTIONARY) {
-  }
+  explicit DictionaryDecoder(const ColumnDescriptor* descr,
+      MemoryAllocator* allocator = default_allocator()):
+      Decoder<TYPE>(descr, Encoding::RLE_DICTIONARY), dictionary_(0, allocator),
+      byte_array_data_(0, allocator) {}
 
   // Perform type-specific initiatialization
   void SetDict(Decoder<TYPE>* dictionary);
@@ -77,11 +80,11 @@ class DictionaryDecoder : public Decoder<TYPE> {
   }
 
   // Only one is set.
-  std::vector<T> dictionary_;
+  Vector<T> dictionary_;
 
   // Data that contains the byte array data (byte_array_dictionary_ just has the
   // pointers).
-  std::vector<uint8_t> byte_array_data_;
+  OwnedMutableBuffer byte_array_data_;
 
   RleDecoder idx_decoder_;
 };
@@ -89,7 +92,7 @@ class DictionaryDecoder : public Decoder<TYPE> {
 template <int TYPE>
 inline void DictionaryDecoder<TYPE>::SetDict(Decoder<TYPE>* dictionary) {
   int num_dictionary_values = dictionary->values_left();
-  dictionary_.resize(num_dictionary_values);
+  dictionary_.Resize(num_dictionary_values);
   dictionary->Decode(&dictionary_[0], num_dictionary_values);
 }
 
@@ -103,14 +106,14 @@ template <>
 inline void DictionaryDecoder<Type::BYTE_ARRAY>::SetDict(
     Decoder<Type::BYTE_ARRAY>* dictionary) {
   int num_dictionary_values = dictionary->values_left();
-  dictionary_.resize(num_dictionary_values);
+  dictionary_.Resize(num_dictionary_values);
   dictionary->Decode(&dictionary_[0], num_dictionary_values);
 
   int total_size = 0;
   for (int i = 0; i < num_dictionary_values; ++i) {
     total_size += dictionary_[i].len;
   }
-  byte_array_data_.resize(total_size);
+  byte_array_data_.Resize(total_size);
   int offset = 0;
   for (int i = 0; i < num_dictionary_values; ++i) {
     memcpy(&byte_array_data_[offset], dictionary_[i].ptr, dictionary_[i].len);
@@ -123,13 +126,13 @@ template <>
 inline void DictionaryDecoder<Type::FIXED_LEN_BYTE_ARRAY>::SetDict(
     Decoder<Type::FIXED_LEN_BYTE_ARRAY>* dictionary) {
   int num_dictionary_values = dictionary->values_left();
-  dictionary_.resize(num_dictionary_values);
+  dictionary_.Resize(num_dictionary_values);
   dictionary->Decode(&dictionary_[0], num_dictionary_values);
 
   int fixed_len = descr_->type_length();
   int total_size = num_dictionary_values*fixed_len;
 
-  byte_array_data_.resize(total_size);
+  byte_array_data_.Resize(total_size);
   int offset = 0;
   for (int i = 0; i < num_dictionary_values; ++i) {
     memcpy(&byte_array_data_[offset], dictionary_[i].ptr, fixed_len);
@@ -198,12 +201,14 @@ class DictEncoderBase {
   int dict_encoded_size() { return dict_encoded_size_; }
 
  protected:
-  explicit DictEncoderBase(MemPool* pool) :
+  explicit DictEncoderBase(MemPool* pool, MemoryAllocator* allocator) :
       hash_table_size_(INITIAL_HASH_TABLE_SIZE),
       mod_bitmask_(hash_table_size_ - 1),
-      hash_slots_(hash_table_size_, HASH_SLOT_EMPTY),
+      hash_slots_(0, allocator),
+      allocator_(allocator),
       pool_(pool),
       dict_encoded_size_(0) {
+    hash_slots_.Assign(hash_table_size_, HASH_SLOT_EMPTY);
     if (!CpuInfo::initialized()) {
       CpuInfo::Init();
     }
@@ -219,7 +224,8 @@ class DictEncoderBase {
   // We use a fixed-size hash table with linear probing
   //
   // These values correspond to the uniques_ array
-  std::vector<hash_slot_t> hash_slots_;
+  Vector<hash_slot_t> hash_slots_;
+  MemoryAllocator* allocator_;
 
   // For ByteArray / FixedLenByteArray data. Not owned
   MemPool* pool_;
@@ -234,9 +240,9 @@ class DictEncoderBase {
 template <typename T>
 class DictEncoder : public DictEncoderBase {
  public:
-  explicit DictEncoder(MemPool* pool = nullptr, int type_length = -1) :
-      DictEncoderBase(pool),
-      type_length_(type_length) { }
+  explicit DictEncoder(MemPool* pool = nullptr,
+      MemoryAllocator* allocator = default_allocator(), int type_length = -1) :
+      DictEncoderBase(pool, allocator), type_length_(type_length) {}
 
   // TODO(wesm): think about how to address the construction semantics in
   // encodings/dictionary-encoding.h
@@ -331,7 +337,8 @@ inline void DictEncoder<T>::Put(const T& v) {
 template <typename T>
 inline void DictEncoder<T>::DoubleTableSize() {
   int new_size = hash_table_size_ * 2;
-  std::vector<hash_slot_t> new_hash_slots(new_size, HASH_SLOT_EMPTY);
+  Vector<hash_slot_t> new_hash_slots(0, allocator_);
+  new_hash_slots.Assign(new_size, HASH_SLOT_EMPTY);
   hash_slot_t index, slot;
   int j;
   for (int i = 0; i < hash_table_size_; ++i) {
@@ -360,7 +367,12 @@ inline void DictEncoder<T>::DoubleTableSize() {
 
   hash_table_size_ = new_size;
   mod_bitmask_ = new_size - 1;
-  new_hash_slots.swap(hash_slots_);
+
+  hash_slots_.Clear();
+  hash_slots_.Reserve(hash_table_size_);
+  for (int i = 0; i < hash_table_size_; i++) {
+    hash_slots_[i] = new_hash_slots[i];
+  }
 }
 
 template<typename T>
@@ -376,7 +388,6 @@ inline void DictEncoder<ByteArray>::AddDictKey(const ByteArray& v) {
     throw ParquetException("out of memory");
   }
   memcpy(heap, v.ptr, v.len);
-
   uniques_.push_back(ByteArray(v.len, heap));
   dict_encoded_size_ += v.len + sizeof(uint32_t);
 }

--- a/src/parquet/encodings/dictionary-encoding.h
+++ b/src/parquet/encodings/dictionary-encoding.h
@@ -368,11 +368,7 @@ inline void DictEncoder<T>::DoubleTableSize() {
   hash_table_size_ = new_size;
   mod_bitmask_ = new_size - 1;
 
-  hash_slots_.Clear();
-  hash_slots_.Reserve(hash_table_size_);
-  for (int i = 0; i < hash_table_size_; i++) {
-    hash_slots_[i] = new_hash_slots[i];
-  }
+  hash_slots_.Swap(new_hash_slots);
 }
 
 template<typename T>

--- a/src/parquet/encodings/encoder.h
+++ b/src/parquet/encodings/encoder.h
@@ -43,12 +43,13 @@ class Encoder {
 
  protected:
   explicit Encoder(const ColumnDescriptor* descr,
-      const Encoding::type& encoding)
-      : descr_(descr), encoding_(encoding) {}
+      const Encoding::type& encoding, MemoryAllocator* allocator)
+      : descr_(descr), encoding_(encoding), allocator_(allocator) {}
 
   // For accessing type-specific metadata, like FIXED_LEN_BYTE_ARRAY
   const ColumnDescriptor* descr_;
   const Encoding::type encoding_;
+  MemoryAllocator* allocator_;
 };
 
 } // namespace parquet_cpp

--- a/src/parquet/encodings/encoding-test.cc
+++ b/src/parquet/encodings/encoding-test.cc
@@ -151,6 +151,7 @@ class TestEncodingBase : public ::testing::Test {
     if (descr_) {
       type_length_ = descr_->type_length();
     }
+    allocator_ = default_allocator();
   }
 
   void TearDown() {
@@ -182,6 +183,7 @@ class TestEncodingBase : public ::testing::Test {
 
  protected:
   MemPool pool_;
+  MemoryAllocator* allocator_;
 
   int num_values_;
   int type_length_;
@@ -199,6 +201,7 @@ class TestEncodingBase : public ::testing::Test {
 // out an alternative to this class layering at some point
 #define USING_BASE_MEMBERS()                    \
   using TestEncodingBase<Type>::pool_;          \
+  using TestEncodingBase<Type>::allocator_;     \
   using TestEncodingBase<Type>::descr_;         \
   using TestEncodingBase<Type>::num_values_;    \
   using TestEncodingBase<Type>::draws_;         \
@@ -252,7 +255,7 @@ class TestDictionaryEncoding : public TestEncodingBase<Type> {
   static constexpr int TYPE = Type::type_num;
 
   void CheckRoundtrip() {
-    DictEncoder<T> encoder(&pool_, type_length_);
+    DictEncoder<T> encoder(&pool_, allocator_, type_length_);
 
     dict_buffer_ = std::make_shared<OwnedMutableBuffer>();
     auto indices = std::make_shared<OwnedMutableBuffer>();

--- a/src/parquet/file/file-deserialize-test.cc
+++ b/src/parquet/file/file-deserialize-test.cc
@@ -87,7 +87,7 @@ class TestPageSerde : public ::testing::Test {
   }
 
   void ResetStream() {
-    out_stream_.reset(new InMemoryOutputStream());
+    out_stream_.reset(new InMemoryOutputStream);
   }
 
   void EndStream() {
@@ -244,7 +244,8 @@ class TestParquetFileReader : public ::testing::Test {
     std::unique_ptr<BufferReader> reader(new BufferReader(buffer));
     reader_.reset(new ParquetFileReader());
 
-    ASSERT_THROW(reader_->Open(SerializedFile::Open(std::move(reader))),
+    ASSERT_THROW(
+        reader_->Open(SerializedFile::Open(std::move(reader))),
         ParquetException);
   }
 

--- a/src/parquet/file/reader.h
+++ b/src/parquet/file/reader.h
@@ -48,7 +48,8 @@ class RowGroupReader {
     virtual std::unique_ptr<PageReader> GetColumnPageReader(int i) = 0;
   };
 
-  RowGroupReader(const SchemaDescriptor* schema, std::unique_ptr<Contents> contents);
+  RowGroupReader(const SchemaDescriptor* schema,
+      std::unique_ptr<Contents> contents, MemoryAllocator* allocator);
 
   // Construct a ColumnReader for the indicated row group-relative
   // column. Ownership is shared with the RowGroupReader.
@@ -66,6 +67,8 @@ class RowGroupReader {
   // This is declared in the .cc file so that we can hide compiled Thrift
   // headers from the public API and also more easily create test fixtures.
   std::unique_ptr<Contents> contents_;
+
+  MemoryAllocator* allocator_;
 };
 
 
@@ -95,7 +98,7 @@ class ParquetFileReader {
 
   // API Convenience to open a serialized Parquet file on disk
   static std::unique_ptr<ParquetFileReader> OpenFile(const std::string& path,
-      bool memory_map = true);
+      bool memory_map = true, MemoryAllocator* allocator = default_allocator());
 
   void Open(std::unique_ptr<Contents> contents);
   void Close();

--- a/src/parquet/reader-test.cc
+++ b/src/parquet/reader-test.cc
@@ -28,6 +28,7 @@
 #include "parquet/column/reader.h"
 #include "parquet/column/scanner.h"
 #include "parquet/util/input.h"
+#include "parquet/util/mem-allocator.h"
 
 using std::string;
 
@@ -93,7 +94,8 @@ TEST_F(TestAllTypesPlain, TestFlatScannerInt32) {
   std::shared_ptr<RowGroupReader> group = reader_->RowGroup(0);
 
   // column 0, id
-  std::shared_ptr<Int32Scanner> scanner(new Int32Scanner(group->Column(0)));
+  std::shared_ptr<Int32Scanner> scanner(
+      new Int32Scanner(group->Column(0)));
   int32_t val;
   bool is_null;
   for (int i = 0; i < 8; ++i) {
@@ -110,7 +112,8 @@ TEST_F(TestAllTypesPlain, TestSetScannerBatchSize) {
   std::shared_ptr<RowGroupReader> group = reader_->RowGroup(0);
 
   // column 0, id
-  std::shared_ptr<Int32Scanner> scanner(new Int32Scanner(group->Column(0)));
+  std::shared_ptr<Int32Scanner> scanner(
+      new Int32Scanner(group->Column(0)));
 
   ASSERT_EQ(128, scanner->batch_size());
   scanner->SetBatchSize(1024);

--- a/src/parquet/util/CMakeLists.txt
+++ b/src/parquet/util/CMakeLists.txt
@@ -28,6 +28,7 @@ install(FILES
   input.h
   logging.h
   macros.h
+  mem-allocator.h
   mem-pool.h
   output.h
   rle-encoding.h
@@ -39,6 +40,7 @@ add_library(parquet_util STATIC
   buffer.cc
   cpu-info.cc
   input.cc
+  mem-allocator.cc
   mem-pool.cc
   output.cc
 )
@@ -64,5 +66,6 @@ endif()
 ADD_PARQUET_TEST(bit-util-test)
 ADD_PARQUET_TEST(buffer-test)
 ADD_PARQUET_TEST(input-output-test)
+ADD_PARQUET_TEST(mem-allocator-test)
 ADD_PARQUET_TEST(mem-pool-test)
 ADD_PARQUET_TEST(rle-test)

--- a/src/parquet/util/buffer-test.cc
+++ b/src/parquet/util/buffer-test.cc
@@ -48,8 +48,6 @@ TEST_F(TestBuffer, Resize) {
 }
 
 TEST_F(TestBuffer, ResizeOOM) {
-  // realloc fails, even though there may be no explicit limit
-
   // Tests that deliberately throw Exceptions foul up valgrind and report
   // red herring memory leaks
 #ifndef PARQUET_VALGRIND

--- a/src/parquet/util/buffer.cc
+++ b/src/parquet/util/buffer.cc
@@ -20,6 +20,7 @@
 #include <cstdint>
 
 #include "parquet/exception.h"
+#include "parquet/types.h"
 
 namespace parquet_cpp {
 
@@ -34,18 +35,86 @@ std::shared_ptr<Buffer> MutableBuffer::GetImmutableView() {
   return std::make_shared<Buffer>(this->get_shared_ptr(), 0, size());
 }
 
-OwnedMutableBuffer::OwnedMutableBuffer() :
-    ResizableBuffer(nullptr, 0) {}
+OwnedMutableBuffer::OwnedMutableBuffer(int64_t size, MemoryAllocator* allocator) :
+    ResizableBuffer(nullptr, 0), allocator_(allocator) {
+  Resize(size);
+}
+
+OwnedMutableBuffer::~OwnedMutableBuffer() {
+  if (mutable_data_) {
+    allocator_->Free(mutable_data_);
+  }
+}
+
+void OwnedMutableBuffer::Reserve(int64_t new_capacity) {
+  if (!mutable_data_ || new_capacity > capacity_) {
+    if (mutable_data_) {
+      uint8_t* new_data = allocator_->Malloc(new_capacity);
+      memcpy(new_data, mutable_data_, size_);
+      allocator_->Free(mutable_data_);
+      mutable_data_ = new_data;
+    } else {
+      mutable_data_ = allocator_->Malloc(new_capacity);
+    }
+    data_ = mutable_data_;
+    capacity_ = new_capacity;
+  }
+}
 
 void OwnedMutableBuffer::Resize(int64_t new_size) {
-  try {
-    buffer_owner_.resize(new_size);
-  } catch (const std::bad_alloc& e) {
-    throw ParquetException("OOM: resize failed");
-  }
+  Reserve(new_size);
   size_ = new_size;
-  data_ = buffer_owner_.data();
-  mutable_data_ = buffer_owner_.data();
 }
+
+uint8_t& OwnedMutableBuffer::operator[](int64_t i) {
+  return mutable_data_[i];
+}
+
+template <class T>
+Vector<T>::Vector(int64_t size, MemoryAllocator* allocator) :
+    buffer_(size * sizeof(T), allocator), size_(size), capacity_(size) {
+  if (size > 0) {
+    data_ = reinterpret_cast<T*>(buffer_.mutable_data());
+  } else {
+    data_ = nullptr;
+  }
+}
+
+template <class T>
+void Vector<T>::Reserve(int64_t new_capacity) {
+  if (new_capacity > capacity_) {
+    buffer_.Resize(new_capacity * sizeof(T));
+    data_ = reinterpret_cast<T*>(buffer_.mutable_data());
+    capacity_ = new_capacity;
+  }
+}
+
+template <class T>
+void Vector<T>::Resize(int64_t new_size) {
+  Reserve(new_size);
+  size_ = new_size;
+}
+
+template <class T>
+void Vector<T>::Clear() {
+  Resize(0);
+}
+
+template <class T>
+void Vector<T>::Assign(int64_t size, const T val) {
+  Resize(size);
+  for (int64_t i = 0; i < size_; i++) {
+    data_[i] = val;
+  }
+}
+
+template class Vector<int32_t>;
+template class Vector<int64_t>;
+template class Vector<bool>;
+template class Vector<float>;
+template class Vector<double>;
+template class Vector<Int96>;
+template class Vector<ByteArray>;
+template class Vector<FixedLenByteArray>;
 
 } // namespace parquet_cpp

--- a/src/parquet/util/buffer.h
+++ b/src/parquet/util/buffer.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "parquet/util/macros.h"
+#include "parquet/util/mem-allocator.h"
 
 namespace parquet_cpp {
 
@@ -119,7 +120,8 @@ class ResizableBuffer : public MutableBuffer {
 
  protected:
   ResizableBuffer(uint8_t* data, int64_t size) :
-      MutableBuffer(data, size) {}
+      MutableBuffer(data, size), capacity_(size) {}
+  int64_t capacity_;
 };
 
 // A ResizableBuffer whose memory is owned by the class instance. For example,
@@ -127,12 +129,41 @@ class ResizableBuffer : public MutableBuffer {
 // garbage-collected
 class OwnedMutableBuffer : public ResizableBuffer {
  public:
-  OwnedMutableBuffer();
-  virtual void Resize(int64_t new_size);
+  explicit OwnedMutableBuffer(int64_t size = 0,
+      MemoryAllocator* allocator = default_allocator());
+  virtual ~OwnedMutableBuffer();
+  void Resize(int64_t new_size) override;
+  void Reserve(int64_t new_capacity);
+  uint8_t& operator[](int64_t i);
 
  private:
   // TODO: aligned allocations
-  std::vector<uint8_t> buffer_owner_;
+  MemoryAllocator* allocator_;
+
+  OwnedMutableBuffer(OwnedMutableBuffer& buffer) = delete;
+  OwnedMutableBuffer& operator=(OwnedMutableBuffer& buffer) = delete;
+};
+
+template <class T>
+class Vector {
+ public:
+  explicit Vector(int64_t size, MemoryAllocator* allocator);
+  void Resize(int64_t new_size);
+  void Reserve(int64_t new_capacity);
+  void Clear();
+  void Assign(int64_t size, const T val);
+  inline T& operator[](int64_t i) {
+    return data_[i];
+  }
+
+ private:
+  OwnedMutableBuffer buffer_;
+  int64_t size_;
+  int64_t capacity_;
+  T* data_;
+
+  Vector(Vector& buffer) = delete;
+  Vector& operator=(Vector& buffer) = delete;
 };
 
 } // namespace parquet_cpp

--- a/src/parquet/util/buffer.h
+++ b/src/parquet/util/buffer.h
@@ -140,8 +140,7 @@ class OwnedMutableBuffer : public ResizableBuffer {
   // TODO: aligned allocations
   MemoryAllocator* allocator_;
 
-  OwnedMutableBuffer(OwnedMutableBuffer& buffer) = delete;
-  OwnedMutableBuffer& operator=(OwnedMutableBuffer& buffer) = delete;
+  DISALLOW_COPY_AND_ASSIGN(OwnedMutableBuffer);
 };
 
 template <class T>
@@ -150,20 +149,19 @@ class Vector {
   explicit Vector(int64_t size, MemoryAllocator* allocator);
   void Resize(int64_t new_size);
   void Reserve(int64_t new_capacity);
-  void Clear();
   void Assign(int64_t size, const T val);
+  void Swap(Vector<T>& v);
   inline T& operator[](int64_t i) {
     return data_[i];
   }
 
  private:
-  OwnedMutableBuffer buffer_;
+  std::unique_ptr<OwnedMutableBuffer> buffer_;
   int64_t size_;
   int64_t capacity_;
   T* data_;
 
-  Vector(Vector& buffer) = delete;
-  Vector& operator=(Vector& buffer) = delete;
+  DISALLOW_COPY_AND_ASSIGN(Vector);
 };
 
 } // namespace parquet_cpp

--- a/src/parquet/util/input-output-test.cc
+++ b/src/parquet/util/input-output-test.cc
@@ -28,6 +28,7 @@
 #include "parquet/exception.h"
 #include "parquet/util/buffer.h"
 #include "parquet/util/input.h"
+#include "parquet/util/mem-allocator.h"
 #include "parquet/util/output.h"
 #include "parquet/util/test-common.h"
 
@@ -115,10 +116,9 @@ TYPED_TEST(TestFileReaders, FileDisappeared) {
   this->DeleteTestFile();
   this->source.Close();
 }
-
+//
 TYPED_TEST(TestFileReaders, BadSeek) {
   this->source.Open(this->test_path_);
-
   ASSERT_THROW(this->source.Seek(this->filesize_ + 1), ParquetException);
 }
 

--- a/src/parquet/util/input-output-test.cc
+++ b/src/parquet/util/input-output-test.cc
@@ -116,7 +116,7 @@ TYPED_TEST(TestFileReaders, FileDisappeared) {
   this->DeleteTestFile();
   this->source.Close();
 }
-//
+
 TYPED_TEST(TestFileReaders, BadSeek) {
   this->source.Open(this->test_path_);
   ASSERT_THROW(this->source.Seek(this->filesize_ + 1), ParquetException);

--- a/src/parquet/util/input.cc
+++ b/src/parquet/util/input.cc
@@ -35,6 +35,10 @@ std::shared_ptr<Buffer> RandomAccessSource::ReadAt(int64_t pos, int64_t nbytes) 
   return Read(nbytes);
 }
 
+int64_t RandomAccessSource::Size() const {
+  return size_;
+}
+
 // ----------------------------------------------------------------------
 // LocalFileSource
 
@@ -86,10 +90,6 @@ void LocalFileSource::Seek(int64_t pos) {
   SeekFile(pos);
 }
 
-int64_t LocalFileSource::Size() const {
-  return size_;
-}
-
 int64_t LocalFileSource::Tell() const {
   int64_t position = ftell(file_);
   if (position < 0) {
@@ -107,7 +107,7 @@ int64_t LocalFileSource::Read(int64_t nbytes, uint8_t* buffer) {
 }
 
 std::shared_ptr<Buffer> LocalFileSource::Read(int64_t nbytes) {
-  auto result = std::make_shared<OwnedMutableBuffer>();
+  auto result = std::make_shared<OwnedMutableBuffer>(0, allocator_);
   result->Resize(nbytes);
 
   int64_t bytes_read = Read(nbytes, result->mutable_data());
@@ -196,10 +196,6 @@ void BufferReader::Seek(int64_t pos) {
     throw ParquetException(ss.str());
   }
   pos_ = pos;
-}
-
-int64_t BufferReader::Size() const {
-  return size_;
 }
 
 int64_t BufferReader::Read(int64_t nbytes, uint8_t* out) {

--- a/src/parquet/util/mem-allocator-test.cc
+++ b/src/parquet/util/mem-allocator-test.cc
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "parquet/exception.h"
+#include "parquet/util/mem-allocator.h"
+
+namespace parquet_cpp {
+
+TEST(TestAllocator, AllocateFree) {
+  TrackingAllocator allocator;
+
+  uint8_t* data = allocator.Malloc(100);
+  ASSERT_TRUE(nullptr != data);
+  data[99] = 55;
+  allocator.Free(data);
+
+  data = allocator.Malloc(0);
+  ASSERT_EQ(nullptr, data);
+  allocator.Free(data);
+
+  int64_t to_alloc = std::numeric_limits<int64_t>::max();
+  ASSERT_THROW(allocator.Malloc(to_alloc), ParquetException);
+}
+
+TEST(TestAllocator, TotalMax) {
+  TrackingAllocator allocator;
+  ASSERT_EQ(0, allocator.TotalMemory());
+  ASSERT_EQ(0, allocator.MaxMemory());
+
+  uint8_t* data = allocator.Malloc(100);
+  ASSERT_EQ(100, allocator.TotalMemory());
+  ASSERT_EQ(100, allocator.MaxMemory());
+
+  uint8_t* data2 = allocator.Malloc(10);
+  ASSERT_EQ(110, allocator.TotalMemory());
+  ASSERT_EQ(110, allocator.MaxMemory());
+
+  allocator.Free(data);
+  ASSERT_EQ(10, allocator.TotalMemory());
+  ASSERT_EQ(110, allocator.MaxMemory());
+
+  allocator.Free(data2);
+  ASSERT_EQ(0, allocator.TotalMemory());
+  ASSERT_EQ(110, allocator.MaxMemory());
+}
+
+} // namespace parquet_cpp

--- a/src/parquet/util/mem-allocator-test.cc
+++ b/src/parquet/util/mem-allocator-test.cc
@@ -28,11 +28,15 @@ TEST(TestAllocator, AllocateFree) {
   uint8_t* data = allocator.Malloc(100);
   ASSERT_TRUE(nullptr != data);
   data[99] = 55;
-  allocator.Free(data);
+  allocator.Free(data, 100);
 
   data = allocator.Malloc(0);
   ASSERT_EQ(nullptr, data);
-  allocator.Free(data);
+  allocator.Free(data, 0);
+
+  data = allocator.Malloc(1);
+  ASSERT_THROW(allocator.Free(data, 2), ParquetException);
+  ASSERT_NO_THROW(allocator.Free(data, 1));
 
   int64_t to_alloc = std::numeric_limits<int64_t>::max();
   ASSERT_THROW(allocator.Malloc(to_alloc), ParquetException);
@@ -51,11 +55,11 @@ TEST(TestAllocator, TotalMax) {
   ASSERT_EQ(110, allocator.TotalMemory());
   ASSERT_EQ(110, allocator.MaxMemory());
 
-  allocator.Free(data);
+  allocator.Free(data, 100);
   ASSERT_EQ(10, allocator.TotalMemory());
   ASSERT_EQ(110, allocator.MaxMemory());
 
-  allocator.Free(data2);
+  allocator.Free(data2, 10);
   ASSERT_EQ(0, allocator.TotalMemory());
   ASSERT_EQ(110, allocator.MaxMemory());
 }

--- a/src/parquet/util/mem-allocator.cc
+++ b/src/parquet/util/mem-allocator.cc
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/util/mem-allocator.h"
+
+#include <cstdlib>
+
+#include "parquet/exception.h"
+
+namespace parquet_cpp {
+
+MemoryAllocator::~MemoryAllocator() {}
+
+uint8_t* TrackingAllocator::Malloc(int64_t size) {
+  if (0 == size) {
+    return nullptr;
+  }
+
+  // store the size at the beginning of the block
+  int64_t* p = static_cast<int64_t*>(std::malloc(size + OFFSET));
+  if (!p) {
+    throw ParquetException("OOM: memory allocation failed");
+  }
+  *p = size + OFFSET;
+  total_memory_ += size;
+  if (total_memory_ > max_memory_) {
+    max_memory_ = total_memory_;
+  }
+
+  return reinterpret_cast<uint8_t*>(++p);
+}
+
+void TrackingAllocator::Free(uint8_t* p) {
+  if (nullptr != p) {
+      int64_t* p1 = reinterpret_cast<int64_t*>(p);
+      --p1;
+      total_memory_ -= *p1-OFFSET;
+      std::free(p1);
+  }
+}
+
+TrackingAllocator::~TrackingAllocator() {
+  if (0 != total_memory_) {
+    throw ParquetException("Memory has not been deallocation");
+  }
+}
+
+MemoryAllocator* default_allocator() {
+  static TrackingAllocator default_allocator;
+  return &default_allocator;
+}
+
+} // namespace parquet_cpp

--- a/src/parquet/util/mem-allocator.h
+++ b/src/parquet/util/mem-allocator.h
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef PARQUET_UTIL_MEMORY_POOL_H
+#define PARQUET_UTIL_MEMORY_POOL_H
+
+#include "parquet/util/logging.h"
+#include "parquet/util/bit-util.h"
+
+namespace parquet_cpp {
+
+class MemoryAllocator {
+ public:
+  virtual ~MemoryAllocator();
+
+  // Returns nullptr if size is 0
+  virtual uint8_t* Malloc(int64_t size) = 0;
+  virtual void Free(uint8_t* p) = 0;
+};
+
+MemoryAllocator* default_allocator();
+
+class TrackingAllocator: public MemoryAllocator {
+ public:
+  TrackingAllocator() : total_memory_(0), max_memory_(0) {}
+  virtual ~TrackingAllocator();
+
+  uint8_t* Malloc(int64_t size) override;
+  void Free(uint8_t* p) override;
+
+  inline int64_t TotalMemory() {
+    return total_memory_;
+  }
+
+  inline int64_t MaxMemory() {
+    return max_memory_;
+  }
+
+ private:
+  static const uint64_t OFFSET = sizeof(int64_t);
+  int64_t total_memory_;
+  int64_t max_memory_;
+};
+
+} // namespace parquet_cpp
+
+#endif // PARQUET_UTIL_MEMORY_POOL_H

--- a/src/parquet/util/mem-allocator.h
+++ b/src/parquet/util/mem-allocator.h
@@ -29,7 +29,7 @@ class MemoryAllocator {
 
   // Returns nullptr if size is 0
   virtual uint8_t* Malloc(int64_t size) = 0;
-  virtual void Free(uint8_t* p) = 0;
+  virtual void Free(uint8_t* p, int64_t size) = 0;
 };
 
 MemoryAllocator* default_allocator();
@@ -40,18 +40,17 @@ class TrackingAllocator: public MemoryAllocator {
   virtual ~TrackingAllocator();
 
   uint8_t* Malloc(int64_t size) override;
-  void Free(uint8_t* p) override;
+  void Free(uint8_t* p, int64_t size) override;
 
-  inline int64_t TotalMemory() {
+  int64_t TotalMemory() {
     return total_memory_;
   }
 
-  inline int64_t MaxMemory() {
+  int64_t MaxMemory() {
     return max_memory_;
   }
 
  private:
-  static const uint64_t OFFSET = sizeof(int64_t);
   int64_t total_memory_;
   int64_t max_memory_;
 };

--- a/src/parquet/util/mem-pool.cc
+++ b/src/parquet/util/mem-pool.cc
@@ -52,7 +52,7 @@ MemPool::~MemPool() {
   int64_t total_bytes_released = 0;
   for (size_t i = 0; i < chunks_.size(); ++i) {
     total_bytes_released += chunks_[i].size;
-    allocator_->Free(chunks_[i].data);
+    allocator_->Free(chunks_[i].data, chunks_[i].size);
   }
 
   DCHECK(chunks_.empty()) << "Must call FreeAll() or AcquireData() for this pool";
@@ -71,7 +71,7 @@ void MemPool::FreeAll() {
   int64_t total_bytes_released = 0;
   for (size_t i = 0; i < chunks_.size(); ++i) {
     total_bytes_released += chunks_[i].size;
-    allocator_->Free(chunks_[i].data);
+    allocator_->Free(chunks_[i].data, chunks_[i].size);
   }
   chunks_.clear();
   next_chunk_size_ = INITIAL_CHUNK_SIZE;
@@ -109,7 +109,6 @@ bool MemPool::FindChunk(int64_t min_size) {
     chunk_size = std::max<int64_t>(min_size, next_chunk_size_);
 
     // Allocate a new chunk. Return early if malloc fails.
-//    uint8_t* buf = reinterpret_cast<uint8_t*>(malloc(chunk_size));
     uint8_t* buf = allocator_->Malloc(chunk_size);
     if (UNLIKELY(buf == NULL)) {
       DCHECK_EQ(current_chunk_idx_, static_cast<int>(chunks_.size()));

--- a/src/parquet/util/mem-pool.cc
+++ b/src/parquet/util/mem-pool.cc
@@ -34,12 +34,13 @@ namespace parquet_cpp {
 const int MemPool::INITIAL_CHUNK_SIZE;
 const int MemPool::MAX_CHUNK_SIZE;
 
-MemPool::MemPool()
+MemPool::MemPool(MemoryAllocator* allocator)
   : current_chunk_idx_(-1),
     next_chunk_size_(INITIAL_CHUNK_SIZE),
     total_allocated_bytes_(0),
     peak_allocated_bytes_(0),
-    total_reserved_bytes_(0) {}
+    total_reserved_bytes_(0),
+    allocator_(allocator) {}
 
 MemPool::ChunkInfo::ChunkInfo(int64_t size, uint8_t* buf)
   : data(buf),
@@ -51,7 +52,7 @@ MemPool::~MemPool() {
   int64_t total_bytes_released = 0;
   for (size_t i = 0; i < chunks_.size(); ++i) {
     total_bytes_released += chunks_[i].size;
-    free(chunks_[i].data);
+    allocator_->Free(chunks_[i].data);
   }
 
   DCHECK(chunks_.empty()) << "Must call FreeAll() or AcquireData() for this pool";
@@ -70,7 +71,7 @@ void MemPool::FreeAll() {
   int64_t total_bytes_released = 0;
   for (size_t i = 0; i < chunks_.size(); ++i) {
     total_bytes_released += chunks_[i].size;
-    free(chunks_[i].data);
+    allocator_->Free(chunks_[i].data);
   }
   chunks_.clear();
   next_chunk_size_ = INITIAL_CHUNK_SIZE;
@@ -108,7 +109,8 @@ bool MemPool::FindChunk(int64_t min_size) {
     chunk_size = std::max<int64_t>(min_size, next_chunk_size_);
 
     // Allocate a new chunk. Return early if malloc fails.
-    uint8_t* buf = reinterpret_cast<uint8_t*>(malloc(chunk_size));
+//    uint8_t* buf = reinterpret_cast<uint8_t*>(malloc(chunk_size));
+    uint8_t* buf = allocator_->Malloc(chunk_size);
     if (UNLIKELY(buf == NULL)) {
       DCHECK_EQ(current_chunk_idx_, static_cast<int>(chunks_.size()));
       current_chunk_idx_ = static_cast<int>(chunks_.size()) - 1;

--- a/src/parquet/util/mem-pool.h
+++ b/src/parquet/util/mem-pool.h
@@ -29,11 +29,12 @@
 
 #include "parquet/util/logging.h"
 #include "parquet/util/bit-util.h"
+#include "parquet/util/mem-allocator.h"
 
 namespace parquet_cpp {
 
-/// A MemPool maintains a list of memory chunks from which it allocates memory in
-/// response to Allocate() calls;
+/// A MemPool maintains a list of memory chunks from which it allocates memory
+/// in response to Allocate() calls;
 /// Chunks stay around for the lifetime of the mempool or until they are passed on to
 /// another mempool.
 //
@@ -75,7 +76,7 @@ namespace parquet_cpp {
 
 class MemPool {
  public:
-  MemPool();
+  explicit MemPool(MemoryAllocator* allocator = default_allocator());
 
   /// Frees all chunks of memory and subtracts the total allocated bytes
   /// from the registered limits.
@@ -164,6 +165,8 @@ class MemPool {
   int64_t total_reserved_bytes_;
 
   std::vector<ChunkInfo> chunks_;
+
+  MemoryAllocator* allocator_;
 
   /// Find or allocated a chunk with at least min_size spare capacity and update
   /// current_chunk_idx_. Also updates chunks_, chunk_sizes_ and allocated_bytes_

--- a/src/parquet/util/output.cc
+++ b/src/parquet/util/output.cc
@@ -28,20 +28,13 @@ namespace parquet_cpp {
 // ----------------------------------------------------------------------
 // In-memory output stream
 
-static constexpr int64_t IN_MEMORY_DEFAULT_CAPACITY = 1024;
-
-InMemoryOutputStream::InMemoryOutputStream(int64_t initial_capacity) :
-    size_(0),
-    capacity_(initial_capacity) {
+InMemoryOutputStream::InMemoryOutputStream(int64_t initial_capacity,
+    MemoryAllocator* allocator) : size_(0), capacity_(initial_capacity) {
   if (initial_capacity == 0) {
     initial_capacity = IN_MEMORY_DEFAULT_CAPACITY;
   }
-  buffer_.reset(new OwnedMutableBuffer());
-  buffer_->Resize(initial_capacity);
+  buffer_.reset(new OwnedMutableBuffer(initial_capacity, allocator));
 }
-
-InMemoryOutputStream::InMemoryOutputStream() :
-    InMemoryOutputStream(IN_MEMORY_DEFAULT_CAPACITY) {}
 
 uint8_t* InMemoryOutputStream::Head() {
   return buffer_->mutable_data() + size_;

--- a/src/parquet/util/output.h
+++ b/src/parquet/util/output.h
@@ -22,6 +22,7 @@
 #include <memory>
 
 #include "parquet/util/macros.h"
+#include "parquet/util/mem-allocator.h"
 
 namespace parquet_cpp {
 
@@ -44,12 +45,13 @@ class OutputStream {
   virtual void Write(const uint8_t* data, int64_t length) = 0;
 };
 
+static constexpr int64_t IN_MEMORY_DEFAULT_CAPACITY = 1024;
 
 // An output stream that is an in-memory
 class InMemoryOutputStream : public OutputStream {
  public:
-  InMemoryOutputStream();
-  explicit InMemoryOutputStream(int64_t initial_capacity);
+  explicit InMemoryOutputStream(int64_t initial_capacity = IN_MEMORY_DEFAULT_CAPACITY,
+      MemoryAllocator* allocator = default_allocator());
 
   // Close is currently a no-op with the in-memory stream
   virtual void Close() {}


### PR DESCRIPTION
Added `MemoryAllocator` interface and a default implementation, ensured `MemPool` can use a custom allocator, added `Vector<T>` to replace `std::vector<T>`.