### PR TITLE
PARQUET-562: Simplified ZSH support in build scripts

### DIFF
--- a/setup_build_env.sh
+++ b/setup_build_env.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-if [ -n "${BASH_VERSION}" ]; then
-    SOURCE_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
-elif [ -n "${ZSH_VERSION}" ]; then
-    SOURCE_DIR=$(cd "$(dirname "${(%):-%N}")"; pwd)
-fi
+SOURCE_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE:-$0}")")"; pwd)
 : ${BUILD_DIR:=$SOURCE_DIR/build}
 
 # Create an isolated thirdparty

--- a/setup_build_env.sh
+++ b/setup_build_env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SOURCE_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE:-$0}")")"; pwd)
+SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 : ${BUILD_DIR:=$SOURCE_DIR/build}
 
 # Create an isolated thirdparty

--- a/thirdparty/build_thirdparty.sh
+++ b/thirdparty/build_thirdparty.sh
@@ -2,7 +2,7 @@
 
 set -x
 set -e
-TP_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+TP_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 source $TP_DIR/versions.sh
 PREFIX=$TP_DIR/installed

--- a/thirdparty/download_thirdparty.sh
+++ b/thirdparty/download_thirdparty.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-TP_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+TP_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 source $TP_DIR/versions.sh
 

--- a/thirdparty/set_thirdparty_env.sh
+++ b/thirdparty/set_thirdparty_env.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-if [ -n "${BASH_VERSION}" ]; then
-    SOURCE_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
-elif [ -n "${ZSH_VERSION}" ]; then
-    SOURCE_DIR=$(cd "$(dirname "${(%):-%N}")"; pwd)
-fi
+SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 source $SOURCE_DIR/versions.sh
 
 if [ -z "$THIRDPARTY_DIR" ]; then


### PR DESCRIPTION
The original proposed patch can be implemented in a much simpler way.
The complicated approach is only needed when used inside a function.

Also some scripts in thirdparty did not support zsh which this patch
adds.