### PR TITLE
PARQUET-572: Rename public namespace to parquet from parquet_cpp

### DIFF
--- a/example/decode_benchmark.cc
+++ b/example/decode_benchmark.cc
@@ -26,7 +26,7 @@
 #include "parquet/encodings/delta-length-byte-array-encoding.h"
 #include "parquet/util/stopwatch.h"
 
-using namespace parquet_cpp;
+using namespace parquet;
 using namespace std;
 
 /**

--- a/example/parquet-dump-schema.cc
+++ b/example/parquet-dump-schema.cc
@@ -20,7 +20,7 @@
 #include <parquet/api/reader.h>
 #include <parquet/api/schema.h>
 
-using namespace parquet_cpp;
+using namespace parquet;
 
 int main(int argc, char** argv) {
   std::string filename = argv[1];

--- a/example/parquet_reader.cc
+++ b/example/parquet_reader.cc
@@ -21,7 +21,7 @@
 
 #include <parquet/api/reader.h>
 
-using namespace parquet_cpp;
+using namespace parquet;
 
 int main(int argc, char** argv) {
   if (argc > 3) {

--- a/src/parquet/column/column-reader-test.cc
+++ b/src/parquet/column/column-reader-test.cc
@@ -37,7 +37,7 @@ using std::string;
 using std::vector;
 using std::shared_ptr;
 
-namespace parquet_cpp {
+namespace parquet {
 
 using schema::NodePtr;
 
@@ -221,4 +221,4 @@ TEST_F(TestPrimitiveReader, TestDictionaryEncodedPages) {
 }
 
 } // namespace test
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/column/levels-test.cc
+++ b/src/parquet/column/levels-test.cc
@@ -26,7 +26,7 @@
 
 using std::string;
 
-namespace parquet_cpp {
+namespace parquet {
 
 void GenerateLevels(int min_repeat_factor, int max_repeat_factor,
     int max_level, std::vector<int16_t>& input_levels) {
@@ -188,4 +188,4 @@ TEST(TestLevels, TestLevelsDecodeMultipleSetData) {
   }
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/column/levels.h
+++ b/src/parquet/column/levels.h
@@ -25,7 +25,7 @@
 #include "parquet/types.h"
 #include "parquet/util/rle-encoding.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 class LevelEncoder {
  public:
@@ -165,5 +165,5 @@ class LevelDecoder {
   std::unique_ptr<BitReader> bit_packed_decoder_;
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 #endif // PARQUET_COLUMN_LEVELS_H

--- a/src/parquet/column/page.h
+++ b/src/parquet/column/page.h
@@ -29,14 +29,14 @@
 #include "parquet/types.h"
 #include "parquet/util/buffer.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 // TODO: Parallel processing is not yet safe because of memory-ownership
 // semantics (the PageReader may or may not own the memory referenced by a
 // page)
 //
 // TODO(wesm): In the future Parquet implementations may store the crc code
-// in parquet::PageHeader. parquet-mr currently does not, so we also skip it
+// in format::PageHeader. parquet-mr currently does not, so we also skip it
 // here, both on the read and write path
 class Page {
  public:
@@ -168,7 +168,7 @@ class DataPageV2 : public Page {
   int32_t repetition_levels_byte_length_;
   bool is_compressed_;
 
-  // TODO(wesm): parquet::DataPageHeaderV2.statistics
+  // TODO(wesm): format::DataPageHeaderV2.statistics
 };
 
 
@@ -210,6 +210,6 @@ class PageReader {
   virtual std::shared_ptr<Page> NextPage() = 0;
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_COLUMN_PAGE_H

--- a/src/parquet/column/reader.cc
+++ b/src/parquet/column/reader.cc
@@ -26,7 +26,7 @@
 #include "parquet/encodings/dictionary-encoding.h"
 #include "parquet/encodings/plain-encoding.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 ColumnReader::ColumnReader(const ColumnDescriptor* descr,
     std::unique_ptr<PageReader> pager, MemoryAllocator* allocator)
@@ -224,4 +224,4 @@ std::shared_ptr<ColumnReader> ColumnReader::Make(
   return std::shared_ptr<ColumnReader>(nullptr);
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/column/reader.h
+++ b/src/parquet/column/reader.h
@@ -32,7 +32,7 @@
 #include "parquet/types.h"
 #include "parquet/util/mem-allocator.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 class ColumnReader {
  public:
@@ -216,6 +216,6 @@ typedef TypedColumnReader<Type::DOUBLE> DoubleReader;
 typedef TypedColumnReader<Type::BYTE_ARRAY> ByteArrayReader;
 typedef TypedColumnReader<Type::FIXED_LEN_BYTE_ARRAY> FixedLenByteArrayReader;
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_COLUMN_READER_H

--- a/src/parquet/column/scanner-test.cc
+++ b/src/parquet/column/scanner-test.cc
@@ -36,7 +36,7 @@ using std::string;
 using std::vector;
 using std::shared_ptr;
 
-namespace parquet_cpp {
+namespace parquet {
 
 using schema::NodePtr;
 
@@ -272,4 +272,4 @@ TEST_F(TestFlatFLBAScanner, TestFLBAPrinterNext) {
 }
 
 } // namespace test
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/column/scanner.cc
+++ b/src/parquet/column/scanner.cc
@@ -22,7 +22,7 @@
 
 #include "parquet/column/reader.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 std::shared_ptr<Scanner> Scanner::Make(std::shared_ptr<ColumnReader> col_reader,
     int64_t batch_size, MemoryAllocator* allocator) {
@@ -51,4 +51,4 @@ std::shared_ptr<Scanner> Scanner::Make(std::shared_ptr<ColumnReader> col_reader,
   return std::shared_ptr<Scanner>(nullptr);
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/column/scanner.h
+++ b/src/parquet/column/scanner.h
@@ -31,7 +31,7 @@
 #include "parquet/types.h"
 #include "parquet/util/mem-allocator.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 static constexpr int64_t DEFAULT_SCANNER_BATCH_SIZE = 128;
 
@@ -243,6 +243,6 @@ typedef TypedScanner<Type::DOUBLE> DoubleScanner;
 typedef TypedScanner<Type::BYTE_ARRAY> ByteArrayScanner;
 typedef TypedScanner<Type::FIXED_LEN_BYTE_ARRAY> FixedLenByteArrayScanner;
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_COLUMN_SCANNER_H

--- a/src/parquet/column/test-util.h
+++ b/src/parquet/column/test-util.h
@@ -40,7 +40,7 @@
 using std::vector;
 using std::shared_ptr;
 
-namespace parquet_cpp {
+namespace parquet {
 
 namespace test {
 
@@ -457,6 +457,6 @@ static int MakePages(const ColumnDescriptor *d, int num_pages, int levels_per_pa
 
 } // namespace test
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_COLUMN_TEST_UTIL_H

--- a/src/parquet/compression/codec-test.cc
+++ b/src/parquet/compression/codec-test.cc
@@ -26,7 +26,7 @@
 using std::string;
 using std::vector;
 
-namespace parquet_cpp {
+namespace parquet {
 
 template <typename T>
 void CheckCodecRoundtrip(const vector<uint8_t>& data) {
@@ -83,4 +83,4 @@ TEST(TestCompressors, GZip) {
   CheckCodec<GZipCodec>();
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/compression/codec.cc
+++ b/src/parquet/compression/codec.cc
@@ -21,7 +21,7 @@
 #include "parquet/exception.h"
 #include "parquet/types.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 std::unique_ptr<Codec> Codec::Create(Compression::type codec_type) {
   std::unique_ptr<Codec> result;
@@ -44,4 +44,4 @@ std::unique_ptr<Codec> Codec::Create(Compression::type codec_type) {
   return result;
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/compression/codec.h
+++ b/src/parquet/compression/codec.h
@@ -26,7 +26,7 @@
 #include "parquet/exception.h"
 #include "parquet/types.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 class Codec {
  public:
@@ -121,6 +121,6 @@ class GZipCodec : public Codec {
   bool decompressor_initialized_;
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif

--- a/src/parquet/compression/gzip-codec.cc
+++ b/src/parquet/compression/gzip-codec.cc
@@ -22,7 +22,7 @@
 #include "parquet/compression/codec.h"
 #include "parquet/exception.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 // These are magic numbers from zlib.h.  Not clear why they are not defined
 // there.
@@ -187,4 +187,4 @@ int64_t GZipCodec::Compress(int64_t input_length, const uint8_t* input,
   return output_length - stream_.avail_out;
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/compression/lz4-codec.cc
+++ b/src/parquet/compression/lz4-codec.cc
@@ -21,7 +21,7 @@
 #include "parquet/compression/codec.h"
 #include "parquet/exception.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 void Lz4Codec::Decompress(int64_t input_len, const uint8_t* input,
       int64_t output_len, uint8_t* output_buffer) {
@@ -42,4 +42,4 @@ int64_t Lz4Codec::Compress(int64_t input_len, const uint8_t* input,
       reinterpret_cast<char*>(output_buffer), input_len);
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/compression/snappy-codec.cc
+++ b/src/parquet/compression/snappy-codec.cc
@@ -22,13 +22,13 @@
 #include "parquet/compression/codec.h"
 #include "parquet/exception.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 void SnappyCodec::Decompress(int64_t input_len, const uint8_t* input,
       int64_t output_len, uint8_t* output_buffer) {
   if (!snappy::RawUncompress(reinterpret_cast<const char*>(input),
       static_cast<size_t>(input_len), reinterpret_cast<char*>(output_buffer))) {
-    throw parquet_cpp::ParquetException("Corrupt snappy compressed data.");
+    throw parquet::ParquetException("Corrupt snappy compressed data.");
   }
 }
 
@@ -45,4 +45,4 @@ int64_t SnappyCodec::Compress(int64_t input_len, const uint8_t* input,
   return output_len;
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/encodings/decoder.h
+++ b/src/parquet/encodings/decoder.h
@@ -24,11 +24,11 @@
 #include "parquet/types.h"
 #include "parquet/util/mem-allocator.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 class ColumnDescriptor;
 
-// The Decoder template is parameterized on parquet_cpp::Type::type
+// The Decoder template is parameterized on parquet::Type::type
 template <int TYPE>
 class Decoder {
  public:
@@ -65,6 +65,6 @@ class Decoder {
   int num_values_;
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_ENCODINGS_DECODER_H

--- a/src/parquet/encodings/delta-bit-pack-encoding.h
+++ b/src/parquet/encodings/delta-bit-pack-encoding.h
@@ -26,7 +26,7 @@
 #include "parquet/util/bit-stream-utils.inline.h"
 #include "parquet/util/buffer.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 template <int TYPE>
 class DeltaBitPackDecoder : public Decoder<TYPE> {
@@ -119,6 +119,6 @@ class DeltaBitPackDecoder : public Decoder<TYPE> {
 
   int32_t last_value_;
 };
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif

--- a/src/parquet/encodings/delta-byte-array-encoding.h
+++ b/src/parquet/encodings/delta-byte-array-encoding.h
@@ -24,7 +24,7 @@
 #include "parquet/encodings/delta-length-byte-array-encoding.h"
 #include "parquet/encodings/delta-bit-pack-encoding.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 class DeltaByteArrayDecoder : public Decoder<Type::BYTE_ARRAY> {
  public:
@@ -77,6 +77,6 @@ class DeltaByteArrayDecoder : public Decoder<Type::BYTE_ARRAY> {
   ByteArray last_value_;
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif

--- a/src/parquet/encodings/delta-length-byte-array-encoding.h
+++ b/src/parquet/encodings/delta-length-byte-array-encoding.h
@@ -25,7 +25,7 @@
 #include "parquet/encodings/decoder.h"
 #include "parquet/encodings/delta-bit-pack-encoding.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 class DeltaLengthByteArrayDecoder : public Decoder<Type::BYTE_ARRAY> {
  public:
@@ -66,6 +66,6 @@ class DeltaLengthByteArrayDecoder : public Decoder<Type::BYTE_ARRAY> {
   int len_;
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif

--- a/src/parquet/encodings/dictionary-encoding.h
+++ b/src/parquet/encodings/dictionary-encoding.h
@@ -34,7 +34,7 @@
 #include "parquet/util/mem-pool.h"
 #include "parquet/util/rle-encoding.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 template <int TYPE>
 class DictionaryDecoder : public Decoder<TYPE> {
@@ -441,6 +441,6 @@ inline int DictEncoderBase::WriteIndices(uint8_t* buffer, int buffer_len) {
   return 1 + encoder.len();
 }
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif

--- a/src/parquet/encodings/encoder.h
+++ b/src/parquet/encodings/encoder.h
@@ -23,7 +23,7 @@
 #include "parquet/exception.h"
 #include "parquet/types.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 class ColumnDescriptor;
 class OutputStream;
@@ -52,6 +52,6 @@ class Encoder {
   MemoryAllocator* allocator_;
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_ENCODINGS_ENCODER_H

--- a/src/parquet/encodings/encoding-test.cc
+++ b/src/parquet/encodings/encoding-test.cc
@@ -35,7 +35,7 @@
 using std::string;
 using std::vector;
 
-namespace parquet_cpp {
+namespace parquet {
 
 namespace test {
 
@@ -311,4 +311,4 @@ TEST(TestDictionaryEncoding, CannotDictDecodeBoolean) {
 
 } // namespace test
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/encodings/plain-encoding.h
+++ b/src/parquet/encodings/plain-encoding.h
@@ -28,7 +28,7 @@
 #include "parquet/util/buffer.h"
 #include "parquet/util/output.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 // ----------------------------------------------------------------------
 // Encoding::PLAIN decoder implementation
@@ -245,6 +245,6 @@ inline void PlainEncoder<Type::FIXED_LEN_BYTE_ARRAY>::Encode(
     dst->Write(reinterpret_cast<const uint8_t*>(src[i].ptr), descr_->type_length());
   }
 }
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif

--- a/src/parquet/exception.h
+++ b/src/parquet/exception.h
@@ -22,7 +22,7 @@
 #include <sstream>
 #include <string>
 
-namespace parquet_cpp {
+namespace parquet {
 
 class ParquetException : public std::exception {
  public:
@@ -44,6 +44,6 @@ class ParquetException : public std::exception {
   std::string msg_;
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_EXCEPTION_H

--- a/src/parquet/file/file-deserialize-test.cc
+++ b/src/parquet/file/file-deserialize-test.cc
@@ -37,13 +37,13 @@
 #include "parquet/util/output.h"
 #include "parquet/util/test-common.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 
 // Adds page statistics occupying a certain amount of bytes (for testing very
 // large page headers)
 static inline void AddDummyStats(int stat_size,
-    parquet::DataPageHeader& data_page) {
+    format::DataPageHeader& data_page) {
 
   std::vector<uint8_t> stat_bytes(stat_size);
   // Some non-zero value
@@ -56,9 +56,9 @@ static inline void AddDummyStats(int stat_size,
 class TestPageSerde : public ::testing::Test {
  public:
   void SetUp() {
-    data_page_header_.encoding = parquet::Encoding::PLAIN;
-    data_page_header_.definition_level_encoding = parquet::Encoding::RLE;
-    data_page_header_.repetition_level_encoding = parquet::Encoding::RLE;
+    data_page_header_.encoding = format::Encoding::PLAIN;
+    data_page_header_.definition_level_encoding = format::Encoding::RLE;
+    data_page_header_.repetition_level_encoding = format::Encoding::RLE;
 
     ResetStream();
   }
@@ -80,7 +80,7 @@ class TestPageSerde : public ::testing::Test {
     page_header_.__set_data_page_header(data_page_header_);
     page_header_.uncompressed_page_size = uncompressed_size;
     page_header_.compressed_page_size = compressed_size;
-    page_header_.type = parquet::PageType::DATA_PAGE;
+    page_header_.type = format::PageType::DATA_PAGE;
 
     ASSERT_NO_THROW(SerializeThriftMsg(&page_header_, max_serialized_len,
           out_stream_.get()));
@@ -99,11 +99,11 @@ class TestPageSerde : public ::testing::Test {
   std::shared_ptr<Buffer> out_buffer_;
 
   std::unique_ptr<SerializedPageReader> page_reader_;
-  parquet::PageHeader page_header_;
-  parquet::DataPageHeader data_page_header_;
+  format::PageHeader page_header_;
+  format::DataPageHeader data_page_header_;
 };
 
-void CheckDataPageHeader(const parquet::DataPageHeader expected,
+void CheckDataPageHeader(const format::DataPageHeader expected,
     const Page* page) {
   ASSERT_EQ(PageType::DATA_PAGE, page->type());
 
@@ -126,7 +126,7 @@ void CheckDataPageHeader(const parquet::DataPageHeader expected,
 }
 
 TEST_F(TestPageSerde, DataPage) {
-  parquet::PageHeader out_page_header;
+  format::PageHeader out_page_header;
 
   int stats_size = 512;
   AddDummyStats(stats_size, data_page_header_);
@@ -291,4 +291,4 @@ TEST_F(TestParquetFileReader, IncompleteMetadata) {
   AssertInvalidFileThrows(buffer);
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/file/reader-internal.h
+++ b/src/parquet/file/reader-internal.h
@@ -29,7 +29,7 @@
 #include "parquet/types.h"
 #include "parquet/util/input.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 // 16 MB is the default maximum page header size
 static constexpr uint32_t DEFAULT_MAX_PAGE_HEADER_SIZE = 16 * 1024 * 1024;
@@ -38,7 +38,7 @@ static constexpr uint32_t DEFAULT_MAX_PAGE_HEADER_SIZE = 16 * 1024 * 1024;
 static constexpr uint32_t DEFAULT_PAGE_HEADER_SIZE = 16 * 1024;
 
 // This subclass delimits pages appearing in a serialized stream, each preceded
-// by a serialized Thrift parquet::PageHeader indicating the type of each page
+// by a serialized Thrift format::PageHeader indicating the type of each page
 // and the page metadata.
 class SerializedPageReader : public PageReader {
  public:
@@ -57,7 +57,7 @@ class SerializedPageReader : public PageReader {
  private:
   std::unique_ptr<InputStream> stream_;
 
-  parquet::PageHeader current_page_header_;
+  format::PageHeader current_page_header_;
   std::shared_ptr<Page> current_page_;
 
   // Compression codec to use.
@@ -71,7 +71,7 @@ class SerializedPageReader : public PageReader {
 class SerializedRowGroup : public RowGroupReader::Contents {
  public:
   SerializedRowGroup(RandomAccessSource* source,
-      const parquet::RowGroup* metadata, MemoryAllocator* allocator) :
+      const format::RowGroup* metadata, MemoryAllocator* allocator) :
       source_(source),
       metadata_(metadata),
       allocator_(allocator) {}
@@ -83,7 +83,7 @@ class SerializedRowGroup : public RowGroupReader::Contents {
 
  private:
   RandomAccessSource* source_;
-  const parquet::RowGroup* metadata_;
+  const format::RowGroup* metadata_;
   MemoryAllocator* allocator_;
 };
 
@@ -112,12 +112,12 @@ class SerializedFile : public ParquetFileReader::Contents {
       MemoryAllocator* allocator);
 
   std::unique_ptr<RandomAccessSource> source_;
-  parquet::FileMetaData metadata_;
+  format::FileMetaData metadata_;
   MemoryAllocator* allocator_;
 
   void ParseMetaData();
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_FILE_READER_INTERNAL_H

--- a/src/parquet/file/reader.cc
+++ b/src/parquet/file/reader.cc
@@ -35,7 +35,7 @@
 using std::string;
 using std::vector;
 
-namespace parquet_cpp {
+namespace parquet {
 
 // ----------------------------------------------------------------------
 // RowGroupReader public API
@@ -223,4 +223,4 @@ void ParquetFileReader::DebugPrint(std::ostream& stream,
   }
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/file/reader.h
+++ b/src/parquet/file/reader.h
@@ -27,7 +27,7 @@
 #include "parquet/column/page.h"
 #include "parquet/schema/descriptor.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 class ColumnReader;
 class RandomAccessSource;
@@ -139,6 +139,6 @@ class ParquetFileReader {
 };
 
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_FILE_READER_H

--- a/src/parquet/public-api-test.cc
+++ b/src/parquet/public-api-test.cc
@@ -21,7 +21,7 @@
 #include "parquet/api/reader.h"
 #include "parquet/api/schema.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 TEST(TestPublicAPI, DoesNotIncludeThrift) {
 #ifdef _THRIFT_THRIFT_H_
@@ -29,4 +29,4 @@ TEST(TestPublicAPI, DoesNotIncludeThrift) {
 #endif
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/reader-test.cc
+++ b/src/parquet/reader-test.cc
@@ -32,7 +32,7 @@
 
 using std::string;
 
-namespace parquet_cpp {
+namespace parquet {
 
 const char* data_dir = std::getenv("PARQUET_TEST_DATA");
 
@@ -187,4 +187,4 @@ TEST_F(TestLocalFileSource, FileClosedOnDestruction) {
 }
 
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/schema/converter.cc
+++ b/src/parquet/schema/converter.cc
@@ -22,9 +22,9 @@
 #include "parquet/schema/types.h"
 #include "parquet/thrift/parquet_types.h"
 
-using parquet::SchemaElement;
+using parquet::format::SchemaElement;
 
-namespace parquet_cpp {
+namespace parquet {
 
 namespace schema {
 
@@ -65,9 +65,9 @@ std::unique_ptr<Node> FlatSchemaConverter::NextNode() {
   }
 }
 
-const parquet::SchemaElement& FlatSchemaConverter::Next() {
+const format::SchemaElement& FlatSchemaConverter::Next() {
   if (pos_ == length_) {
-    throw ParquetException("Malformed schema: not enough parquet::SchemaElement values");
+    throw ParquetException("Malformed schema: not enough SchemaElement values");
   }
   return elements_[pos_++];
 }
@@ -85,4 +85,4 @@ std::shared_ptr<SchemaDescriptor> FromParquet(const std::vector<SchemaElement>& 
 
 } // namespace schema
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/schema/converter.h
+++ b/src/parquet/schema/converter.h
@@ -28,9 +28,9 @@
 #include <memory>
 #include <vector>
 
-namespace parquet { class SchemaElement;}
+namespace parquet {
 
-namespace parquet_cpp {
+namespace format { class SchemaElement;}
 
 class SchemaDescriptor;
 
@@ -43,11 +43,11 @@ class Node;
 // Conversion from Parquet Thrift metadata
 
 std::shared_ptr<SchemaDescriptor> FromParquet(
-    const std::vector<parquet::SchemaElement>& schema);
+    const std::vector<format::SchemaElement>& schema);
 
 class FlatSchemaConverter {
  public:
-  FlatSchemaConverter(const parquet::SchemaElement* elements, int length) :
+  FlatSchemaConverter(const format::SchemaElement* elements, int length) :
       elements_(elements),
       length_(length),
       pos_(0),
@@ -56,7 +56,7 @@ class FlatSchemaConverter {
   std::unique_ptr<Node> Convert();
 
  private:
-  const parquet::SchemaElement* elements_;
+  const format::SchemaElement* elements_;
   int length_;
   int pos_;
   int current_id_;
@@ -65,7 +65,7 @@ class FlatSchemaConverter {
     return current_id_++;
   }
 
-  const parquet::SchemaElement& Next();
+  const format::SchemaElement& Next();
 
   std::unique_ptr<Node> NextNode();
 };
@@ -73,20 +73,20 @@ class FlatSchemaConverter {
 // ----------------------------------------------------------------------
 // Conversion to Parquet Thrift metadata
 
-void ToParquet(const GroupNode* schema, std::vector<parquet::SchemaElement>* out);
+void ToParquet(const GroupNode* schema, std::vector<format::SchemaElement>* out);
 
-// Converts nested parquet_cpp schema back to a flat vector of Thrift structs
+// Converts nested parquet schema back to a flat vector of Thrift structs
 class SchemaFlattener {
  public:
-  SchemaFlattener(const GroupNode* schema, std::vector<parquet::SchemaElement>* out);
+  SchemaFlattener(const GroupNode* schema, std::vector<format::SchemaElement>* out);
 
  private:
   const GroupNode* root_;
-  std::vector<parquet::SchemaElement>* schema_;
+  std::vector<format::SchemaElement>* schema_;
 };
 
 } // namespace schema
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_SCHEMA_CONVERTER_H

--- a/src/parquet/schema/descriptor.cc
+++ b/src/parquet/schema/descriptor.cc
@@ -19,7 +19,7 @@
 
 #include "parquet/exception.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 using schema::ColumnPath;
 using schema::Node;
@@ -113,4 +113,4 @@ const std::shared_ptr<ColumnPath> ColumnDescriptor::path() const {
   return std::make_shared<ColumnPath>(std::move(path_));
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/schema/descriptor.h
+++ b/src/parquet/schema/descriptor.h
@@ -27,7 +27,7 @@
 #include "parquet/schema/types.h"
 #include "parquet/types.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 class SchemaDescriptor;
 
@@ -138,6 +138,6 @@ class SchemaDescriptor {
   std::unordered_map<int, schema::NodePtr> leaf_to_base_;
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_SCHEMA_DESCRIPTOR_H

--- a/src/parquet/schema/printer.cc
+++ b/src/parquet/schema/printer.cc
@@ -23,7 +23,7 @@
 #include "parquet/schema/types.h"
 #include "parquet/types.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 namespace schema {
 
@@ -140,4 +140,4 @@ void PrintSchema(const Node* schema, std::ostream& stream,
 
 } // namespace schema
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/schema/printer.h
+++ b/src/parquet/schema/printer.h
@@ -22,7 +22,7 @@
 
 #include <ostream>
 
-namespace parquet_cpp {
+namespace parquet {
 
 namespace schema {
 
@@ -33,6 +33,6 @@ void PrintSchema(const Node* schema, std::ostream& stream,
 
 } // namespace schema
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_SCHEMA_PRINTER_H

--- a/src/parquet/schema/schema-converter-test.cc
+++ b/src/parquet/schema/schema-converter-test.cc
@@ -32,11 +32,11 @@
 using std::string;
 using std::vector;
 
-using parquet::ConvertedType;
-using parquet::FieldRepetitionType;
-using parquet::SchemaElement;
+using parquet::format::ConvertedType;
+using parquet::format::FieldRepetitionType;
+using parquet::format::SchemaElement;
 
-namespace parquet_cpp {
+namespace parquet {
 
 namespace schema {
 
@@ -46,10 +46,10 @@ namespace schema {
 class TestSchemaConverter : public ::testing::Test {
  public:
   void setUp() {
-    name_ = "parquet_cpp_schema";
+    name_ = "parquet_schema";
   }
 
-  void Convert(const parquet::SchemaElement* elements, int length) {
+  void Convert(const parquet::format::SchemaElement* elements, int length) {
     FlatSchemaConverter converter(elements, length);
     node_ = converter.Convert();
     ASSERT_TRUE(node_->is_group());
@@ -86,7 +86,7 @@ TEST_F(TestSchemaConverter, NestedExample) {
 
   // A primitive one
   elements.push_back(NewPrimitive("a", FieldRepetitionType::REQUIRED,
-          parquet::Type::INT32));
+          format::Type::INT32));
 
   // A group
   elements.push_back(NewGroup("bag", FieldRepetitionType::OPTIONAL, 1));
@@ -96,7 +96,7 @@ TEST_F(TestSchemaConverter, NestedExample) {
   elt.__set_converted_type(ConvertedType::LIST);
   elements.push_back(elt);
   elements.push_back(NewPrimitive("item", FieldRepetitionType::OPTIONAL,
-          parquet::Type::INT64));
+          format::Type::INT64));
 
   Convert(&elements[0], elements.size());
 
@@ -127,7 +127,7 @@ TEST_F(TestSchemaConverter, InvalidRoot) {
 
   SchemaElement elements[2];
   elements[0] = NewPrimitive("not-a-group", FieldRepetitionType::REQUIRED,
-      parquet::Type::INT32);
+      format::Type::INT32);
   ASSERT_THROW(Convert(elements, 2), ParquetException);
 
   // While the Parquet spec indicates that the root group should have REPEATED
@@ -136,7 +136,7 @@ TEST_F(TestSchemaConverter, InvalidRoot) {
   // practicality matter.
   elements[0] = NewGroup("not-repeated", FieldRepetitionType::REQUIRED, 1);
   elements[1] = NewPrimitive("a", FieldRepetitionType::REQUIRED,
-      parquet::Type::INT32);
+      format::Type::INT32);
   Convert(elements, 2);
 
   elements[0] = NewGroup("not-repeated", FieldRepetitionType::OPTIONAL, 1);
@@ -156,4 +156,4 @@ TEST_F(TestSchemaConverter, NotEnoughChildren) {
 
 } // namespace schema
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/schema/schema-descriptor-test.cc
+++ b/src/parquet/schema/schema-descriptor-test.cc
@@ -31,7 +31,7 @@
 using std::string;
 using std::vector;
 
-namespace parquet_cpp {
+namespace parquet {
 
 namespace schema {
 
@@ -131,4 +131,4 @@ TEST_F(TestSchemaDescriptor, BuildTree) {
 
 } // namespace schema
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/schema/schema-printer-test.cc
+++ b/src/parquet/schema/schema-printer-test.cc
@@ -28,7 +28,7 @@
 using std::string;
 using std::vector;
 
-namespace parquet_cpp {
+namespace parquet {
 
 namespace schema {
 
@@ -69,4 +69,4 @@ TEST(TestSchemaPrinter, Examples) {
 
 } // namespace schema
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/schema/schema-types-test.cc
+++ b/src/parquet/schema/schema-types-test.cc
@@ -30,7 +30,7 @@
 using std::string;
 using std::vector;
 
-namespace parquet_cpp {
+namespace parquet {
 
 namespace schema {
 
@@ -59,7 +59,7 @@ class TestPrimitiveNode : public ::testing::Test {
     id_ = 5;
   }
 
-  void Convert(const parquet::SchemaElement* element) {
+  void Convert(const format::SchemaElement* element) {
     node_ = PrimitiveNode::FromParquet(element, id_);
     ASSERT_TRUE(node_->is_primitive());
     prim_node_ = static_cast<const PrimitiveNode*>(node_.get());
@@ -112,7 +112,7 @@ TEST_F(TestPrimitiveNode, Attrs) {
 
 TEST_F(TestPrimitiveNode, FromParquet) {
   SchemaElement elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL,
-      parquet::Type::INT32);
+      format::Type::INT32);
   Convert(&elt);
   ASSERT_EQ(name_, prim_node_->name());
   ASSERT_EQ(id_, prim_node_->id());
@@ -121,7 +121,7 @@ TEST_F(TestPrimitiveNode, FromParquet) {
   ASSERT_EQ(LogicalType::NONE, prim_node_->logical_type());
 
   // Test a logical type
-  elt = NewPrimitive(name_, FieldRepetitionType::REQUIRED, parquet::Type::BYTE_ARRAY);
+  elt = NewPrimitive(name_, FieldRepetitionType::REQUIRED, format::Type::BYTE_ARRAY);
   elt.__set_converted_type(ConvertedType::UTF8);
 
   Convert(&elt);
@@ -131,7 +131,7 @@ TEST_F(TestPrimitiveNode, FromParquet) {
 
   // FIXED_LEN_BYTE_ARRAY
   elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL,
-      parquet::Type::FIXED_LEN_BYTE_ARRAY);
+      format::Type::FIXED_LEN_BYTE_ARRAY);
   elt.__set_type_length(16);
 
   Convert(&elt);
@@ -143,7 +143,7 @@ TEST_F(TestPrimitiveNode, FromParquet) {
 
   // ConvertedType::Decimal
   elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL,
-      parquet::Type::FIXED_LEN_BYTE_ARRAY);
+      format::Type::FIXED_LEN_BYTE_ARRAY);
   elt.__set_converted_type(ConvertedType::DECIMAL);
   elt.__set_type_length(6);
   elt.__set_scale(2);
@@ -297,4 +297,4 @@ TEST_F(TestGroupNode, Equals) {
 
 } // namespace schema
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/schema/test-util.h
+++ b/src/parquet/schema/test-util.h
@@ -27,16 +27,16 @@
 #include "parquet/schema/types.h"
 #include "parquet/thrift/parquet_types.h"
 
-using parquet::ConvertedType;
-using parquet::FieldRepetitionType;
-using parquet::SchemaElement;
+using parquet::format::ConvertedType;
+using parquet::format::FieldRepetitionType;
+using parquet::format::SchemaElement;
 
-namespace parquet_cpp {
+namespace parquet {
 
 namespace schema {
 
 static inline SchemaElement NewPrimitive(const std::string& name,
-    FieldRepetitionType::type repetition, parquet::Type::type type) {
+    FieldRepetitionType::type repetition, format::Type::type type) {
   SchemaElement result;
   result.__set_name(name);
   result.__set_repetition_type(repetition);
@@ -58,6 +58,6 @@ static inline SchemaElement NewGroup(const std::string& name,
 
 } // namespace schema
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_COLUMN_TEST_UTIL_H

--- a/src/parquet/schema/types.cc
+++ b/src/parquet/schema/types.cc
@@ -24,7 +24,7 @@
 #include "parquet/thrift/parquet_types.h"
 #include "parquet/thrift/util.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 namespace schema {
 
@@ -244,7 +244,7 @@ struct NodeParams {
   LogicalType::type logical_type;
 };
 
-static inline NodeParams GetNodeParams(const parquet::SchemaElement* element) {
+static inline NodeParams GetNodeParams(const format::SchemaElement* element) {
   NodeParams params(element->name);
 
   params.repetition = FromThrift(element->repetition_type);
@@ -258,8 +258,8 @@ static inline NodeParams GetNodeParams(const parquet::SchemaElement* element) {
 
 std::unique_ptr<Node> GroupNode::FromParquet(const void* opaque_element, int node_id,
     const NodeVector& fields) {
-  const parquet::SchemaElement* element =
-    static_cast<const parquet::SchemaElement*>(opaque_element);
+  const format::SchemaElement* element =
+    static_cast<const format::SchemaElement*>(opaque_element);
   NodeParams params = GetNodeParams(element);
   return std::unique_ptr<Node>(new GroupNode(params.name, params.repetition, fields,
           params.logical_type, node_id));
@@ -267,8 +267,8 @@ std::unique_ptr<Node> GroupNode::FromParquet(const void* opaque_element, int nod
 
 std::unique_ptr<Node> PrimitiveNode::FromParquet(const void* opaque_element,
     int node_id) {
-  const parquet::SchemaElement* element =
-    static_cast<const parquet::SchemaElement*>(opaque_element);
+  const format::SchemaElement* element =
+    static_cast<const format::SchemaElement*>(opaque_element);
   NodeParams params = GetNodeParams(element);
 
   std::unique_ptr<PrimitiveNode> result = std::unique_ptr<PrimitiveNode>(
@@ -282,4 +282,4 @@ std::unique_ptr<Node> PrimitiveNode::FromParquet(const void* opaque_element,
 
 } // namespace schema
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/schema/types.h
+++ b/src/parquet/schema/types.h
@@ -29,7 +29,7 @@
 #include "parquet/types.h"
 #include "parquet/util/macros.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 namespace schema {
 
@@ -318,6 +318,6 @@ PRIMITIVE_FACTORY(ByteArray, BYTE_ARRAY);
 
 } // namespace schema
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_SCHEMA_TYPES_H

--- a/src/parquet/thrift/parquet.thrift
+++ b/src/parquet/thrift/parquet.thrift
@@ -20,7 +20,7 @@
 /**
  * File format description for the parquet file format
  */
-namespace cpp parquet
+namespace cpp parquet.format
 namespace java parquet.format
 
 /**
@@ -84,32 +84,32 @@ enum ConvertedType {
    * Stored as days since Unix epoch, encoded as the INT32 physical type.
    *
    */
-  DATE = 6; 
+  DATE = 6;
 
-  /** 
-   * A time 
+  /**
+   * A time
    *
-   * The total number of milliseconds since midnight.  The value is stored 
+   * The total number of milliseconds since midnight.  The value is stored
    * as an INT32 physical type.
    */
   TIME_MILLIS = 7;
-  // RESERVED = 8; 
+  // RESERVED = 8;
 
   /**
    * A date/time combination
-   * 
+   *
    * Date and time recorded as milliseconds since the Unix epoch.  Recorded as
    * a physical type of INT64.
    */
-  TIMESTAMP_MILLIS = 9; 
+  TIMESTAMP_MILLIS = 9;
   // RESERVED = 10;
 
 
-  /** 
-   * An unsigned integer value.  
-   * 
-   * The number describes the maximum number of meainful data bits in 
-   * the stored value. 8, 16 and 32 bit values are stored using the 
+  /**
+   * An unsigned integer value.
+   *
+   * The number describes the maximum number of meainful data bits in
+   * the stored value. 8, 16 and 32 bit values are stored using the
    * INT32 physical type.  64 bit values are stored using the INT64
    * physical type.
    *
@@ -133,34 +133,34 @@ enum ConvertedType {
   INT_32 = 17;
   INT_64 = 18;
 
-  /** 
+  /**
    * An embedded JSON document
-   * 
+   *
    * A JSON document embedded within a single UTF8 column.
    */
   JSON = 19;
 
-  /** 
+  /**
    * An embedded BSON document
-   * 
-   * A BSON document embedded within a single BINARY column. 
+   *
+   * A BSON document embedded within a single BINARY column.
    */
   BSON = 20;
 
   /**
    * An interval of time
-   * 
+   *
    * This type annotates data stored as a FIXED_LEN_BYTE_ARRAY of length 12
    * This data is composed of three separate little endian unsigned
    * integers.  Each stores a component of a duration of time.  The first
    * integer identifies the number of months associated with the duration,
    * the second identifies the number of days associated with the duration
-   * and the third identifies the number of milliseconds associated with 
+   * and the third identifies the number of milliseconds associated with
    * the provided duration.  This duration of time is independent of any
    * particular timezone or date.
    */
   INTERVAL = 21;
-  
+
 }
 
 /**
@@ -553,4 +553,3 @@ struct FileMetaData {
    **/
   6: optional string created_by
 }
-

--- a/src/parquet/thrift/util.h
+++ b/src/parquet/thrift/util.h
@@ -22,29 +22,29 @@
 #include "parquet/util/logging.h"
 #include "parquet/util/output.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 // ----------------------------------------------------------------------
-// Convert Thrift enums to / from parquet_cpp enums
+// Convert Thrift enums to / from parquet enums
 
-static inline Type::type FromThrift(parquet::Type::type type) {
+static inline Type::type FromThrift(format::Type::type type) {
   return static_cast<Type::type>(type);
 }
 
-static inline LogicalType::type FromThrift(parquet::ConvertedType::type type) {
+static inline LogicalType::type FromThrift(format::ConvertedType::type type) {
   // item 0 is NONE
   return static_cast<LogicalType::type>(static_cast<int>(type) + 1);
 }
 
-static inline Repetition::type FromThrift(parquet::FieldRepetitionType::type type) {
+static inline Repetition::type FromThrift(format::FieldRepetitionType::type type) {
   return static_cast<Repetition::type>(type);
 }
 
-static inline Encoding::type FromThrift(parquet::Encoding::type type) {
+static inline Encoding::type FromThrift(format::Encoding::type type) {
   return static_cast<Encoding::type>(type);
 }
 
-static inline Compression::type FromThrift(parquet::CompressionCodec::type type) {
+static inline Compression::type FromThrift(format::CompressionCodec::type type) {
   return static_cast<Compression::type>(type);
 }
 
@@ -100,6 +100,6 @@ inline void SerializeThriftMsg(T* obj, uint32_t len, OutputStream* out) {
   out->Write(out_buffer, out_length);
 }
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_THRIFT_UTIL_H

--- a/src/parquet/types-test.cc
+++ b/src/parquet/types-test.cc
@@ -21,7 +21,7 @@
 
 #include "parquet/types.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 TEST(TestTypeToString, PhysicalTypes) {
   ASSERT_STREQ("BOOLEAN", type_to_string(Type::BOOLEAN).c_str());
@@ -79,4 +79,4 @@ TEST(TestLogicalTypeToString, LogicalTypes) {
 }
 
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/types.h
+++ b/src/parquet/types.h
@@ -26,7 +26,7 @@
 
 #include "parquet/util/compiler-util.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 // ----------------------------------------------------------------------
 // Metadata enums to match Thrift metadata
@@ -383,6 +383,6 @@ static inline std::string logical_type_to_string(LogicalType::type t) {
       break;
   }
 }
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_TYPES_H

--- a/src/parquet/util/bit-stream-utils.h
+++ b/src/parquet/util/bit-stream-utils.h
@@ -28,7 +28,7 @@
 #include "parquet/util/logging.h"
 #include "parquet/util/bit-util.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 /// Utility class to write bit/byte streams.  This class can write data to either be
 /// bit packed or byte aligned (and a single stream that has a mix of both).
@@ -162,6 +162,6 @@ class BitReader {
   int bit_offset_;        // Offset in buffered_values_
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_UTIL_BIT_STREAM_UTILS_H

--- a/src/parquet/util/bit-stream-utils.inline.h
+++ b/src/parquet/util/bit-stream-utils.inline.h
@@ -22,7 +22,7 @@
 
 #include "parquet/util/bit-stream-utils.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 inline bool BitWriter::PutValue(uint64_t v, int num_bits) {
   // TODO: revisit this limit if necessary (can be raised to 64 by fixing some edge cases)
@@ -165,6 +165,6 @@ inline bool BitReader::GetZigZagVlqInt(int32_t* v) {
   return true;
 }
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_UTIL_BIT_STREAM_UTILS_INLINE_H

--- a/src/parquet/util/bit-util-test.cc
+++ b/src/parquet/util/bit-util-test.cc
@@ -30,7 +30,7 @@
 #include "parquet/util/bit-stream-utils.inline.h"
 #include "parquet/util/cpu-info.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 static void ensure_cpu_info_initialized() {
   if (!CpuInfo::initialized()) {
@@ -189,4 +189,4 @@ TEST(BitStreamUtil, ZigZag) {
   TestZigZag(-std::numeric_limits<int32_t>::max());
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/util/bit-util.h
+++ b/src/parquet/util/bit-util.h
@@ -32,7 +32,7 @@
 #include "parquet/util/cpu-info.h"
 #include "parquet/util/sse-util.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 // TODO(wesm): The source from Impala was depending on boost::make_unsigned
 //
@@ -323,6 +323,6 @@ class BitUtil {
   }
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_UTIL_BIT_UTIL_H

--- a/src/parquet/util/buffer-builder.h
+++ b/src/parquet/util/buffer-builder.h
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include <cstdint>
 
-namespace parquet_cpp {
+namespace parquet {
 
 /// Utility class to build an in-memory buffer.
 class BufferBuilder {
@@ -56,6 +56,6 @@ class BufferBuilder {
   int size_;
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_UTIL_BUFFER_BUILDER_H

--- a/src/parquet/util/buffer-test.cc
+++ b/src/parquet/util/buffer-test.cc
@@ -28,7 +28,7 @@
 
 using std::string;
 
-namespace parquet_cpp {
+namespace parquet {
 
 class TestBuffer : public ::testing::Test {
 };
@@ -65,4 +65,4 @@ TEST_F(TestBuffer, ResizeOOM) {
 #endif
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/util/buffer.cc
+++ b/src/parquet/util/buffer.cc
@@ -23,7 +23,7 @@
 #include "parquet/exception.h"
 #include "parquet/types.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 Buffer::Buffer(const std::shared_ptr<Buffer>& parent, int64_t offset,
     int64_t size) {
@@ -122,4 +122,4 @@ template class Vector<Int96>;
 template class Vector<ByteArray>;
 template class Vector<FixedLenByteArray>;
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/util/buffer.h
+++ b/src/parquet/util/buffer.h
@@ -27,7 +27,7 @@
 #include "parquet/util/macros.h"
 #include "parquet/util/mem-allocator.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 // ----------------------------------------------------------------------
 // Buffer classes
@@ -164,6 +164,6 @@ class Vector {
   DISALLOW_COPY_AND_ASSIGN(Vector);
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_UTIL_BUFFER_H

--- a/src/parquet/util/cpu-info.cc
+++ b/src/parquet/util/cpu-info.cc
@@ -44,7 +44,7 @@ using boost::algorithm::trim;
 using std::max;
 using std::string;
 
-namespace parquet_cpp {
+namespace parquet {
 
 bool CpuInfo::initialized_ = false;
 int64_t CpuInfo::hardware_flags_ = 0;
@@ -167,4 +167,4 @@ void CpuInfo::EnableFeature(int64_t flag, bool enable) {
   }
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/util/cpu-info.h
+++ b/src/parquet/util/cpu-info.h
@@ -26,7 +26,7 @@
 
 #include "parquet/util/logging.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 /// CpuInfo is an interface to query for cpu information at runtime.  The caller can
 /// ask for the sizes of the caches and what hardware features are supported.
@@ -107,6 +107,6 @@ class CpuInfo {
   static std::string model_name_; // NOLINT
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_UTIL_CPU_INFO_H

--- a/src/parquet/util/hash-util.h
+++ b/src/parquet/util/hash-util.h
@@ -27,7 +27,7 @@
 #include "parquet/util/logging.h"
 #include "parquet/util/sse-util.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 /// Utility class to compute hash values.
 class HashUtil {
@@ -246,6 +246,6 @@ class HashUtil {
   }
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_UTIL_HASH_UTIL_H

--- a/src/parquet/util/input-output-test.cc
+++ b/src/parquet/util/input-output-test.cc
@@ -32,7 +32,7 @@
 #include "parquet/util/output.h"
 #include "parquet/util/test-common.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 TEST(TestInMemoryOutputStream, Basics) {
   std::unique_ptr<InMemoryOutputStream> stream(new InMemoryOutputStream(8));
@@ -122,4 +122,4 @@ TYPED_TEST(TestFileReaders, BadSeek) {
   ASSERT_THROW(this->source.Seek(this->filesize_ + 1), ParquetException);
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/util/input.cc
+++ b/src/parquet/util/input.cc
@@ -25,7 +25,7 @@
 #include "parquet/exception.h"
 #include "parquet/util/buffer.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 // ----------------------------------------------------------------------
 // RandomAccessSource
@@ -233,4 +233,4 @@ void InMemoryInputStream::Advance(int64_t num_bytes) {
   offset_ += num_bytes;
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/util/input.h
+++ b/src/parquet/util/input.h
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-namespace parquet_cpp {
+namespace parquet {
 
 class Buffer;
 
@@ -183,6 +183,6 @@ class InMemoryInputStream : public InputStream {
   int64_t offset_;
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_UTIL_INPUT_H

--- a/src/parquet/util/logging.h
+++ b/src/parquet/util/logging.h
@@ -20,7 +20,7 @@
 
 #include <iostream>
 
-namespace parquet_cpp {
+namespace parquet {
 
 // Stubbed versions of macros defined in glog/logging.h, intended for
 // environments where glog headers aren't available.
@@ -34,7 +34,7 @@ namespace parquet_cpp {
 #define PARQUET_ERROR 2
 #define PARQUET_FATAL 3
 
-#define PARQUET_LOG_INTERNAL(level) parquet_cpp::internal::CerrLog(level)
+#define PARQUET_LOG_INTERNAL(level) parquet::internal::CerrLog(level)
 #define PARQUET_LOG(level) PARQUET_LOG_INTERNAL(PARQUET_##level)
 
 #define PARQUET_CHECK(condition) \
@@ -43,13 +43,13 @@ namespace parquet_cpp {
 #ifdef NDEBUG
 #define PARQUET_DFATAL PARQUET_WARNING
 
-#define DCHECK(condition) while (false) parquet_cpp::internal::NullLog()
-#define DCHECK_EQ(val1, val2) while (false) parquet_cpp::internal::NullLog()
-#define DCHECK_NE(val1, val2) while (false) parquet_cpp::internal::NullLog()
-#define DCHECK_LE(val1, val2) while (false) parquet_cpp::internal::NullLog()
-#define DCHECK_LT(val1, val2) while (false) parquet_cpp::internal::NullLog()
-#define DCHECK_GE(val1, val2) while (false) parquet_cpp::internal::NullLog()
-#define DCHECK_GT(val1, val2) while (false) parquet_cpp::internal::NullLog()
+#define DCHECK(condition) while (false) parquet::internal::NullLog()
+#define DCHECK_EQ(val1, val2) while (false) parquet::internal::NullLog()
+#define DCHECK_NE(val1, val2) while (false) parquet::internal::NullLog()
+#define DCHECK_LE(val1, val2) while (false) parquet::internal::NullLog()
+#define DCHECK_LT(val1, val2) while (false) parquet::internal::NullLog()
+#define DCHECK_GE(val1, val2) while (false) parquet::internal::NullLog()
+#define DCHECK_GT(val1, val2) while (false) parquet::internal::NullLog()
 
 #else
 #define PARQUET_DFATAL PARQUET_FATAL
@@ -104,6 +104,6 @@ class CerrLog {
 
 } // namespace internal
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_UTIL_LOGGING_H

--- a/src/parquet/util/mem-allocator-test.cc
+++ b/src/parquet/util/mem-allocator-test.cc
@@ -20,7 +20,7 @@
 #include "parquet/exception.h"
 #include "parquet/util/mem-allocator.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 TEST(TestAllocator, AllocateFree) {
   TrackingAllocator allocator;
@@ -64,4 +64,4 @@ TEST(TestAllocator, TotalMax) {
   ASSERT_EQ(110, allocator.MaxMemory());
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/util/mem-allocator.cc
+++ b/src/parquet/util/mem-allocator.cc
@@ -21,7 +21,7 @@
 
 #include "parquet/exception.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 MemoryAllocator::~MemoryAllocator() {}
 
@@ -58,4 +58,4 @@ MemoryAllocator* default_allocator() {
   return &default_allocator;
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/util/mem-allocator.h
+++ b/src/parquet/util/mem-allocator.h
@@ -21,7 +21,7 @@
 #include "parquet/util/logging.h"
 #include "parquet/util/bit-util.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 class MemoryAllocator {
  public:
@@ -55,6 +55,6 @@ class TrackingAllocator: public MemoryAllocator {
   int64_t max_memory_;
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_UTIL_MEMORY_POOL_H

--- a/src/parquet/util/mem-pool-test.cc
+++ b/src/parquet/util/mem-pool-test.cc
@@ -26,7 +26,7 @@
 #include "parquet/util/mem-pool.h"
 #include "parquet/util/bit-util.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 // Utility class to call private functions on MemPool.
 class MemPoolTest {
@@ -244,4 +244,4 @@ TEST(MemPoolTest, FragmentationOverhead) {
   p.FreeAll();
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/util/mem-pool.cc
+++ b/src/parquet/util/mem-pool.cc
@@ -29,7 +29,7 @@
 
 #include "parquet/util/bit-util.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 const int MemPool::INITIAL_CHUNK_SIZE;
 const int MemPool::MAX_CHUNK_SIZE;
@@ -232,4 +232,4 @@ bool MemPool::CheckIntegrity(bool current_chunk_empty) {
   return true;
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/util/mem-pool.h
+++ b/src/parquet/util/mem-pool.h
@@ -31,7 +31,7 @@
 #include "parquet/util/bit-util.h"
 #include "parquet/util/mem-allocator.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 /// A MemPool maintains a list of memory chunks from which it allocates memory
 /// in response to Allocate() calls;
@@ -206,6 +206,6 @@ class MemPool {
   }
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_UTIL_MEM_POOL_H

--- a/src/parquet/util/output.cc
+++ b/src/parquet/util/output.cc
@@ -23,7 +23,7 @@
 #include "parquet/exception.h"
 #include "parquet/util/buffer.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 // ----------------------------------------------------------------------
 // In-memory output stream
@@ -64,4 +64,4 @@ std::shared_ptr<Buffer> InMemoryOutputStream::GetBuffer() {
   return result;
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/util/output.h
+++ b/src/parquet/util/output.h
@@ -24,7 +24,7 @@
 #include "parquet/util/macros.h"
 #include "parquet/util/mem-allocator.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 class Buffer;
 class ResizableBuffer;
@@ -74,6 +74,6 @@ class InMemoryOutputStream : public OutputStream {
   DISALLOW_COPY_AND_ASSIGN(InMemoryOutputStream);
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_UTIL_OUTPUT_H

--- a/src/parquet/util/rle-encoding.h
+++ b/src/parquet/util/rle-encoding.h
@@ -27,7 +27,7 @@
 #include "parquet/util/bit-stream-utils.inline.h"
 #include "parquet/util/bit-util.h"
 
-namespace parquet_cpp {
+namespace parquet {
 
 /// Utility classes to do run length encoding (RLE) for fixed bit width values.  If runs
 /// are sufficiently long, RLE is used, otherwise, the values are just bit-packed
@@ -441,6 +441,6 @@ inline void RleEncoder::Clear() {
   bit_writer_.Clear();
 }
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_UTIL_RLE_ENCODING_H

--- a/src/parquet/util/rle-test.cc
+++ b/src/parquet/util/rle-test.cc
@@ -34,7 +34,7 @@
 
 using std::vector;
 
-namespace parquet_cpp {
+namespace parquet {
 
 const int MAX_WIDTH = 32;
 
@@ -437,4 +437,4 @@ TEST(BitRle, Overflow) {
   }
 }
 
-} // namespace parquet_cpp
+} // namespace parquet

--- a/src/parquet/util/sse-util.h
+++ b/src/parquet/util/sse-util.h
@@ -25,7 +25,7 @@
 #include <emmintrin.h>
 #endif
 
-namespace parquet_cpp {
+namespace parquet {
 
 
 /// This class contains constants useful for text processing with SSE4.2 intrinsics.
@@ -243,6 +243,6 @@ static inline int64_t POPCNT_popcnt_u64(uint64_t a) {
 
 #endif // PARQUET_USE_SSE
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif //  PARQUET_UTIL_SSE_UTIL_H

--- a/src/parquet/util/stopwatch.h
+++ b/src/parquet/util/stopwatch.h
@@ -24,7 +24,7 @@
 #include <iostream>
 #include <ctime>
 
-namespace parquet_cpp {
+namespace parquet {
 
 class StopWatch {
  public:
@@ -48,6 +48,6 @@ class StopWatch {
   struct timeval  start_time;
 };
 
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif

--- a/src/parquet/util/test-common.h
+++ b/src/parquet/util/test-common.h
@@ -27,7 +27,7 @@
 
 using std::vector;
 
-namespace parquet_cpp {
+namespace parquet {
 
 namespace test {
 
@@ -192,6 +192,6 @@ void random_byte_array(int n, uint32_t seed, uint8_t *buf,
 }
 
 } // namespace test
-} // namespace parquet_cpp
+} // namespace parquet
 
 #endif // PARQUET_UTIL_TEST_COMMON_H


### PR DESCRIPTION
cc @asandryh @majetideepak let me know if this would be problematic in some way. Thank you