### PR TITLE
PARQUET-561: Add destructor to PIMPL

### DIFF
--- a/src/parquet/file/reader.h
+++ b/src/parquet/file/reader.h
@@ -69,6 +69,7 @@ class ParquetFileReader {
  public:
   // Forward declare the PIMPL
   struct Contents {
+    virtual ~Contents() {}
     // Perform any cleanup associated with the file contents
     virtual void Close() = 0;
 


### PR DESCRIPTION
Without this destuctor, the SerializedFile class cannot be destructed and leaks memory.