### PR TITLE
PARQUET-564: Add cmake option to run valgrind on each unit test executable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,12 @@ matrix:
     os: linux
     before_script:
     - source $TRAVIS_BUILD_DIR/ci/before_script_travis.sh
-    - cmake -DCMAKE_CXX_FLAGS="-Werror" -DPARQUET_GENERATE_COVERAGE=1 $TRAVIS_BUILD_DIR
+    - cmake -DCMAKE_CXX_FLAGS="-Werror" -DPARQUET_TEST_MEMCHECK=ON -DPARQUET_GENERATE_COVERAGE=1 $TRAVIS_BUILD_DIR
     - export PARQUET_TEST_DATA=$TRAVIS_BUILD_DIR/data
     script:
     - make lint
     - make -j4 || exit 1
-    - valgrind --tool=memcheck --leak-check=yes --error-exitcode=1 ctest
+    - ctest || exit 1
     - sudo pip install cpp_coveralls
     - export PARQUET_ROOT=$TRAVIS_BUILD_DIR
     - $TRAVIS_BUILD_DIR/ci/upload_coverage.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,8 @@ function(ADD_PARQUET_TEST REL_TEST_NAME)
   endif()
 
   if (PARQUET_TEST_MEMCHECK)
+	SET_TARGET_PROPERTIES(${TEST_NAME}
+	  PROPERTIES COMPILE_FLAGS -DPARQUET_VALGRIND)
 	add_test(${TEST_NAME}
       valgrind --tool=memcheck --leak-check=full --error-exitcode=1 ${TEST_PATH})
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,6 @@ if (NOT "$ENV{PARQUET_GCC_ROOT}" STREQUAL "")
   set(CMAKE_CXX_COMPILER ${GCC_ROOT}/bin/g++)
 endif()
 
-if ("$ENV{PARQUET_USE_CCACHE}")
-  set(CMAKE_C_COMPILER_ARG1 ${CMAKE_C_COMPILER})
-  set(CMAKE_CXX_COMPILER_ARG1 ${CMAKE_CXX_COMPILER})
-  set(CMAKE_C_COMPILER ccache)
-  set(CMAKE_CXX_COMPILER ccache)
-endif()
-
 # generate CTest input files
 enable_testing()
 
@@ -132,10 +125,11 @@ function(ADD_PARQUET_TEST REL_TEST_NAME)
   endif()
 
   if (PARQUET_TEST_MEMCHECK)
-	SET_TARGET_PROPERTIES(${TEST_NAME}
-	  PROPERTIES COMPILE_FLAGS -DPARQUET_VALGRIND)
+	SET_PROPERTY(TARGET ${TEST_NAME}
+	  APPEND_STRING PROPERTY
+	  COMPILE_FLAGS " -DPARQUET_VALGRIND")
 	add_test(${TEST_NAME}
-      valgrind --tool=memcheck --leak-check=full --error-exitcode=1 ${TEST_PATH})
+	  valgrind --tool=memcheck --leak-check=full --error-exitcode=1 ${TEST_PATH})
   else()
 	add_test(${TEST_NAME}
       ${BUILD_SUPPORT_DIR}/run-test.sh ${TEST_PATH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,9 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   option(PARQUET_BUILD_TESTS
 	"Build the libparquet test suite"
 	ON)
+  option(PARQUET_TEST_MEMCHECK
+	"Run the test suite using valgrind --tool=memcheck"
+	OFF)
   option(PARQUET_BUILD_EXECUTABLES
 	"Build the libparquet executable CLI tools"
 	ON)
@@ -128,8 +131,13 @@ function(ADD_PARQUET_TEST REL_TEST_NAME)
     set(TEST_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${REL_TEST_NAME})
   endif()
 
-  add_test(${TEST_NAME}
-    ${BUILD_SUPPORT_DIR}/run-test.sh ${TEST_PATH})
+  if (PARQUET_TEST_MEMCHECK)
+	add_test(${TEST_NAME}
+      valgrind --tool=memcheck --leak-check=full --error-exitcode=1 ${TEST_PATH})
+  else()
+	add_test(${TEST_NAME}
+      ${BUILD_SUPPORT_DIR}/run-test.sh ${TEST_PATH})
+  endif()
   if(ARGN)
     set_tests_properties(${TEST_NAME} PROPERTIES ${ARGN})
   endif()

--- a/src/parquet/schema/schema-types-test.cc
+++ b/src/parquet/schema/schema-types-test.cc
@@ -39,7 +39,7 @@ namespace schema {
 
 class TestPrimitiveNode : public ::testing::Test {
  public:
-  void setUp() {
+  void SetUp() {
     name_ = "name";
     id_ = 5;
   }

--- a/src/parquet/util/buffer.cc
+++ b/src/parquet/util/buffer.cc
@@ -38,12 +38,12 @@ OwnedMutableBuffer::OwnedMutableBuffer() :
     ResizableBuffer(nullptr, 0) {}
 
 void OwnedMutableBuffer::Resize(int64_t new_size) {
-  size_ = new_size;
   try {
     buffer_owner_.resize(new_size);
   } catch (const std::bad_alloc& e) {
     throw ParquetException("OOM: resize failed");
   }
+  size_ = new_size;
   data_ = buffer_owner_.data();
   mutable_data_ = buffer_owner_.data();
 }


### PR DESCRIPTION
This also enables the current test suite to pass cleanly under `ctest` with this option enabled.