### PR TITLE
PARQUET-552: Estimate peak dynamic memory usage using FileMetadata

### DIFF
--- a/src/parquet/column/scanner.h
+++ b/src/parquet/column/scanner.h
@@ -70,6 +70,8 @@ class Scanner {
 
   int64_t batch_size() const { return batch_size_;}
 
+  int64_t buffer_size() const { return value_buffer_.size(); }
+
   void SetBatchSize(int64_t batch_size) {
     batch_size_ = batch_size;
   }

--- a/src/parquet/file/reader-internal.h
+++ b/src/parquet/file/reader-internal.h
@@ -19,6 +19,7 @@
 #define PARQUET_FILE_READER_INTERNAL_H
 
 #include <cstdint>
+#include <list>
 #include <memory>
 #include <vector>
 
@@ -104,7 +105,10 @@ class SerializedFile : public ParquetFileReader::Contents {
   virtual int64_t num_rows() const;
   virtual int num_columns() const;
   virtual int num_row_groups() const;
+  virtual int64_t metadata_length() const;
   virtual ~SerializedFile();
+  virtual ParquetFileReader::MemoryUsage EstimateMemoryUsage(bool memory_map,
+      std::list<int>& selected_columns);
 
  private:
   // This class takes ownership of the provided data source
@@ -114,6 +118,7 @@ class SerializedFile : public ParquetFileReader::Contents {
   std::unique_ptr<RandomAccessSource> source_;
   format::FileMetaData metadata_;
   MemoryAllocator* allocator_;
+  uint32_t metadata_length_;
 
   void ParseMetaData();
 };

--- a/src/parquet/reader-test.cc
+++ b/src/parquet/reader-test.cc
@@ -45,13 +45,14 @@ class TestAllTypesPlain : public ::testing::Test {
     std::stringstream ss;
     ss << dir_string << "/" << "alltypes_plain.parquet";
 
-    reader_ = ParquetFileReader::OpenFile(ss.str());
+    reader_ = ParquetFileReader::OpenFile(ss.str(), false, &allocator_);
   }
 
   void TearDown() {}
 
  protected:
   std::unique_ptr<ParquetFileReader> reader_;
+  TrackingAllocator allocator_;
 };
 
 TEST_F(TestAllTypesPlain, NoopConstructDestruct) {
@@ -125,7 +126,7 @@ TEST_F(TestAllTypesPlain, DebugPrintWorks) {
   std::stringstream ss;
 
   std::list<int> columns;
-  reader_->DebugPrint(ss, columns);
+  reader_->DebugPrint(ss, columns, 128);
 
   std::string result = ss.str();
   ASSERT_GT(result.size(), 0);
@@ -138,7 +139,7 @@ TEST_F(TestAllTypesPlain, ColumnSelection) {
   columns.push_back(5);
   columns.push_back(0);
   columns.push_back(10);
-  reader_->DebugPrint(ss, columns);
+  reader_->DebugPrint(ss, columns, 128);
 
   std::string result = ss.str();
   ASSERT_GT(result.size(), 0);
@@ -149,13 +150,43 @@ TEST_F(TestAllTypesPlain, ColumnSelectionOutOfRange) {
 
   std::list<int> columns;
   columns.push_back(100);
-  ASSERT_THROW(reader_->DebugPrint(ss, columns), ParquetException);
+  ASSERT_THROW(reader_->DebugPrint(ss, columns, 128), ParquetException);
 
   columns.clear();
   columns.push_back(-1);
-  ASSERT_THROW(reader_->DebugPrint(ss, columns), ParquetException);
+  ASSERT_THROW(reader_->DebugPrint(ss, columns, 128), ParquetException);
 }
 
+TEST_F(TestAllTypesPlain, MemoryEstimation) {
+  std::stringstream ss;
+
+  int64_t batch_size = 128;
+  std::list<int> columns;
+
+  columns.push_back(0);
+  columns.push_back(5);
+  ParquetFileReader::MemoryUsage memory_usage1 =
+      reader_->EstimateMemoryUsage(false, columns, batch_size);
+  reader_->DebugPrint(ss, columns, batch_size, true);
+  ASSERT_GT(allocator_.MaxMemory(), memory_usage1.memory);
+  ASSERT_TRUE(memory_usage1.has_dictionary);
+
+  columns.push_back(9);
+  ParquetFileReader::MemoryUsage memory_usage2
+      = reader_->EstimateMemoryUsage(false, columns, batch_size);
+  reader_->DebugPrint(ss, columns, batch_size, true);
+  ASSERT_GT(allocator_.MaxMemory(), memory_usage2.memory);
+  ASSERT_TRUE(memory_usage2.has_dictionary);
+  ASSERT_GT(memory_usage2.memory, memory_usage1.memory);
+
+  columns.clear();
+  ParquetFileReader::MemoryUsage memory_usage_all
+      = reader_->EstimateMemoryUsage(false, columns, batch_size);
+  reader_->DebugPrint(ss, columns, batch_size, true);
+  ASSERT_GT(allocator_.MaxMemory(), memory_usage_all.memory);
+  ASSERT_TRUE(memory_usage_all.has_dictionary);
+  ASSERT_GT(memory_usage_all.memory, memory_usage2.memory);
+}
 
 class TestLocalFileSource : public ::testing::Test {
  public:

--- a/src/parquet/util/input.cc
+++ b/src/parquet/util/input.cc
@@ -107,9 +107,7 @@ int64_t LocalFileSource::Read(int64_t nbytes, uint8_t* buffer) {
 }
 
 std::shared_ptr<Buffer> LocalFileSource::Read(int64_t nbytes) {
-  auto result = std::make_shared<OwnedMutableBuffer>(0, allocator_);
-  result->Resize(nbytes);
-
+  auto result = std::make_shared<OwnedMutableBuffer>(nbytes, allocator_);
   int64_t bytes_read = Read(nbytes, result->mutable_data());
   if (bytes_read < nbytes) {
     result->Resize(bytes_read);


### PR DESCRIPTION
The estimate `MemoryUsage.memory` is an upper bound on dynamic memory usage. However, it does not include memory used in buffers during dictionary decoding. Flag `MemoryUsage.has_dictionary` is set to indicate whether dictionary encoding is used.