### PR TITLE
PARQUET-488: Add SSE cmake toggle, fix build on systems without SSE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,9 @@ string (TOLOWER ${CMAKE_BUILD_TYPE} BUILD_SUBDIR_NAME)
 
 # Top level cmake file, set options
 if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+  option(PARQUET_USE_SSE
+	"Build with SSE4 optimizations"
+	OFF)
   option(PARQUET_BUILD_TESTS
 	"Build the libparquet test suite"
 	ON)
@@ -246,7 +249,10 @@ message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 # TODO(wesm): These compiler warning suppressions should be removed one by one
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
 
-# add_definitions(-DPARQUET_USE_SSE)
+if (PARQUET_USE_SSE)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.2")
+  add_definitions(-DPARQUET_USE_SSE)
+endif()
 
 if (APPLE)
   # Use libc++ to avoid linker errors on some platforms

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,9 @@ message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 
 # Build with C++11 and SSE3 by default
 # TODO(wesm): These compiler warning suppressions should be removed one by one
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -msse3 -Wall")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+
+# add_definitions(-DPARQUET_USE_SSE)
 
 if (APPLE)
   # Use libc++ to avoid linker errors on some platforms

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,8 +245,6 @@ endif ()
 
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 
-# Build with C++11 and SSE3 by default
-# TODO(wesm): These compiler warning suppressions should be removed one by one
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
 
 if (PARQUET_USE_SSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,7 +248,7 @@ message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
 
 if (PARQUET_USE_SSE)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.2")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
   add_definitions(-DPARQUET_USE_SSE)
 endif()
 

--- a/src/parquet/util/bit-util.h
+++ b/src/parquet/util/bit-util.h
@@ -151,11 +151,15 @@ class BitUtil {
 
   /// Returns the number of set bits in x
   static inline int Popcount(uint64_t x) {
+#ifdef PARQUET_USE_SSE
     if (LIKELY(CpuInfo::IsSupported(CpuInfo::POPCNT))) {
       return POPCNT_popcnt_u64(x);
     } else {
       return PopcountNoHw(x);
     }
+#else
+    return PopcountNoHw(x);
+#endif
   }
 
   // Compute correct population count for various-width signed integers

--- a/src/parquet/util/cpu-info.cc
+++ b/src/parquet/util/cpu-info.cc
@@ -24,7 +24,8 @@
 #include <sys/sysctl.h>
 #endif
 
-#include <mmintrin.h>
+// #include <mmintrin.h>
+
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/src/parquet/util/cpu-info.cc
+++ b/src/parquet/util/cpu-info.cc
@@ -24,8 +24,6 @@
 #include <sys/sysctl.h>
 #endif
 
-// #include <mmintrin.h>
-
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/src/parquet/util/hash-util.h
+++ b/src/parquet/util/hash-util.h
@@ -202,11 +202,15 @@ class HashUtil {
   /// Seed values for different steps of the query execution should use different seeds
   /// to prevent accidental key collisions. (See IMPALA-219 for more details).
   static uint32_t Hash(const void* data, int32_t bytes, uint32_t seed) {
+#ifdef PARQUET_USE_SSE
     if (LIKELY(CpuInfo::IsSupported(CpuInfo::SSE4_2))) {
       return CrcHash(data, bytes, seed);
     } else {
       return MurmurHash2_64(data, bytes, seed);
     }
+#else
+    return MurmurHash2_64(data, bytes, seed);
+#endif
   }
 
   /// The magic number (used in hash_combine()) 0x9e3779b9 = 2^32 / (golden ratio).

--- a/src/parquet/util/sse-util.h
+++ b/src/parquet/util/sse-util.h
@@ -23,7 +23,7 @@
 
 #ifdef PARQUET_USE_SSE
 #include <emmintrin.h>
-#endif 
+#endif
 
 namespace parquet_cpp {
 
@@ -84,12 +84,6 @@ namespace SSEUtil {
 /// SSE 4.2 checks and Impala will crash on CPUs that don't support SSE 4.2
 /// (IMPALA-1399/1646).  The compiler intrinsics cannot be used without -msse4.2, so we
 /// define our own implementations of the intrinsics instead.
-
-#if defined(__SSE4_1__) || defined(__POPCNT__)
-/// Impala native code should not be compiled with -msse4.1 or higher until the minimum
-/// CPU requirement is raised to at least the targeted instruction set.
-#error "Do not compile with -msse4.1 or higher."
-#endif
 
 /// The PCMPxSTRy instructions require that the control byte 'mode' be encoded as an
 /// immediate.  So, those need to be always inlined in order to always propagate the

--- a/src/parquet/util/sse-util.h
+++ b/src/parquet/util/sse-util.h
@@ -21,7 +21,9 @@
 #ifndef PARQUET_UTIL_SSE_UTIL_H
 #define PARQUET_UTIL_SSE_UTIL_H
 
+#ifdef PARQUET_USE_SSE
 #include <emmintrin.h>
+#endif 
 
 namespace parquet_cpp {
 
@@ -70,6 +72,8 @@ namespace SSEUtil {
     1 << 15,
   };
 } // namespace SSEUtil
+
+#ifdef PARQUET_USE_SSE
 
 /// Define the SSE 4.2 intrinsics.  The caller must first verify at runtime (or codegen
 /// IR load time) that the processor supports SSE 4.2 before calling these.  These are
@@ -214,7 +218,36 @@ static inline int64_t POPCNT_popcnt_u64(uint64_t a) {
   return 0;
 }
 
-#endif
+#endif // IR_COMPILE
+
+#else
+
+static inline uint32_t SSE4_crc32_u8(uint32_t crc, uint8_t v) {
+  DCHECK(false) << "SSE support is not enabled";
+  return 0;
+}
+
+static inline uint32_t SSE4_crc32_u16(uint32_t crc, uint16_t v) {
+  DCHECK(false) << "SSE support is not enabled";
+  return 0;
+}
+
+static inline uint32_t SSE4_crc32_u32(uint32_t crc, uint32_t v) {
+  DCHECK(false) << "SSE support is not enabled";
+  return 0;
+}
+
+static inline uint32_t SSE4_crc32_u64(uint32_t crc, uint64_t v) {
+  DCHECK(false) << "SSE support is not enabled";
+  return 0;
+}
+
+static inline int64_t POPCNT_popcnt_u64(uint64_t a) {
+  DCHECK(false) << "SSE support is not enabled";
+  return 0;
+}
+
+#endif // PARQUET_USE_SSE
 
 } // namespace parquet_cpp
 


### PR DESCRIPTION
I added an option to make SSE strictly opt-in for now. As a side effect of this, parquet-cpp now builds and the test suite passes out of the box on 32-bit ARMv7 (I tried it on my RaspberryPi Model B 2). 