### PR TITLE
PARQUET-436: Implement basic Write Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,10 +317,13 @@ endif()
 
 set(LIBPARQUET_SRCS
   src/parquet/column/reader.cc
+  src/parquet/column/writer.cc
   src/parquet/column/scanner.cc
 
   src/parquet/file/reader.cc
   src/parquet/file/reader-internal.cc
+  src/parquet/file/writer.cc
+  src/parquet/file/writer-internal.cc
 
   src/parquet/schema/converter.cc
   src/parquet/schema/descriptor.cc

--- a/src/parquet/column/CMakeLists.txt
+++ b/src/parquet/column/CMakeLists.txt
@@ -24,5 +24,6 @@ install(FILES
   DESTINATION include/parquet/column)
 
 ADD_PARQUET_TEST(column-reader-test)
+ADD_PARQUET_TEST(column-writer-test)
 ADD_PARQUET_TEST(levels-test)
 ADD_PARQUET_TEST(scanner-test)

--- a/src/parquet/column/column-writer-test.cc
+++ b/src/parquet/column/column-writer-test.cc
@@ -34,17 +34,17 @@ namespace test {
 
 class TestPrimitiveWriter : public ::testing::Test {
  public:
-  void SetUpSchemaRequiredNonRepeated() {
+  void SetUpSchemaRequired() {
     node_ = PrimitiveNode::Make("int64", Repetition::REQUIRED, Type::INT64);
     schema_ = std::make_shared<ColumnDescriptor>(node_, 0, 0);
   }
 
-  void SetUpSchemaOptionalNonRepeated() {
-    node_ = PrimitiveNode::Make("int64", Repetition::REQUIRED, Type::INT64);
+  void SetUpSchemaOptional() {
+    node_ = PrimitiveNode::Make("int64", Repetition::OPTIONAL, Type::INT64);
     schema_ = std::make_shared<ColumnDescriptor>(node_, 1, 0);
   }
 
-  void SetUpSchemaOptionalRepeated() {
+  void SetUpSchemaRepeated() {
     node_ = PrimitiveNode::Make("int64", Repetition::REPEATED, Type::INT64);
     schema_ = std::make_shared<ColumnDescriptor>(node_, 1, 1);
   }
@@ -54,7 +54,7 @@ class TestPrimitiveWriter : public ::testing::Test {
     definition_levels_out_.resize(100);
     repetition_levels_out_.resize(100);
 
-    SetUpSchemaRequiredNonRepeated();
+    SetUpSchemaRequired();
   }
 
   std::unique_ptr<Int64Reader> BuildReader() {
@@ -104,14 +104,14 @@ TEST_F(TestPrimitiveWriter, RequiredNonRepeated) {
   writer->Close();
 
   ReadColumn();
-  ASSERT_EQ(values_read_, 100);
-  ASSERT_EQ(values_out_, values);
+  ASSERT_EQ(100, values_read_);
+  ASSERT_EQ(values, values_out_);
 }
 
 TEST_F(TestPrimitiveWriter, OptionalNonRepeated) {
   // Optional and non-repeated, with definition levels
   // but no repetition levels
-  SetUpSchemaOptionalNonRepeated();
+  SetUpSchemaOptional();
 
   std::vector<int64_t> values(100, 128);
   std::vector<int16_t> definition_levels(100, 1);
@@ -122,15 +122,15 @@ TEST_F(TestPrimitiveWriter, OptionalNonRepeated) {
   writer->Close();
 
   ReadColumn();
-  ASSERT_EQ(values_read_, 99);
+  ASSERT_EQ(99, values_read_);
   values_out_.resize(99);
   values.resize(99);
-  ASSERT_EQ(values_out_, values);
+  ASSERT_EQ(values, values_out_);
 }
 
 TEST_F(TestPrimitiveWriter, OptionalRepeated) {
   // Optional and repeated, so definition and repetition levels
-  SetUpSchemaOptionalRepeated();
+  SetUpSchemaRepeated();
 
   std::vector<int64_t> values(100, 128);
   std::vector<int16_t> definition_levels(100, 1);
@@ -143,10 +143,10 @@ TEST_F(TestPrimitiveWriter, OptionalRepeated) {
   writer->Close();
 
   ReadColumn();
-  ASSERT_EQ(values_read_, 99);
+  ASSERT_EQ(99, values_read_);
   values_out_.resize(99);
   values.resize(99);
-  ASSERT_EQ(values_out_, values);
+  ASSERT_EQ(values, values_out_);
 }
 
 TEST_F(TestPrimitiveWriter, RequiredTooFewRows) {
@@ -167,7 +167,7 @@ TEST_F(TestPrimitiveWriter, RequiredTooMany) {
 
 TEST_F(TestPrimitiveWriter, OptionalRepeatedTooFewRows) {
   // Optional and repeated, so definition and repetition levels
-  SetUpSchemaOptionalRepeated();
+  SetUpSchemaRepeated();
 
   std::vector<int64_t> values(100, 128);
   std::vector<int16_t> definition_levels(100, 1);
@@ -191,9 +191,9 @@ TEST_F(TestPrimitiveWriter, RequiredNonRepeatedLargeChunk) {
 
   // Just read the first 100 to ensure we could read it back in
   ReadColumn();
-  ASSERT_EQ(values_read_, 100);
+  ASSERT_EQ(100, values_read_);
   values.resize(100);
-  ASSERT_EQ(values_out_, values);
+  ASSERT_EQ(values, values_out_);
 }
 
 } // namespace test

--- a/src/parquet/column/column-writer-test.cc
+++ b/src/parquet/column/column-writer-test.cc
@@ -50,10 +50,15 @@ class TestPrimitiveWriter : public ::testing::Test {
   }
 
   void SetUp() {
+    values_out.resize(100);
+    definition_levels_out.resize(100);
+    repetition_levels_out.resize(100);
+
     SetUpSchemaRequiredNonRepeated();
   }
 
-  std::unique_ptr<Int64Reader> BuildReader(const std::shared_ptr<Buffer>& buffer) {
+  std::unique_ptr<Int64Reader> BuildReader() {
+    auto buffer = sink_->GetBuffer();
     std::unique_ptr<InMemoryInputStream> source(new InMemoryInputStream(buffer));
     std::unique_ptr<SerializedPageReader> page_reader(
         new SerializedPageReader(std::move(source), Compression::UNCOMPRESSED));
@@ -61,76 +66,82 @@ class TestPrimitiveWriter : public ::testing::Test {
         new Int64Reader(schema.get(), std::move(page_reader)));
   }
 
-  std::unique_ptr<Int64Writer> BuildWriter(OutputStream* sink) {
+  std::unique_ptr<Int64Writer> BuildWriter() {
+    sink_.reset(new InMemoryOutputStream());
     std::unique_ptr<SerializedPageWriter> pager(
-        new SerializedPageWriter(sink, Compression::UNCOMPRESSED));
+        new SerializedPageWriter(sink_.get(), Compression::UNCOMPRESSED));
     return std::unique_ptr<Int64Writer>(new Int64Writer(schema.get(), std::move(pager)));
   }
+
+  void ReadColumn() {
+    auto reader = BuildReader();
+    reader->ReadBatch(values_out.size(), definition_levels_out.data(),
+        repetition_levels_out.data(), values_out.data(), &values_read);
+  }
+
+ protected:
+  int64_t values_read;
+  
+  // Output buffers
+  std::vector<int64_t> values_out;
+  std::vector<int16_t> definition_levels_out;
+  std::vector<int16_t> repetition_levels_out;
 
  private:
   NodePtr node;
   std::shared_ptr<ColumnDescriptor> schema;
+  std::unique_ptr<InMemoryOutputStream> sink_;
 };
 
-TEST_F(TestPrimitiveWriter, WriteReadLoopSinglePage) {
-  // Small dataset that should fit inside a single page
-  std::vector<int64_t> values(100);
-  std::fill(values.begin(), values.end(), 128);
-  std::vector<int16_t> definition_levels(100);
-  std::fill(definition_levels.begin(), definition_levels.end(), 1);
-  definition_levels[1] = 0;
-  std::vector<int16_t> repetition_levels(100);
-  std::fill(repetition_levels.begin(), repetition_levels.end(), 0);
-
-  // Output buffers
-  std::vector<int64_t> values_out(100);
-  std::vector<int16_t> definition_levels_out(100);
-  std::vector<int16_t> repetition_levels_out(100);
+TEST_F(TestPrimitiveWriter, RequiredNonRepeated) {
+  std::vector<int64_t> values(100, 128);
 
   // Test case 1: required and non-repeated, so no definition or repetition levels
-  std::unique_ptr<InMemoryOutputStream> sink(new InMemoryOutputStream());
-  std::unique_ptr<Int64Writer> writer = BuildWriter(sink.get());
+  std::unique_ptr<Int64Writer> writer = BuildWriter();
   writer->WriteBatch(values.size(), nullptr, nullptr, values.data());
   writer->Close();
 
-  std::unique_ptr<Int64Reader> reader = BuildReader(sink->GetBuffer());
-  int64_t values_read = 0;
-  reader->ReadBatch(values.size(), definition_levels_out.data(),
-      repetition_levels_out.data(), values_out.data(), &values_read);
+  ReadColumn();
   ASSERT_EQ(values_read, 100);
   ASSERT_EQ(values_out, values);
+}
 
-  // Test case 2: optional and non-repeated, with definition levels
+TEST_F(TestPrimitiveWriter, OptionalNonRepeated) {
+  // Optional and non-repeated, with definition levels
   // but no repetition levels
   SetUpSchemaOptionalNonRepeated();
-  sink.reset(new InMemoryOutputStream());
-  writer = BuildWriter(sink.get());
+  
+  std::vector<int64_t> values(100, 128);
+  std::vector<int16_t> definition_levels(100, 1);
+  definition_levels[1] = 0;
+  std::vector<int64_t> values_expected(99, 128);
+  
+  auto writer = BuildWriter();
   writer->WriteBatch(values.size(), definition_levels.data(), nullptr, values.data());
   writer->Close();
 
-  reader = BuildReader(sink->GetBuffer());
-  values_read = 0;
-  reader->ReadBatch(values.size(), definition_levels_out.data(),
-      repetition_levels_out.data(), values_out.data(), &values_read);
+  ReadColumn();
   ASSERT_EQ(values_read, 99);
-  std::vector<int64_t> values_expected(99);
-  std::fill(values_expected.begin(), values_expected.end(), 128);
   values_out.resize(99);
   ASSERT_EQ(values_out, values_expected);
+}
 
-  // Test case 3: optional and repeated, so definition and repetition levels
+TEST_F(TestPrimitiveWriter, OptionalRepeated) {
+  // Optional and repeated, so definition and repetition levels
   SetUpSchemaOptionalRepeated();
-  sink.reset(new InMemoryOutputStream());
-  writer = BuildWriter(sink.get());
+
+  std::vector<int64_t> values(100, 128);
+  std::vector<int16_t> definition_levels(100, 1);
+  definition_levels[1] = 0;
+  std::vector<int16_t> repetition_levels(100, 0);
+  std::vector<int64_t> values_expected(99, 128);
+
+  auto writer = BuildWriter();
   writer->WriteBatch(values.size(), definition_levels.data(),
       repetition_levels.data(), values.data());
   writer->Close();
 
-  reader = BuildReader(sink->GetBuffer());
-  values_read = 0;
-  values_out.resize(100);
-  reader->ReadBatch(values.size(), definition_levels_out.data(),
-      repetition_levels_out.data(), values_out.data(), &values_read);
+  ReadColumn();
   ASSERT_EQ(values_read, 99);
   values_out.resize(99);
   ASSERT_EQ(values_out, values_expected);

--- a/src/parquet/column/column-writer-test.cc
+++ b/src/parquet/column/column-writer-test.cc
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "parquet/file/reader-internal.h"
+#include "parquet/file/writer-internal.h"
+#include "parquet/column/reader.h"
+#include "parquet/column/writer.h"
+#include "parquet/util/input.h"
+#include "parquet/util/output.h"
+#include "parquet/types.h"
+
+namespace parquet {
+
+using schema::NodePtr;
+using schema::PrimitiveNode;
+
+namespace test {
+
+class TestPrimitiveWriter : public ::testing::Test {
+ public:
+  void SetUp() {
+    node = PrimitiveNode::Make("int64", Repetition::REQUIRED, Type::INT64);  
+    schema = std::make_shared<ColumnDescriptor>(node, 0, 0);
+  }
+
+  std::unique_ptr<Int64Reader> BuildReader(const std::shared_ptr<Buffer>& buffer) {
+    std::unique_ptr<InMemoryInputStream> source(new InMemoryInputStream(buffer));
+    std::unique_ptr<SerializedPageReader> page_reader(new SerializedPageReader(std::move(source), Compression::UNCOMPRESSED));
+    return std::unique_ptr<Int64Reader>(new Int64Reader(schema.get(), std::move(page_reader)));
+  }
+
+  std::unique_ptr<Int64Writer> BuildWriter(OutputStream* sink) {
+    std::unique_ptr<SerializedPageWriter> pager(new SerializedPageWriter(sink, Compression::UNCOMPRESSED));
+    return std::unique_ptr<Int64Writer>(new Int64Writer(schema.get(), std::move(pager)));
+  }
+
+ private:
+  NodePtr node;
+  std::shared_ptr<ColumnDescriptor> schema;
+};
+
+TEST_F(TestPrimitiveWriter, WriteReadLoopSinglePage) {
+  // Small dataset that should fit inside a single page
+  std::vector<int64_t> values(100);
+  std::fill(values.begin(), values.end(), 128);
+  
+  // Test case 1: required and non-repeated, so no definition or repetition levels
+  InMemoryOutputStream sink;
+  std::unique_ptr<Int64Writer> writer = BuildWriter(&sink);
+  writer->WriteBatch(values.size(), nullptr, nullptr, values.data());
+  writer->Close();
+  writer.reset();
+
+  std::unique_ptr<Int64Reader> reader = BuildReader(sink.GetBuffer());
+  std::vector<int64_t> values_out(100);
+  std::vector<int16_t> definition_levels(100);
+  std::vector<int16_t> repetition_levels(100);
+  int64_t values_read = 0;
+  reader->ReadBatch(values.size(), definition_levels.data(), repetition_levels.data(), values_out.data(), &values_read);
+  reader.reset();
+  ASSERT_EQ(values_read, 100);
+  ASSERT_EQ(values_out, values);
+  
+  // Test case 2: optional and non-repeated, with definition level but not repetition levels
+  // TODO
+
+  // Test case 3: optional and repeated, so definition and repetition levels 
+  // TODO
+}
+
+} // namespace test
+} // namespace parquet
+
+

--- a/src/parquet/column/column-writer-test.cc
+++ b/src/parquet/column/column-writer-test.cc
@@ -68,7 +68,6 @@ TEST_F(TestPrimitiveWriter, WriteReadLoopSinglePage) {
   // Small dataset that should fit inside a single page
   std::vector<int64_t> values(100);
   std::fill(values.begin(), values.end(), 128);
-  values[1] = -1;
   std::vector<int16_t> definition_levels(100);
   std::fill(definition_levels.begin(), definition_levels.end(), 1);
   definition_levels[1] = 0;
@@ -96,15 +95,17 @@ TEST_F(TestPrimitiveWriter, WriteReadLoopSinglePage) {
   sink.reset(new InMemoryOutputStream());
   writer = BuildWriter(sink.get());
   // TODO: Implement definition_levels
-  // writer->WriteBatch(values.size(), definition_levels.data(), nullptr, values.data());
-  // writer->Close();
+  writer->WriteBatch(values.size(), definition_levels.data(), nullptr, values.data());
+  writer->Close();
   
-  // reader = BuildReader(sink->GetBuffer());
-  // values_read = 0;
-  // reader->ReadBatch(values.size(), definition_levels_out.data(), repetition_levels_out.data(), values_out.data(), &values_read);
-  // ASSERT_EQ(values_read, 99);
-  // ASSERT_EQ(values_out, values);
-  // TODO: values is not the expected data
+  reader = BuildReader(sink->GetBuffer());
+  values_read = 0;
+  reader->ReadBatch(values.size(), definition_levels_out.data(), repetition_levels_out.data(), values_out.data(), &values_read);
+  ASSERT_EQ(values_read, 99);
+  std::vector<int64_t> values_expected(99);
+  std::fill(values_expected.begin(), values_expected.end(), 128);
+  values_out.resize(99);
+  ASSERT_EQ(values_out, values_expected);
 
   // Test case 3: optional and repeated, so definition and repetition levels 
   // TODO

--- a/src/parquet/column/column-writer-test.cc
+++ b/src/parquet/column/column-writer-test.cc
@@ -69,7 +69,7 @@ class TestPrimitiveWriter : public ::testing::Test {
   std::unique_ptr<Int64Writer> BuildWriter(int64_t output_size = 100) {
     sink_.reset(new InMemoryOutputStream());
     std::unique_ptr<SerializedPageWriter> pager(
-        new SerializedPageWriter(sink_.get(), Compression::UNCOMPRESSED));
+        new SerializedPageWriter(sink_.get(), Compression::UNCOMPRESSED, &metadata));
     return std::unique_ptr<Int64Writer>(new Int64Writer(schema.get(), std::move(pager),
           output_size));
   }
@@ -90,6 +90,7 @@ class TestPrimitiveWriter : public ::testing::Test {
 
  private:
   NodePtr node;
+  format::ColumnChunk metadata;
   std::shared_ptr<ColumnDescriptor> schema;
   std::unique_ptr<InMemoryOutputStream> sink_;
 };

--- a/src/parquet/column/page.h
+++ b/src/parquet/column/page.h
@@ -210,6 +210,15 @@ class PageReader {
   virtual std::shared_ptr<Page> NextPage() = 0;
 };
 
+class PageWriter {
+ public:
+  virtual ~PageWriter() {}
+
+  virtual void Close() = 0;
+
+  // TODO: WritePage
+};
+
 } // namespace parquet
 
 #endif // PARQUET_COLUMN_PAGE_H

--- a/src/parquet/column/page.h
+++ b/src/parquet/column/page.h
@@ -216,7 +216,7 @@ class PageWriter {
 
   virtual void Close() = 0;
 
-  virtual void WriteDataPage(int32_t num_rows, int32_t num_values, int32_t num_nulls,
+  virtual int64_t WriteDataPage(int32_t num_rows, int32_t num_values, int32_t num_nulls,
       const std::shared_ptr<Buffer>& definition_levels,
       Encoding::type definition_level_encoding,
       const std::shared_ptr<Buffer>& repetition_levels,

--- a/src/parquet/column/page.h
+++ b/src/parquet/column/page.h
@@ -216,7 +216,7 @@ class PageWriter {
 
   virtual void Close() = 0;
 
-  virtual int64_t WriteDataPage(int32_t num_rows, int32_t num_values, int32_t num_nulls,
+  virtual int64_t WriteDataPage(int32_t num_rows, int32_t num_values,
       const std::shared_ptr<Buffer>& definition_levels,
       Encoding::type definition_level_encoding,
       const std::shared_ptr<Buffer>& repetition_levels,

--- a/src/parquet/column/page.h
+++ b/src/parquet/column/page.h
@@ -216,7 +216,10 @@ class PageWriter {
 
   virtual void Close() = 0;
 
-  // TODO: WritePage
+  virtual void WriteDataPage(int32_t num_rows, int32_t num_values, int32_t num_nulls,
+      const std::shared_ptr<Buffer>& definition_levels, Encoding::type definition_level_encoding,
+      const std::shared_ptr<Buffer>& repetition_levels, Encoding::type repetition_level_encoding,
+      const std::shared_ptr<Buffer>& values, Encoding::type encoding) = 0;
 };
 
 } // namespace parquet

--- a/src/parquet/column/page.h
+++ b/src/parquet/column/page.h
@@ -217,8 +217,10 @@ class PageWriter {
   virtual void Close() = 0;
 
   virtual void WriteDataPage(int32_t num_rows, int32_t num_values, int32_t num_nulls,
-      const std::shared_ptr<Buffer>& definition_levels, Encoding::type definition_level_encoding,
-      const std::shared_ptr<Buffer>& repetition_levels, Encoding::type repetition_level_encoding,
+      const std::shared_ptr<Buffer>& definition_levels,
+      Encoding::type definition_level_encoding,
+      const std::shared_ptr<Buffer>& repetition_levels,
+      Encoding::type repetition_level_encoding,
       const std::shared_ptr<Buffer>& values, Encoding::type encoding) = 0;
 };
 

--- a/src/parquet/column/reader.cc
+++ b/src/parquet/column/reader.cc
@@ -224,4 +224,16 @@ std::shared_ptr<ColumnReader> ColumnReader::Make(
   return std::shared_ptr<ColumnReader>(nullptr);
 }
 
+// ----------------------------------------------------------------------
+// Instantiate templated classes
+
+template class TypedColumnReader<Type::BOOLEAN>;
+template class TypedColumnReader<Type::INT32>;
+template class TypedColumnReader<Type::INT64>;
+template class TypedColumnReader<Type::INT96>;
+template class TypedColumnReader<Type::FLOAT>;
+template class TypedColumnReader<Type::DOUBLE>;
+template class TypedColumnReader<Type::BYTE_ARRAY>;
+template class TypedColumnReader<Type::FIXED_LEN_BYTE_ARRAY>;
+
 } // namespace parquet

--- a/src/parquet/column/reader.h
+++ b/src/parquet/column/reader.h
@@ -108,7 +108,7 @@ class TypedColumnReader : public ColumnReader {
   typedef typename type_traits<TYPE>::value_type T;
 
   TypedColumnReader(const ColumnDescriptor* schema,
-      std::unique_ptr<PageReader> pager, MemoryAllocator* allocator) :
+      std::unique_ptr<PageReader> pager, MemoryAllocator* allocator = default_allocator()) :
       ColumnReader(schema, std::move(pager), allocator),
       current_decoder_(NULL) {
   }

--- a/src/parquet/column/reader.h
+++ b/src/parquet/column/reader.h
@@ -108,7 +108,8 @@ class TypedColumnReader : public ColumnReader {
   typedef typename type_traits<TYPE>::value_type T;
 
   TypedColumnReader(const ColumnDescriptor* schema,
-      std::unique_ptr<PageReader> pager, MemoryAllocator* allocator = default_allocator()) :
+      std::unique_ptr<PageReader> pager,
+      MemoryAllocator* allocator = default_allocator()) :
       ColumnReader(schema, std::move(pager), allocator),
       current_decoder_(NULL) {
   }

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/column/writer.h"
+
+namespace parquet {
+
+ColumnWriter::ColumnWriter(const ColumnDescriptor* descr, std::unique_ptr<PageWriter> pager,
+        MemoryAllocator* allocator) :  descr_(descr), pager_(std::move(pager)), allocator_(allocator) {}
+
+} // namespace parquet

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -17,9 +17,103 @@
 
 #include "parquet/column/writer.h"
 
+#include "parquet/encodings/plain-encoding.h"
+
 namespace parquet {
 
+// ----------------------------------------------------------------------
+// ColumnWriter
+
 ColumnWriter::ColumnWriter(const ColumnDescriptor* descr, std::unique_ptr<PageWriter> pager,
-        MemoryAllocator* allocator) :  descr_(descr), pager_(std::move(pager)), allocator_(allocator) {}
+        MemoryAllocator* allocator) :  descr_(descr), pager_(std::move(pager)), allocator_(allocator),
+        num_buffered_values_(0), num_buffered_encoded_values_(0), 
+        // TODO: Get from WriterProperties
+        num_buffered_values_next_size_check_(DEFAULT_MINIMUM_RECORD_COUNT_FOR_CHECK),
+        num_rows_(0)
+  {
+  // TODO: Initialize level encoders already here
+  InitSinks();
+}
+
+void ColumnWriter::InitSinks() {
+  definition_levels_sink_ = std::unique_ptr<InMemoryOutputStream>(new InMemoryOutputStream()); 
+  repetition_levels_sink_ = std::unique_ptr<InMemoryOutputStream>(new InMemoryOutputStream()); 
+  values_sink_ = std::unique_ptr<InMemoryOutputStream>(new InMemoryOutputStream()); 
+}
+
+void ColumnWriter::WriteNewPage() {
+  // TODO: Currently we only support writing DataPages
+  std::shared_ptr<Buffer> definition_levels = definition_levels_sink_->GetBuffer();
+  std::shared_ptr<Buffer> repetition_levels = repetition_levels_sink_->GetBuffer();
+  std::shared_ptr<Buffer> values = values_sink_->GetBuffer();
+
+  // TODO: Encodings are hard-coded
+  pager_->WriteDataPage(num_buffered_values_, num_buffered_encoded_values_,
+      // num_nulls = Difference of enocoded and actual values
+      num_buffered_values_ - num_buffered_encoded_values_,
+      definition_levels, Encoding::RLE,
+      repetition_levels, Encoding::BIT_PACKED,
+      values, Encoding::PLAIN);
+
+  // Re-initialize the sinks as GetBuffer made them invalid.
+  InitSinks();
+}
+
+void ColumnWriter::Close() {
+  // TODO: no-op if already closed
+  // TODO: Check if enough rows were written
+ 
+  // Write all outstanding data to a new page 
+  if (num_buffered_values_ > 0) {
+    WriteNewPage();
+  }
+
+  pager_->Close();
+}
+
+// ----------------------------------------------------------------------
+// TypedColumnWriter
+
+template <int TYPE>
+TypedColumnWriter<TYPE>::TypedColumnWriter(const ColumnDescriptor* schema,
+      std::unique_ptr<PageWriter> pager, MemoryAllocator* allocator) :
+      ColumnWriter(schema, std::move(pager), allocator) {
+  // Get decoder type from WriterProperties
+  current_encoder_ = std::unique_ptr<EncoderType>(new PlainEncoder<TYPE>(schema, allocator));
+}
+
+// ----------------------------------------------------------------------
+// Dynamic column writer constructor
+
+std::shared_ptr<ColumnWriter> ColumnWriter::Make(
+    const ColumnDescriptor* descr,
+    std::unique_ptr<PageWriter> pager,
+    MemoryAllocator* allocator) {
+  switch (descr->physical_type()) {
+    case Type::BOOLEAN:
+      return std::make_shared<BoolWriter>(descr, std::move(pager), allocator);
+    case Type::INT32:
+      return std::make_shared<Int32Writer>(descr, std::move(pager), allocator);
+    case Type::INT64:
+      return std::make_shared<Int64Writer>(descr, std::move(pager), allocator);
+    case Type::INT96:
+      return std::make_shared<Int96Writer>(descr, std::move(pager), allocator);
+    case Type::FLOAT:
+      return std::make_shared<FloatWriter>(descr, std::move(pager), allocator);
+    case Type::DOUBLE:
+      return std::make_shared<DoubleWriter>(descr, std::move(pager), allocator);
+    case Type::BYTE_ARRAY:
+      return std::make_shared<ByteArrayWriter>(descr, std::move(pager), allocator);
+    case Type::FIXED_LEN_BYTE_ARRAY:
+      return std::make_shared<FixedLenByteArrayWriter>(descr,
+          std::move(pager), allocator);
+    default:
+      ParquetException::NYI("type reader not implemented");
+  }
+  // Unreachable code, but supress compiler warning
+  return std::shared_ptr<ColumnWriter>(nullptr);
+}
+
+
 
 } // namespace parquet

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -30,10 +30,7 @@ ColumnWriter::ColumnWriter(const ColumnDescriptor* descr,
     descr_(descr), pager_(std::move(pager)), expected_rows_(expected_rows),
     allocator_(allocator),
     num_buffered_values_(0), num_buffered_encoded_values_(0),
-    // TODO: Get from WriterProperties
-    num_buffered_values_next_size_check_(DEFAULT_MINIMUM_RECORD_COUNT_FOR_CHECK),
     num_rows_(0), total_bytes_written_(0) {
-  // TODO: Initialize level encoders already here
   InitSinks();
 }
 

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -167,6 +167,17 @@ std::shared_ptr<ColumnWriter> ColumnWriter::Make(
   return std::shared_ptr<ColumnWriter>(nullptr);
 }
 
+// ----------------------------------------------------------------------
+// Instantiate templated classes
+
+template class TypedColumnWriter<Type::BOOLEAN>;
+template class TypedColumnWriter<Type::INT32>;
+template class TypedColumnWriter<Type::INT64>;
+template class TypedColumnWriter<Type::INT96>;
+template class TypedColumnWriter<Type::FLOAT>;
+template class TypedColumnWriter<Type::DOUBLE>;
+template class TypedColumnWriter<Type::BYTE_ARRAY>;
+template class TypedColumnWriter<Type::FIXED_LEN_BYTE_ARRAY>;
 
 
 } // namespace parquet

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -86,7 +86,7 @@ void ColumnWriter::WriteNewPage() {
         descr_->max_repetition_level());
   }
 
-  // TODO: Encodings are hard-coded
+  // TODO(PARQUET-590): Encodings are hard-coded
   int64_t bytes_written = pager_->WriteDataPage(num_buffered_values_, num_buffered_encoded_values_,
       definition_levels, Encoding::RLE,
       repetition_levels, Encoding::RLE,
@@ -123,7 +123,7 @@ TypedColumnWriter<TYPE>::TypedColumnWriter(const ColumnDescriptor* schema,
       std::unique_ptr<PageWriter> pager, int64_t expected_rows,
       MemoryAllocator* allocator) :
       ColumnWriter(schema, std::move(pager), expected_rows, allocator) {
-  // Get decoder type from WriterProperties
+  // TODO(PARQUET-590) Get decoder type from WriterProperties
   current_encoder_ = std::unique_ptr<EncoderType>(
       new PlainEncoder<TYPE>(schema, allocator));
 }

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -87,10 +87,11 @@ void ColumnWriter::WriteNewPage() {
   }
 
   // TODO(PARQUET-590): Encodings are hard-coded
-  int64_t bytes_written = pager_->WriteDataPage(num_buffered_values_, num_buffered_encoded_values_,
-      definition_levels, Encoding::RLE,
-      repetition_levels, Encoding::RLE,
-      values, Encoding::PLAIN);
+  int64_t bytes_written = pager_->WriteDataPage(num_buffered_values_,
+          num_buffered_encoded_values_,
+          definition_levels, Encoding::RLE,
+          repetition_levels, Encoding::RLE,
+          values, Encoding::PLAIN);
   total_bytes_written_ += bytes_written;
 
   // Re-initialize the sinks as GetBuffer made them invalid.

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -91,8 +91,6 @@ void ColumnWriter::WriteNewPage() {
 
   // TODO: Encodings are hard-coded
   int64_t bytes_written = pager_->WriteDataPage(num_buffered_values_, num_buffered_encoded_values_,
-      // num_nulls = Difference of enocoded and actual values
-      num_buffered_values_ - num_buffered_encoded_values_,
       definition_levels, Encoding::RLE,
       repetition_levels, Encoding::RLE,
       values, Encoding::PLAIN);

--- a/src/parquet/column/writer.h
+++ b/src/parquet/column/writer.h
@@ -100,7 +100,7 @@ class ColumnWriter {
   void InitSinks();
 };
 
-// API to read values from a single column. This is the main client facing API.
+// API to write values to a single column. This is the main client facing API.
 template <int TYPE>
 class TypedColumnWriter : public ColumnWriter {
  public:

--- a/src/parquet/column/writer.h
+++ b/src/parquet/column/writer.h
@@ -161,8 +161,7 @@ inline void TypedColumnWriter<TYPE>::WriteBatch(int64_t num_values, int16_t* def
       }
     }
 
-    // TODO: Write definition levels
-    // WriteDefinitionLevels(num_values, def_levels);
+    WriteDefinitionLevels(num_values, def_levels);
   } else {
     // Required field, write all values
     values_to_write = num_values;

--- a/src/parquet/column/writer.h
+++ b/src/parquet/column/writer.h
@@ -53,12 +53,15 @@ class ColumnWriter {
     return descr_;
   }
 
-  void Close();
+  /**
+   * Closes the ColumnWriter, commits any buffered values to pages.
+   *
+   * @return Total size of the column in bytes
+   */
+  int64_t Close();
 
  protected:
   void WriteNewPage();
-  // virtual void CommitPages() = 0;
-  // virtual void ClosePages() = 0;
 
   // Write multiple definition levels
   void WriteDefinitionLevels(int64_t num_levels, int16_t* levels);
@@ -98,6 +101,8 @@ class ColumnWriter {
 
   // Total number of rows written with this ColumnWriter
   int num_rows_;
+
+  int total_bytes_written_;
 
   std::unique_ptr<InMemoryOutputStream> definition_levels_sink_;
   std::unique_ptr<InMemoryOutputStream> repetition_levels_sink_;

--- a/src/parquet/column/writer.h
+++ b/src/parquet/column/writer.h
@@ -65,16 +65,14 @@ class ColumnWriter {
   // Write multiple repetition levels
   void WriteRepetitionLevels(int64_t num_levels, int16_t* levels);
 
+  std::shared_ptr<Buffer> RleEncodeLevels(const std::shared_ptr<Buffer>& buffer, int16_t max_level);
+
   const ColumnDescriptor* descr_;
 
   std::unique_ptr<PageWriter> pager_;
   std::shared_ptr<Page> current_page_;
 
-  // Not set if full schema for this field has no optional or repeated elements
-  LevelEncoder definition_level_encoder_;
-
-  // Not set for flat schemas.
-  LevelEncoder repetition_level_encoder_;
+  LevelEncoder level_encoder_;
 
   MemoryAllocator* allocator_;
   
@@ -169,8 +167,7 @@ inline void TypedColumnWriter<TYPE>::WriteBatch(int64_t num_values, int16_t* def
 
   // Not present for non-repeated fields
   if (descr_->max_repetition_level() > 0) {
-    // TODO: Write repetition levels
-    // WriteRepetitionLevels(num_values, rep_levels);
+    WriteRepetitionLevels(num_values, rep_levels);
   }
 
   WriteValues(values_to_write, values);

--- a/src/parquet/column/writer.h
+++ b/src/parquet/column/writer.h
@@ -65,7 +65,8 @@ class ColumnWriter {
   // Write multiple repetition levels
   void WriteRepetitionLevels(int64_t num_levels, int16_t* levels);
 
-  std::shared_ptr<Buffer> RleEncodeLevels(const std::shared_ptr<Buffer>& buffer, int16_t max_level);
+  std::shared_ptr<Buffer> RleEncodeLevels(const std::shared_ptr<Buffer>& buffer,
+      int16_t max_level);
 
   const ColumnDescriptor* descr_;
 
@@ -75,7 +76,7 @@ class ColumnWriter {
   LevelEncoder level_encoder_;
 
   MemoryAllocator* allocator_;
-  
+
   // The total number of values stored in the data page. This is the maximum of
   // the number of encoded definition levels or encoded values. For
   // non-repeated, required columns, this is equal to the number of encoded
@@ -97,7 +98,7 @@ class ColumnWriter {
   std::unique_ptr<InMemoryOutputStream> definition_levels_sink_;
   std::unique_ptr<InMemoryOutputStream> repetition_levels_sink_;
   std::unique_ptr<InMemoryOutputStream> values_sink_;
- 
+
  private:
   void InitSinks();
 };
@@ -109,8 +110,9 @@ class TypedColumnWriter : public ColumnWriter {
   typedef typename type_traits<TYPE>::value_type T;
 
   TypedColumnWriter(const ColumnDescriptor* schema,
-      std::unique_ptr<PageWriter> pager, MemoryAllocator* allocator = default_allocator());
-  
+      std::unique_ptr<PageWriter> pager,
+      MemoryAllocator* allocator = default_allocator());
+
   // Write a batch of repetition levels, definition levels, and values to the
   // column.
   void WriteBatch(int64_t num_values, int16_t* def_levels, int16_t* rep_levels,
@@ -127,7 +129,6 @@ class TypedColumnWriter : public ColumnWriter {
   // void CommitPages() override;
   // void ClosePages() override;
 
-
   // Map of encoding type to the respective encoder object. For example, a
   // column chunk's data pages may include both dictionary-encoded and
   // plain-encoded data.
@@ -139,14 +140,15 @@ class TypedColumnWriter : public ColumnWriter {
 };
 
 // TODO: This is just chosen at random, we should make better estimates.
-// See also: parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreV2.java:sizeCheck
+// See also: parquet-column/../column/impl/ColumnWriteStoreV2.java:sizeCheck
 const int64_t PAGE_ROW_COUNT = 1000;
 
 template <int TYPE>
 inline void TypedColumnWriter<TYPE>::WriteBatch(int64_t num_values, int16_t* def_levels,
     int16_t* rep_levels, T* values) {
   // Calculate how much rows we can write before we have to do the next size check.
-  // int64_t values_to_next_size_check = num_buffered_values_next_size_check_ - num_buffered_values_;
+  // int64_t values_to_next_size_check = num_buffered_values_next_size_check_
+  // - num_buffered_values_;
   // TODO: Chunking, size check
 
   int64_t values_to_write = 0;

--- a/src/parquet/column/writer.h
+++ b/src/parquet/column/writer.h
@@ -24,8 +24,17 @@
 #include "parquet/types.h"
 #include "parquet/util/mem-allocator.h"
 #include "parquet/encodings/encoder.h"
+#include "parquet/util/output.h"
 
 namespace parquet {
+
+// Constants used for the default size checks for paging
+// TODO: Make configurable
+const int32_t DEFAULT_PAGE_SIZE = 1024 * 1024;
+const int32_t DEFAULT_DICTIONARY_PAGE_SIZE = DEFAULT_PAGE_SIZE;
+const bool DEFAULT_ESTIMATE_ROW_COUNT_FOR_PAGE_SIZE_CHECK = true;
+const int32_t DEFAULT_MINIMUM_RECORD_COUNT_FOR_CHECK = 100;
+const int32_t DEFAULT_MAXIMUM_RECORD_COUNT_FOR_CHECK = 10000;
 
 class ColumnWriter {
  public:
@@ -46,9 +55,9 @@ class ColumnWriter {
   void Close();
 
  protected:
-  virtual bool WriteNewPage() = 0;
-  virtual void CommitPages() = 0;
-  virtual void ClosePages() = 0;
+  void WriteNewPage();
+  // virtual void CommitPages() = 0;
+  // virtual void ClosePages() = 0;
 
   // Write multiple definition levels
   void WriteDefinitionLevels(int64_t num_levels, int16_t* levels);
@@ -67,6 +76,8 @@ class ColumnWriter {
   // Not set for flat schemas.
   LevelEncoder repetition_level_encoder_;
 
+  MemoryAllocator* allocator_;
+  
   // The total number of values stored in the data page. This is the maximum of
   // the number of encoded definition levels or encoded values. For
   // non-repeated, required columns, this is equal to the number of encoded
@@ -75,7 +86,22 @@ class ColumnWriter {
   // case.
   int num_buffered_values_;
 
-  MemoryAllocator* allocator_;
+  // The total number of stored values. For repeated or optional values, this
+  // number may be lower than num_buffered_values_.
+  int num_buffered_encoded_values_;
+
+  // The next count when we should do a size estimate.
+  int num_buffered_values_next_size_check_;
+
+  // Total number of rows written with this ColumnWriter
+  int num_rows_;
+
+  std::unique_ptr<InMemoryOutputStream> definition_levels_sink_;
+  std::unique_ptr<InMemoryOutputStream> repetition_levels_sink_;
+  std::unique_ptr<InMemoryOutputStream> values_sink_;
+ 
+ private:
+  void InitSinks();
 };
 
 // API to read values from a single column. This is the main client facing API.
@@ -85,11 +111,8 @@ class TypedColumnWriter : public ColumnWriter {
   typedef typename type_traits<TYPE>::value_type T;
 
   TypedColumnWriter(const ColumnDescriptor* schema,
-      std::unique_ptr<PageWriter> pager, MemoryAllocator* allocator) :
-      ColumnWriter(schema, std::move(pager), allocator),
-      current_encoder_(NULL) {
-  }
-
+      std::unique_ptr<PageWriter> pager, MemoryAllocator* allocator = default_allocator());
+  
   // Write a batch of repetition levels, definition levels, and values to the
   // column.
   void WriteBatch(int64_t num_values, int16_t* def_levels, int16_t* rep_levels,
@@ -99,10 +122,13 @@ class TypedColumnWriter : public ColumnWriter {
   typedef Encoder<TYPE> EncoderType;
 
   // Write values to a temporary buffer before they are encoded into pages
-  int64_t WriteValues(int64_t num_values, T* out);
+  void WriteValues(int64_t num_values, T* values);
 
   // Advance to the next data page
-  virtual bool WriteNewPage();
+  // bool WriteNewPage() override;
+  // void CommitPages() override;
+  // void ClosePages() override;
+
 
   // Map of encoding type to the respective encoder object. For example, a
   // column chunk's data pages may include both dictionary-encoded and
@@ -111,27 +137,32 @@ class TypedColumnWriter : public ColumnWriter {
 
   void ConfigureDictionary(const DictionaryPage* page);
 
-  EncoderType* current_encoder_;
+  std::unique_ptr<EncoderType> current_encoder_;
 };
 
+// TODO: This is just chosen at random, we should make better estimates.
+// See also: parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreV2.java:sizeCheck
+const int64_t PAGE_ROW_COUNT = 1000;
 
 template <int TYPE>
 inline void TypedColumnWriter<TYPE>::WriteBatch(int64_t num_values, int16_t* def_levels,
     int16_t* rep_levels, T* values) {
+  // Calculate how much rows we can write before we have to do the next size check.
+  // int64_t values_to_next_size_check = num_buffered_values_next_size_check_ - num_buffered_values_;
+  // TODO: Chunking, size check
+
   int64_t values_to_write = 0;
 
   // If the field is required and non-repeated, there are no definition levels
   if (descr_->max_definition_level() > 0) {
-    // TODO(wesm): this tallying of values-to-decode can be performed with better
-    // cache-efficiency if fused with the level decoding.
     for (int64_t i = 0; i < num_values; ++i) {
       if (def_levels[i] == descr_->max_definition_level()) {
         ++values_to_write;
       }
     }
 
-    WriteDefinitionLevels(num_values, def_levels);
     // TODO: Write definition levels
+    // WriteDefinitionLevels(num_values, def_levels);
   } else {
     // Required field, write all values
     values_to_write = num_values;
@@ -139,13 +170,20 @@ inline void TypedColumnWriter<TYPE>::WriteBatch(int64_t num_values, int16_t* def
 
   // Not present for non-repeated fields
   if (descr_->max_repetition_level() > 0) {
-    WriteRepetitionLevels(num_values, rep_levels);
+    // TODO: Write repetition levels
+    // WriteRepetitionLevels(num_values, rep_levels);
   }
 
   WriteValues(values_to_write, values);
 
-  // TODO(xhochy): We might be able to commit earlier, i.e. with less memory overhead.
-  CommitPages();
+  num_buffered_values_ += num_values;
+  num_buffered_encoded_values_ += values_to_write;
+  num_rows_ += num_values;
+}
+
+template <int TYPE>
+void TypedColumnWriter<TYPE>::WriteValues(int64_t num_values, T* values) {
+  current_encoder_->Encode(values, num_values, values_sink_.get());
 }
 
 

--- a/src/parquet/column/writer.h
+++ b/src/parquet/column/writer.h
@@ -131,7 +131,7 @@ class TypedColumnWriter : public ColumnWriter {
   std::unique_ptr<EncoderType> current_encoder_;
 };
 
-// TODO: This is just chosen at random, we should make better estimates.
+// TODO(PARQUET-591): This is just chosen at random, we should make better estimates.
 // See also: parquet-column/../column/impl/ColumnWriteStoreV2.java:sizeCheck
 const int64_t PAGE_VALUE_COUNT = 1000;
 
@@ -179,7 +179,7 @@ inline void TypedColumnWriter<TYPE>::WriteBatch(int64_t num_values, int16_t* def
   num_buffered_values_ += num_values;
   num_buffered_encoded_values_ += values_to_write;
 
-  // TODO: Instead of rows as a boundary, do a size check
+  // TODO(PARQUET-591): Instead of rows as a boundary, do a size check
   if (num_buffered_values_ >= PAGE_VALUE_COUNT) {
     WriteNewPage();
   }

--- a/src/parquet/column/writer.h
+++ b/src/parquet/column/writer.h
@@ -1,0 +1,164 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef PARQUET_COLUMN_WRITER_H
+#define PARQUET_COLUMN_WRITER_H
+
+#include "parquet/column/page.h"
+#include "parquet/column/levels.h"
+#include "parquet/schema/descriptor.h"
+#include "parquet/types.h"
+#include "parquet/util/mem-allocator.h"
+#include "parquet/encodings/encoder.h"
+
+namespace parquet {
+
+class ColumnWriter {
+ public:
+  ColumnWriter(const ColumnDescriptor*, std::unique_ptr<PageWriter>,
+      MemoryAllocator* allocator = default_allocator());
+
+  static std::shared_ptr<ColumnWriter> Make(const ColumnDescriptor*,
+      std::unique_ptr<PageWriter>, MemoryAllocator* allocator = default_allocator());
+
+  Type::type type() const {
+    return descr_->physical_type();
+  }
+
+  const ColumnDescriptor* descr() const {
+    return descr_;
+  }
+
+  void Close();
+
+ protected:
+  virtual bool WriteNewPage() = 0;
+  virtual void CommitPages() = 0;
+  virtual void ClosePages() = 0;
+
+  // Write multiple definition levels
+  void WriteDefinitionLevels(int64_t num_levels, int16_t* levels);
+
+  // Write multiple repetition levels
+  void WriteRepetitionLevels(int64_t num_levels, int16_t* levels);
+
+  const ColumnDescriptor* descr_;
+
+  std::unique_ptr<PageWriter> pager_;
+  std::shared_ptr<Page> current_page_;
+
+  // Not set if full schema for this field has no optional or repeated elements
+  LevelEncoder definition_level_encoder_;
+
+  // Not set for flat schemas.
+  LevelEncoder repetition_level_encoder_;
+
+  // The total number of values stored in the data page. This is the maximum of
+  // the number of encoded definition levels or encoded values. For
+  // non-repeated, required columns, this is equal to the number of encoded
+  // values. For repeated or optional values, there may be fewer data values
+  // than levels, and this tells you how many encoded levels there are in that
+  // case.
+  int num_buffered_values_;
+
+  MemoryAllocator* allocator_;
+};
+
+// API to read values from a single column. This is the main client facing API.
+template <int TYPE>
+class TypedColumnWriter : public ColumnWriter {
+ public:
+  typedef typename type_traits<TYPE>::value_type T;
+
+  TypedColumnWriter(const ColumnDescriptor* schema,
+      std::unique_ptr<PageWriter> pager, MemoryAllocator* allocator) :
+      ColumnWriter(schema, std::move(pager), allocator),
+      current_encoder_(NULL) {
+  }
+
+  // Write a batch of repetition levels, definition levels, and values to the
+  // column.
+  void WriteBatch(int64_t num_values, int16_t* def_levels, int16_t* rep_levels,
+      T* values);
+
+ private:
+  typedef Encoder<TYPE> EncoderType;
+
+  // Write values to a temporary buffer before they are encoded into pages
+  int64_t WriteValues(int64_t num_values, T* out);
+
+  // Advance to the next data page
+  virtual bool WriteNewPage();
+
+  // Map of encoding type to the respective encoder object. For example, a
+  // column chunk's data pages may include both dictionary-encoded and
+  // plain-encoded data.
+  std::unordered_map<int, std::shared_ptr<EncoderType> > encoders_;
+
+  void ConfigureDictionary(const DictionaryPage* page);
+
+  EncoderType* current_encoder_;
+};
+
+
+template <int TYPE>
+inline void TypedColumnWriter<TYPE>::WriteBatch(int64_t num_values, int16_t* def_levels,
+    int16_t* rep_levels, T* values) {
+  int64_t values_to_write = 0;
+
+  // If the field is required and non-repeated, there are no definition levels
+  if (descr_->max_definition_level() > 0) {
+    // TODO(wesm): this tallying of values-to-decode can be performed with better
+    // cache-efficiency if fused with the level decoding.
+    for (int64_t i = 0; i < num_values; ++i) {
+      if (def_levels[i] == descr_->max_definition_level()) {
+        ++values_to_write;
+      }
+    }
+
+    WriteDefinitionLevels(num_values, def_levels);
+    // TODO: Write definition levels
+  } else {
+    // Required field, write all values
+    values_to_write = num_values;
+  }
+
+  // Not present for non-repeated fields
+  if (descr_->max_repetition_level() > 0) {
+    WriteRepetitionLevels(num_values, rep_levels);
+  }
+
+  WriteValues(values_to_write, values);
+
+  // TODO(xhochy): We might be able to commit earlier, i.e. with less memory overhead.
+  CommitPages();
+}
+
+
+typedef TypedColumnWriter<Type::BOOLEAN> BoolWriter;
+typedef TypedColumnWriter<Type::INT32> Int32Writer;
+typedef TypedColumnWriter<Type::INT64> Int64Writer;
+typedef TypedColumnWriter<Type::INT96> Int96Writer;
+typedef TypedColumnWriter<Type::FLOAT> FloatWriter;
+typedef TypedColumnWriter<Type::DOUBLE> DoubleWriter;
+typedef TypedColumnWriter<Type::BYTE_ARRAY> ByteArrayWriter;
+typedef TypedColumnWriter<Type::FIXED_LEN_BYTE_ARRAY> FixedLenByteArrayWriter;
+
+} // namespace parquet
+
+#endif // PARQUET_COLUMN_READER_H
+

--- a/src/parquet/encodings/encoder.h
+++ b/src/parquet/encodings/encoder.h
@@ -39,6 +39,8 @@ class Encoder {
 
   virtual ~Encoder() {}
 
+  virtual void Encode(const T* src, int num_values, OutputStream* dst) = 0;
+  
   const Encoding::type encoding() const { return encoding_; }
 
  protected:

--- a/src/parquet/encodings/encoder.h
+++ b/src/parquet/encodings/encoder.h
@@ -40,7 +40,7 @@ class Encoder {
   virtual ~Encoder() {}
 
   virtual void Encode(const T* src, int num_values, OutputStream* dst) = 0;
-  
+
   const Encoding::type encoding() const { return encoding_; }
 
  protected:

--- a/src/parquet/encodings/plain-encoding.h
+++ b/src/parquet/encodings/plain-encoding.h
@@ -177,7 +177,7 @@ class PlainEncoder : public Encoder<TYPE> {
       MemoryAllocator* allocator = default_allocator()) :
       Encoder<TYPE>(descr, Encoding::PLAIN, allocator) {}
 
-  void Encode(const T* src, int num_values, OutputStream* dst);
+  void Encode(const T* src, int num_values, OutputStream* dst) override;
 };
 
 template <>

--- a/src/parquet/file/CMakeLists.txt
+++ b/src/parquet/file/CMakeLists.txt
@@ -20,3 +20,4 @@ install(FILES
   DESTINATION include/parquet/file)
 
 ADD_PARQUET_TEST(file-deserialize-test)
+ADD_PARQUET_TEST(file-serialize-test)

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "parquet/column/reader.h"
+#include "parquet/column/writer.h"
+#include "parquet/file/reader.h"
+#include "parquet/file/writer.h"
+#include "parquet/types.h"
+#include "parquet/util/input.h"
+#include "parquet/util/output.h"
+
+namespace parquet {
+
+using schema::GroupNode;
+using schema::NodePtr;
+using schema::PrimitiveNode;
+
+namespace test {
+
+class TestSerialize : public ::testing::Test {
+ public:
+  void SetUpSchemaRequiredNonRepeated() {
+    auto pnode = PrimitiveNode::Make("int64", Repetition::REQUIRED, Type::INT64);
+    node = GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
+    schema.Init(node);
+  }
+
+  void SetUpSchemaOptionalNonRepeated() {
+    auto pnode = PrimitiveNode::Make("int64", Repetition::REQUIRED, Type::INT64);
+    node = GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
+    schema.Init(node);
+  }
+
+  void SetUpSchemaOptionalRepeated() {
+    auto pnode = PrimitiveNode::Make("int64", Repetition::REPEATED, Type::INT64);
+    node = GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
+    schema.Init(node);
+  }
+
+  void SetUp() {
+    SetUpSchemaRequiredNonRepeated();
+  }
+
+ protected:
+  NodePtr node;
+  SchemaDescriptor schema;
+};
+
+
+TEST_F(TestSerialize, SmallFile) {
+  std::shared_ptr<InMemoryOutputStream> sink(new InMemoryOutputStream());
+  auto gnode = std::static_pointer_cast<GroupNode>(node);
+  auto file_writer = ParquetFileWriter::Open(sink, gnode);
+  auto row_group_writer = file_writer->AppendRowGroup(100);
+  auto column_writer = static_cast<Int64Writer*>(row_group_writer->NextColumn());
+  std::vector<int64_t> values(100);
+  std::fill(values.begin(), values.end(), 128);
+  column_writer->WriteBatch(values.size(), nullptr, nullptr, values.data());
+  column_writer->Close();
+  row_group_writer->Close();
+  file_writer->Close();
+
+  auto buffer = sink->GetBuffer();
+  std::unique_ptr<RandomAccessSource> source(new BufferReader(buffer));
+  auto file_reader = ParquetFileReader::Open(std::move(source));
+}
+
+} // namespace test
+
+} // namespace parquet

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -35,26 +35,26 @@ namespace test {
 
 class TestSerialize : public ::testing::Test {
  public:
-  void SetUpSchemaRequiredNonRepeated() {
+  void SetUpSchemaRequired() {
     auto pnode = PrimitiveNode::Make("int64", Repetition::REQUIRED, Type::INT64);
     node = GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
     schema.Init(node);
   }
 
-  void SetUpSchemaOptionalNonRepeated() {
-    auto pnode = PrimitiveNode::Make("int64", Repetition::REQUIRED, Type::INT64);
+  void SetUpSchemaOptional() {
+    auto pnode = PrimitiveNode::Make("int64", Repetition::OPTIONAL, Type::INT64);
     node = GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
     schema.Init(node);
   }
 
-  void SetUpSchemaOptionalRepeated() {
+  void SetUpSchemaRepeated() {
     auto pnode = PrimitiveNode::Make("int64", Repetition::REPEATED, Type::INT64);
     node = GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
     schema.Init(node);
   }
 
   void SetUp() {
-    SetUpSchemaRequiredNonRepeated();
+    SetUpSchemaRequired();
   }
 
  protected:

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -37,19 +37,22 @@ class TestSerialize : public ::testing::Test {
  public:
   void SetUpSchemaRequired() {
     auto pnode = PrimitiveNode::Make("int64", Repetition::REQUIRED, Type::INT64);
-    node_ = GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
+    node_ = GroupNode::Make("schema", Repetition::REQUIRED,
+        std::vector<NodePtr>({pnode}));
     schema_.Init(node_);
   }
 
   void SetUpSchemaOptional() {
     auto pnode = PrimitiveNode::Make("int64", Repetition::OPTIONAL, Type::INT64);
-    node_ = GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
+    node_ = GroupNode::Make("schema", Repetition::REQUIRED,
+        std::vector<NodePtr>({pnode}));
     schema_.Init(node_);
   }
 
   void SetUpSchemaRepeated() {
     auto pnode = PrimitiveNode::Make("int64", Repetition::REPEATED, Type::INT64);
-    node_ = GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
+    node_ = GroupNode::Make("schema", Repetition::REQUIRED,
+        std::vector<NodePtr>({pnode}));
     schema_.Init(node_);
   }
 

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -37,20 +37,20 @@ class TestSerialize : public ::testing::Test {
  public:
   void SetUpSchemaRequired() {
     auto pnode = PrimitiveNode::Make("int64", Repetition::REQUIRED, Type::INT64);
-    node = GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
-    schema.Init(node);
+    node_ = GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
+    schema_.Init(node_);
   }
 
   void SetUpSchemaOptional() {
     auto pnode = PrimitiveNode::Make("int64", Repetition::OPTIONAL, Type::INT64);
-    node = GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
-    schema.Init(node);
+    node_ = GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
+    schema_.Init(node_);
   }
 
   void SetUpSchemaRepeated() {
     auto pnode = PrimitiveNode::Make("int64", Repetition::REPEATED, Type::INT64);
-    node = GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
-    schema.Init(node);
+    node_ = GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
+    schema_.Init(node_);
   }
 
   void SetUp() {
@@ -58,14 +58,14 @@ class TestSerialize : public ::testing::Test {
   }
 
  protected:
-  NodePtr node;
-  SchemaDescriptor schema;
+  NodePtr node_;
+  SchemaDescriptor schema_;
 };
 
 
 TEST_F(TestSerialize, SmallFile) {
   std::shared_ptr<InMemoryOutputStream> sink(new InMemoryOutputStream());
-  auto gnode = std::static_pointer_cast<GroupNode>(node);
+  auto gnode = std::static_pointer_cast<GroupNode>(node_);
   auto file_writer = ParquetFileWriter::Open(sink, gnode);
   auto row_group_writer = file_writer->AppendRowGroup(100);
   auto column_writer = static_cast<Int64Writer*>(row_group_writer->NextColumn());

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -91,7 +91,7 @@ TEST_F(TestSerialize, SmallFile) {
   std::vector<int16_t> def_levels_out(100);
   std::vector<int16_t> rep_levels_out(100);
   int64_t values_read;
-  col_reader->ReadBatch(values_out.size(), def_levels_out.data(), rep_levels_out.data(), 
+  col_reader->ReadBatch(values_out.size(), def_levels_out.data(), rep_levels_out.data(),
       values_out.data(), &values_read);
   ASSERT_EQ(100, values_read);
   ASSERT_EQ(values, values_out);

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -78,6 +78,8 @@ void SerializedPageWriter::WriteDataPage(int32_t num_rows, int32_t num_values, i
   // TODO: crc checksum
   
   SerializeThriftMsg(&page_header, sizeof(format::PageHeader), sink_);
+  sink_->Write(repetition_levels->data(), repetition_levels->size());
+  sink_->Write(definition_levels->data(), definition_levels->size());
   sink_->Write(values->data(), values->size());
 }
 

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -66,10 +66,10 @@ int64_t SerializedPageWriter::WriteDataPage(int32_t num_rows, int32_t num_values
   std::shared_ptr<OwnedMutableBuffer> uncompressed_data =
     std::make_shared<OwnedMutableBuffer>(uncompressed_size, allocator_);
   uint8_t* uncompressed_ptr = uncompressed_data->mutable_data();
-  memcpy(uncompressed_ptr, definition_levels->data(), definition_levels->size());
-  uncompressed_ptr += definition_levels->size();
   memcpy(uncompressed_ptr, repetition_levels->data(), repetition_levels->size());
   uncompressed_ptr += repetition_levels->size();
+  memcpy(uncompressed_ptr, definition_levels->data(), definition_levels->size());
+  uncompressed_ptr += definition_levels->size();
   memcpy(uncompressed_ptr, values->data(), values->size());
 
   // Compress the data

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -63,6 +63,8 @@ int64_t SerializedPageWriter::WriteDataPage(int32_t num_rows, int32_t num_values
     + values->size();
 
   // Concatenate data into a single buffer
+  // TODO: In the uncompressed case, directly write this to the sink
+  // TODO: Reuse the (un)compressed_data buffer instead of recreating it each time.
   std::shared_ptr<OwnedMutableBuffer> uncompressed_data =
     std::make_shared<OwnedMutableBuffer>(uncompressed_size, allocator_);
   uint8_t* uncompressed_ptr = uncompressed_data->mutable_data();

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -54,7 +54,7 @@ void SerializedPageWriter::AddEncoding(Encoding::type encoding) {
 }
 
 int64_t SerializedPageWriter::WriteDataPage(int32_t num_rows, int32_t num_values,
-    int32_t num_nulls, const std::shared_ptr<Buffer>& definition_levels,
+    const std::shared_ptr<Buffer>& definition_levels,
     Encoding::type definition_level_encoding,
     const std::shared_ptr<Buffer>& repetition_levels,
     Encoding::type repetition_level_encoding,

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -1,0 +1,146 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/file/writer-internal.h"
+
+#include "parquet/schema/converter.h"
+#include "parquet/thrift/util.h"
+#include "parquet/util/output.h"
+
+using parquet::schema::GroupNode;
+using parquet::schema::SchemaFlattener;
+
+namespace parquet {
+
+// FIXME: copied from reader-internal.cc
+static constexpr uint8_t PARQUET_MAGIC[4] = {'P', 'A', 'R', '1'};
+
+int RowGroupSerializer::num_columns() const {
+  return schema_->num_columns();
+}
+
+int64_t RowGroupSerializer::num_rows() const {
+  return num_rows_;
+}
+
+const SchemaDescriptor* RowGroupSerializer::schema() const  {
+  return schema_;
+}
+
+PageWriter* RowGroupSerializer::NextColumn(Compression::type codec) {
+  if (current_column_index_ == schema_->num_columns()) {
+    throw ParquetException("All columns have already been written.");
+  }
+  current_column_index_++;
+  
+  if (current_column_writer_) {
+    current_column_writer_->Close();
+  }
+
+  current_column_writer_.reset(new SerializedPageWriter(sink_, codec, allocator_));
+  return current_column_writer_.get();
+}
+
+void RowGroupSerializer::Close() {
+  if (current_column_index_ != schema_->num_columns()) {
+    throw ParquetException("Not all column were written in the current rowgroup.");
+  }
+
+  if (current_column_writer_) {
+    current_column_writer_->Close();
+    current_column_writer_.reset();
+  }
+}
+
+std::unique_ptr<ParquetFileWriter::Contents> FileSerializer::Open(
+    std::unique_ptr<OutputStream> sink, std::shared_ptr<GroupNode>& schema,
+    MemoryAllocator* allocator) {
+  std::unique_ptr<ParquetFileWriter::Contents> result(
+      new FileSerializer(std::move(sink), schema, allocator));
+
+  return result;
+}
+
+void FileSerializer::Close() {
+  if (row_group_writer_) {
+    row_group_writer_->Close();
+  }
+  row_group_writer_.reset();
+
+  // Write magic bytes and metadata
+  WriteMetaData();
+
+  sink_->Close();
+}
+
+int FileSerializer::num_columns() const {
+  return schema_.num_columns();
+}
+  
+RowGroupWriter* FileSerializer::AppendRowGroup(int64_t num_rows) {
+  if (row_group_writer_) {
+    row_group_writer_->Close();
+  }
+  num_rows_ += num_rows;
+  // TODO: Create Contents
+  std::unique_ptr<RowGroupWriter::Contents> contents(new RowGroupSerializer(num_rows, &schema_, sink_.get(), allocator_));
+  row_group_writer_.reset(new RowGroupWriter(std::move(contents), allocator_)); 
+  return row_group_writer_.get();
+}
+
+FileSerializer::~FileSerializer() {
+  Close();
+}
+
+void FileSerializer::WriteMetaData() {
+  // Write MetaData
+  uint32_t metadata_len = sink_->Tell();
+  format::FileMetaData metadata;
+  // TODO: version
+  SchemaFlattener flattener(static_cast<GroupNode*>(schema_.schema().get()),
+      &metadata.schema);
+  flattener.Flatten();
+  // TODO: num_rows
+  // TODO: row_groups
+  // TODO: key_value_metadata
+  // TODO: created_by
+  // TODO: fill metadata
+  SerializeThriftMsg(&metadata, 1024, sink_.get()); 
+  metadata_len = sink_->Tell() - metadata_len;
+  
+  // Write Footer
+  sink_->Write(PARQUET_MAGIC, 4);
+  sink_->Write(reinterpret_cast<uint8_t*>(&metadata_len), 4);
+}
+
+FileSerializer::FileSerializer(
+    std::unique_ptr<OutputStream> sink,
+    std::shared_ptr<GroupNode>& schema,
+    MemoryAllocator* allocator = default_allocator()) :
+        sink_(std::move(sink)), allocator_(allocator),
+        state_(SerializerState::STARTED),
+        num_row_groups_(0), num_rows_(0) {
+  schema_.Init(schema);
+  StartFile();
+}
+
+void FileSerializer::StartFile() {
+  // Parquet files always start with PAR1
+  sink_->Write(PARQUET_MAGIC, 4);
+}
+
+} // namespace parquet

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -190,6 +190,14 @@ int FileSerializer::num_columns() const {
   return schema_.num_columns();
 }
 
+int FileSerializer::num_row_groups() const {
+  return num_row_groups_;
+}
+
+int64_t FileSerializer::num_rows() const {
+  return num_rows_;
+}
+
 RowGroupWriter* FileSerializer::AppendRowGroup(int64_t num_rows) {
   if (row_group_writer_) {
     row_group_writer_->Close();

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -76,7 +76,7 @@ int64_t SerializedPageWriter::WriteDataPage(int32_t num_rows, int32_t num_values
   int64_t compressed_size = uncompressed_size;
   std::shared_ptr<OwnedMutableBuffer> compressed_data = uncompressed_data;
   if (compressor_) {
-    // TODO: Add support for compression
+    // TODO(PARQUET-592): Add support for compression
     // int64_t max_compressed_size = compressor_->MaxCompressedLen(
     // uncompressed_data.size(), uncompressed_data.data());
     // OwnedMutableBuffer compressed_data(compressor_->MaxCompressedLen(
@@ -90,14 +90,14 @@ int64_t SerializedPageWriter::WriteDataPage(int32_t num_rows, int32_t num_values
   data_page_header.__set_encoding(ToThrift(encoding));
   data_page_header.__set_definition_level_encoding(ToThrift(definition_level_encoding));
   data_page_header.__set_repetition_level_encoding(ToThrift(repetition_level_encoding));
-  // TODO: statistics
+  // TODO(PARQUET-593) statistics
 
   format::PageHeader page_header;
   page_header.__set_type(format::PageType::DATA_PAGE);
   page_header.__set_uncompressed_page_size(uncompressed_size);
   page_header.__set_compressed_page_size(compressed_size);
   page_header.__set_data_page_header(data_page_header);
-  // TODO: crc checksum
+  // TODO(PARQUET-594) crc checksum
 
   int64_t start_pos = sink_->Tell();
   SerializeThriftMsg(&page_header, sizeof(format::PageHeader), sink_);
@@ -230,8 +230,8 @@ void FileSerializer::WriteMetaData() {
   metadata_.__set_version(1);
   metadata_.__set_num_rows(num_rows_);
   metadata_.__set_row_groups(row_group_metadata_);
-  // TODO: Support key_value_metadata
-  // TODO: Get from WriterProperties
+  // TODO(PARQUET-595) Support key_value_metadata
+  // TODO(PARQUET-590) Get from WriterProperties
   metadata_.__set_created_by("parquet-cpp");
 
   SerializeThriftMsg(&metadata_, 1024, sink_.get());

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -122,7 +122,7 @@ ColumnWriter* RowGroupSerializer::NextColumn() {
         Compression::UNCOMPRESSED, allocator_));
   auto column_descr = schema_->Column(current_column_index_);
   current_column_writer_ = ColumnWriter::Make(column_descr,
-      std::move(pager), allocator_);
+      std::move(pager), num_rows_, allocator_);
   return current_column_writer_.get();
 }
 

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -138,8 +138,8 @@ ColumnWriter* RowGroupSerializer::NextColumn() {
     total_bytes_written_ += current_column_writer_->Close();
   }
 
-  auto column_descr = schema_->Column(current_column_index_);
-  auto col_meta = &metadata_->columns[current_column_index_];
+  const ColumnDescriptor* column_descr = schema_->Column(current_column_index_);
+  format::ColumnChunk* col_meta = &metadata_->columns[current_column_index_];
   col_meta->__isset.meta_data = true;
   col_meta->meta_data.__set_type(ToThrift(column_descr->physical_type()));
   col_meta->meta_data.__set_path_in_schema(column_descr->path()->ToDotVector());

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -76,7 +76,7 @@ int64_t SerializedPageWriter::WriteDataPage(int32_t num_rows, int32_t num_values
   int64_t compressed_size = uncompressed_size;
   std::shared_ptr<OwnedMutableBuffer> compressed_data = uncompressed_data;
   if (compressor_) {
-    // TODO
+    // TODO: Add support for compression
     // int64_t max_compressed_size = compressor_->MaxCompressedLen(
     // uncompressed_data.size(), uncompressed_data.data());
     // OwnedMutableBuffer compressed_data(compressor_->MaxCompressedLen(
@@ -247,7 +247,6 @@ FileSerializer::FileSerializer(
     std::shared_ptr<GroupNode>& schema,
     MemoryAllocator* allocator = default_allocator()) :
         sink_(sink), allocator_(allocator),
-        state_(SerializerState::STARTED),
         num_row_groups_(0), num_rows_(0) {
   schema_.Init(schema);
   StartFile();

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -1,0 +1,144 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef PARQUET_FILE_WRITER_INTERNAL_H
+#define PARQUET_FILE_WRITER_INTERNAL_H
+
+#include <memory>
+
+#include "parquet/column/page.h"
+#include "parquet/compression/codec.h"
+#include "parquet/file/writer.h"
+#include "parquet/thrift/parquet_types.h"
+
+namespace parquet {
+
+struct SerializerState {
+  enum state {
+    STARTED,
+    ROWGROUP_OPEN,
+    ROWGROUP_END
+  };
+};
+
+// This subclass delimits pages appearing in a serialized stream, each preceded
+// by a serialized Thrift format::PageHeader indicating the type of each page
+// and the page metadata.
+class SerializedPageWriter : public PageWriter {
+ public:
+  SerializedPageWriter(OutputStream* sink,
+      Compression::type codec, MemoryAllocator* allocator = default_allocator());
+
+  virtual ~SerializedPageWriter() {}
+
+  void WritePage(const std::shared_ptr<Buffer>& definition_levels,
+      const std::shared_ptr<Buffer>& repetition_levels,
+      const std::shared_ptr<Buffer>& values);
+
+  void set_max_page_header_size(uint32_t size) {
+    max_page_header_size_ = size;
+  }
+
+  void Close() override;
+
+ private:
+  OutputStream* sink_;
+
+  // TODO: Continue here.
+  format::PageHeader current_page_header_;
+  std::shared_ptr<Page> current_page_;
+
+  // Compression codec to use.
+  std::unique_ptr<Codec> decompressor_;
+  OwnedMutableBuffer decompression_buffer_;
+  // Maximum allowed page size
+  uint32_t max_page_header_size_;
+};
+
+// RowGroupWriter::Contents implementation for the Parquet file specification
+class RowGroupSerializer : public RowGroupWriter::Contents {
+ public:
+  RowGroupSerializer(int64_t num_rows,
+      const SchemaDescriptor* schema,
+      OutputStream* sink,
+      MemoryAllocator* allocator) :
+      num_rows_(num_rows), schema_(schema), sink_(sink),
+      allocator_(allocator), current_column_index_(-1) {}
+
+  int num_columns() const override;
+  int64_t num_rows() const override;
+  const SchemaDescriptor* schema() const override;
+  
+  // TODO: PARQUET-579
+  // void WriteRowGroupStatitics() override;
+  PageWriter* NextColumn(Compression::type codec) override;
+  void Close() override;
+
+ private:
+  int64_t num_rows_;
+  const SchemaDescriptor* schema_;
+  OutputStream* sink_;
+  MemoryAllocator* allocator_;
+  
+  int64_t current_column_index_;
+  std::unique_ptr<PageWriter> current_column_writer_;
+};
+
+// An implementation of ParquetFileWriter::Contents that deals with the Parquet
+// file structure, Thrift serialization, and other internal matters
+
+class FileSerializer : public ParquetFileWriter::Contents {
+ public:
+  // TODO?: This class does _not_ take ownership of the data source. You must manage its
+  // lifetime separately
+  static std::unique_ptr<ParquetFileWriter::Contents> Open(
+      std::unique_ptr<OutputStream> sink,
+      std::shared_ptr<schema::GroupNode>& schema,
+      MemoryAllocator* allocator = default_allocator());
+  void Close() override;
+  RowGroupWriter* AppendRowGroup(int64_t num_rows) override;
+  // virtual std::shared_ptr<RowGroupReader> GetRowGroup(int i);
+  // virtual int64_t num_rows() const;
+  int num_columns() const override;
+  // virtual int num_row_groups() const;
+  virtual ~FileSerializer();
+
+ private:
+  // TODO?: This class takes ownership of the provided data sink
+  explicit FileSerializer(std::unique_ptr<OutputStream> sink,
+      std::shared_ptr<schema::GroupNode>& schema,
+      MemoryAllocator* allocator);
+
+  std::unique_ptr<OutputStream> sink_;
+  format::FileMetaData metadata_;
+  MemoryAllocator* allocator_;
+  SerializerState::state state_;
+  int num_row_groups_;
+  int num_rows_;
+  std::unique_ptr<RowGroupWriter> row_group_writer_;
+
+  void StartFile();
+  void StartRowGroup();
+  void EndRowGroup();
+  void StartColumn();
+  void EndColumn();
+  void WriteMetaData();
+};
+
+} // namespace parquet
+
+#endif // PARQUET_FILE_WRITER_INTERNAL_H

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -49,7 +49,7 @@ class SerializedPageWriter : public PageWriter {
 
   virtual ~SerializedPageWriter() {}
 
-  int64_t WriteDataPage(int32_t num_rows, int32_t num_values, int32_t num_nulls,
+  int64_t WriteDataPage(int32_t num_rows, int32_t num_values,
       const std::shared_ptr<Buffer>& definition_levels,
       Encoding::type definition_level_encoding,
       const std::shared_ptr<Buffer>& repetition_levels,

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -28,14 +28,6 @@
 
 namespace parquet {
 
-struct SerializerState {
-  enum state {
-    STARTED,
-    ROWGROUP_OPEN,
-    ROWGROUP_END
-  };
-};
-
 // This subclass delimits pages appearing in a serialized stream, each preceded
 // by a serialized Thrift format::PageHeader indicating the type of each page
 // and the page metadata.
@@ -140,7 +132,6 @@ class FileSerializer : public ParquetFileWriter::Contents {
   format::FileMetaData metadata_;
   std::vector<format::RowGroup> row_group_metadata_;
   MemoryAllocator* allocator_;
-  SerializerState::state state_;
   int num_row_groups_;
   int num_rows_;
   std::unique_ptr<RowGroupWriter> row_group_writer_;

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -48,8 +48,10 @@ class SerializedPageWriter : public PageWriter {
   virtual ~SerializedPageWriter() {}
 
   void WriteDataPage(int32_t num_rows, int32_t num_values, int32_t num_nulls,
-      const std::shared_ptr<Buffer>& definition_levels, Encoding::type definition_level_encoding,
-      const std::shared_ptr<Buffer>& repetition_levels, Encoding::type repetition_level_encoding,
+      const std::shared_ptr<Buffer>& definition_levels,
+      Encoding::type definition_level_encoding,
+      const std::shared_ptr<Buffer>& repetition_levels,
+      Encoding::type repetition_level_encoding,
       const std::shared_ptr<Buffer>& values, Encoding::type encoding) override;
 
   void Close() override;
@@ -78,7 +80,7 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
   int num_columns() const override;
   int64_t num_rows() const override;
   const SchemaDescriptor* schema() const override;
-  
+
   // TODO: PARQUET-579
   // void WriteRowGroupStatitics() override;
   PageWriter* NextColumn(Compression::type codec) override;
@@ -89,7 +91,7 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
   const SchemaDescriptor* schema_;
   OutputStream* sink_;
   MemoryAllocator* allocator_;
-  
+
   int64_t current_column_index_;
   std::unique_ptr<PageWriter> current_column_writer_;
 };
@@ -99,8 +101,8 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
 
 class FileSerializer : public ParquetFileWriter::Contents {
  public:
-  // TODO?: This class does _not_ take ownership of the data source. You must manage its
-  // lifetime separately
+  // TODO: (??) This class does _not_ take ownership of the data source.
+  // You must manage its lifetime separately
   static std::unique_ptr<ParquetFileWriter::Contents> Open(
       std::unique_ptr<OutputStream> sink,
       std::shared_ptr<schema::GroupNode>& schema,
@@ -114,7 +116,7 @@ class FileSerializer : public ParquetFileWriter::Contents {
   virtual ~FileSerializer();
 
  private:
-  // TODO?: This class takes ownership of the provided data sink
+  // TODO: (??) This class takes ownership of the provided data sink
   explicit FileSerializer(std::unique_ptr<OutputStream> sink,
       std::shared_ptr<schema::GroupNode>& schema,
       MemoryAllocator* allocator);

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/file/writer.h"
+
+#include "parquet/file/writer-internal.h"
+#include "parquet/util/output.h"
+
+using parquet::schema::GroupNode;
+
+namespace parquet {
+
+RowGroupWriter::RowGroupWriter(std::unique_ptr<Contents> contents, MemoryAllocator* allocator) : contents_(std::move(contents)), allocator_(allocator) {
+  schema_ = contents_->schema();
+}
+
+void RowGroupWriter::Close() {
+  contents_->Close();
+}
+
+// ----------------------------------------------------------------------
+// ParquetFileWriter public API
+
+ParquetFileWriter::ParquetFileWriter() {}
+
+ParquetFileWriter::~ParquetFileWriter() {
+  Close();
+}
+
+std::unique_ptr<ParquetFileWriter> ParquetFileWriter::Open(
+    std::unique_ptr<OutputStream> sink, std::shared_ptr<GroupNode>& schema,
+    MemoryAllocator* allocator) {
+  auto contents = FileSerializer::Open(std::move(sink), schema, allocator);
+
+  std::unique_ptr<ParquetFileWriter> result(new ParquetFileWriter());
+  result->Open(std::move(contents));
+
+  return result;
+}
+
+void ParquetFileWriter::Open(std::unique_ptr<ParquetFileWriter::Contents> contents) {
+  contents_ = std::move(contents);
+  schema_ = contents_->schema();
+}
+
+void ParquetFileWriter::Close() {
+  if (contents_) {
+    contents_->Close();
+  }
+}
+
+} // namespace parquet

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -24,7 +24,9 @@ using parquet::schema::GroupNode;
 
 namespace parquet {
 
-RowGroupWriter::RowGroupWriter(std::unique_ptr<Contents> contents, MemoryAllocator* allocator) : contents_(std::move(contents)), allocator_(allocator) {
+RowGroupWriter::RowGroupWriter(std::unique_ptr<Contents> contents,
+    MemoryAllocator* allocator):
+  contents_(std::move(contents)), allocator_(allocator) {
   schema_ = contents_->schema();
 }
 

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -24,6 +24,9 @@ using parquet::schema::GroupNode;
 
 namespace parquet {
 
+// ----------------------------------------------------------------------
+// RowGroupWriter public API
+
 RowGroupWriter::RowGroupWriter(std::unique_ptr<Contents> contents,
     MemoryAllocator* allocator):
   contents_(std::move(contents)), allocator_(allocator) {

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -53,7 +53,7 @@ class RowGroupWriter {
     // virtual void WriteRowGroupStatitics();
     virtual PageWriter* NextColumn(Compression::type codec) = 0;
     virtual void Close() = 0;
-    
+
     // Return const-poitner to make it clear that this object is not to be copied
     virtual const SchemaDescriptor* schema() const = 0;
   };
@@ -104,7 +104,7 @@ class ParquetFileWriter {
     }
     SchemaDescriptor schema_;
   };
-  
+
   ParquetFileWriter();
   ~ParquetFileWriter();
 
@@ -138,7 +138,7 @@ class ParquetFileWriter {
   const ColumnDescriptor* column_schema(int i) const {
     return schema_->Column(i);
   }
- 
+
  private:
   // PIMPL idiom
   // This is declared in the .cc file so that we can hide compiled Thrift

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -31,17 +31,6 @@ class ColumnWriter;
 class PageWriter;
 class OutputStream;
 
-/*
- * Basic Structure:
- * -> Write RowGroup
- *  -> Write Columns
- *    -> Write Batch
- *    -> Check if Batch has the correct size
- *  -> Check if all columns were writtern
- * -> Check number of RowGroups?
- * -> Write MetaData
- * -> Close File
- */
 class RowGroupWriter {
  public:
   // Forward declare the PIMPL

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -33,7 +33,6 @@ class OutputStream;
 
 class RowGroupWriter {
  public:
-  // Forward declare the PIMPL
   struct Contents {
     virtual int num_columns() const = 0;
     virtual int64_t num_rows() const = 0;
@@ -43,7 +42,7 @@ class RowGroupWriter {
     virtual ColumnWriter* NextColumn() = 0;
     virtual void Close() = 0;
 
-    // Return const-poitner to make it clear that this object is not to be copied
+    // Return const-pointer to make it clear that this object is not to be copied
     virtual const SchemaDescriptor* schema() const = 0;
   };
 
@@ -53,7 +52,7 @@ class RowGroupWriter {
    * Construct a ColumnWriter for the indicated row group-relative column.
    *
    * Ownership is solely within the RowGroupWriter. The ColumnWriter is only valid
-   * until the next call to NextColumn or Close. As the contents are diretly written to
+   * until the next call to NextColumn or Close. As the contents are directly written to
    * the sink, once a new column is started, the contents of the previous one cannot be
    * modified anymore.
    */
@@ -71,10 +70,9 @@ class RowGroupWriter {
   // virtual void WriteRowGroupStatitics();
 
  private:
-  // Owned by the parent ParquetFileReader
+  // Owned by the parent ParquetFileWriter
   const SchemaDescriptor* schema_;
 
-  // PIMPL idiom
   // This is declared in the .cc file so that we can hide compiled Thrift
   // headers from the public API and also more easily create test fixtures.
   std::unique_ptr<Contents> contents_;
@@ -84,7 +82,6 @@ class RowGroupWriter {
 
 class ParquetFileWriter {
  public:
-  // Forward declare the PIMPL
   struct Contents {
     virtual ~Contents() {}
     // Perform any cleanup associated with the file contents
@@ -156,7 +153,6 @@ class ParquetFileWriter {
   }
 
  private:
-  // PIMPL idiom
   // This is declared in the .cc file so that we can hide compiled Thrift
   // headers from the public API and also more easily create test fixtures.
   std::unique_ptr<Contents> contents_;

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -1,0 +1,155 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef PARQUET_FILE_WRITER_H
+#define PARQUET_FILE_WRITER_H
+
+#include <cstdint>
+#include <memory>
+
+#include "parquet/schema/descriptor.h"
+#include "parquet/schema/types.h"
+#include "parquet/util/mem-allocator.h"
+
+namespace parquet {
+
+class ColumnWriter;
+class PageWriter;
+class OutputStream;
+
+/*
+ * Basic Structure:
+ * -> Write RowGroup
+ *  -> Write Columns
+ *    -> Write Batch
+ *    -> Check if Batch has the correct size
+ *  -> Check if all columns were writtern
+ * -> Check number of RowGroups?
+ * -> Write MetaData
+ * -> Close File
+ */
+class RowGroupWriter {
+ public:
+  // Forward declare the PIMPL
+  struct Contents {
+    virtual int num_columns() const = 0;
+    virtual int64_t num_rows() const = 0;
+
+    // TODO: PARQUET-579
+    // virtual void WriteRowGroupStatitics();
+    virtual PageWriter* NextColumn(Compression::type codec) = 0;
+    virtual void Close() = 0;
+    
+    // Return const-poitner to make it clear that this object is not to be copied
+    virtual const SchemaDescriptor* schema() const = 0;
+  };
+
+  RowGroupWriter(std::unique_ptr<Contents> contents, MemoryAllocator* allocator);
+
+  // Construct a ColumnWriter for the indicated row group-relative
+  // column. Ownership is solely within the RowGroupWriter.
+  // The ColumnWriter is only valid until the next call to NextColumn or Close.
+  // TODO: Pass a std::weak_ref?
+  ColumnWriter* NextColumn(Compression::type codec);
+  void Close();
+  int num_columns() const;
+  int64_t num_rows() const;
+
+  // TODO: PARQUET-579
+  // virtual void WriteRowGroupStatitics();
+
+ private:
+  // Owned by the parent ParquetFileReader
+  const SchemaDescriptor* schema_;
+
+  // PIMPL idiom
+  // This is declared in the .cc file so that we can hide compiled Thrift
+  // headers from the public API and also more easily create test fixtures.
+  std::unique_ptr<Contents> contents_;
+
+  MemoryAllocator* allocator_;
+};
+
+class ParquetFileWriter {
+ public:
+  // Forward declare the PIMPL
+  struct Contents {
+    virtual ~Contents() {}
+    // Perform any cleanup associated with the file contents
+    virtual void Close() = 0;
+
+    virtual RowGroupWriter* AppendRowGroup(int64_t num_rows) = 0;
+
+    // virtual int64_t num_rows() const = 0;
+    virtual int num_columns() const = 0;
+    // virtual int num_row_groups() const = 0;
+
+    // Return const-poitner to make it clear that this object is not to be copied
+    const SchemaDescriptor* schema() const {
+       return &schema_;
+    }
+    SchemaDescriptor schema_;
+  };
+  
+  ParquetFileWriter();
+  ~ParquetFileWriter();
+
+  // API Convenience to open a serialized Parquet file on disk
+  // static std::unique_ptr<ParquetFileWriter> OpenFile(const std::string& path,
+  //     bool memory_map = true, MemoryAllocator* allocator = default_allocator());
+
+  static std::unique_ptr<ParquetFileWriter> Open(
+      std::unique_ptr<OutputStream> sink,
+      std::shared_ptr<schema::GroupNode>& schema,
+      MemoryAllocator* allocator = default_allocator());
+
+  void Open(std::unique_ptr<Contents> contents);
+  void Close();
+
+  // Construct a RowGroupWriter for the indicated number of rows. Ownership
+  // is solely within the ParquetFileWriter. The RowGroupWriter is only valid
+  // until the next call to AppendRowGroup or Close.
+  // TODO: Pass a std::weak_ref?
+  RowGroupWriter* AppendRowGroup(int64_t num_rows);
+
+  int num_columns() const;
+  // int64_t num_rows() const;
+  // int num_row_groups() const;
+
+  // // Returns the file schema descriptor
+  const SchemaDescriptor* descr() {
+    return schema_;
+  }
+
+  const ColumnDescriptor* column_schema(int i) const {
+    return schema_->Column(i);
+  }
+ 
+ private:
+  // PIMPL idiom
+  // This is declared in the .cc file so that we can hide compiled Thrift
+  // headers from the public API and also more easily create test fixtures.
+  std::unique_ptr<Contents> contents_;
+
+  // The SchemaDescriptor is provided by the Contents impl
+  const SchemaDescriptor* schema_;
+};
+
+} // namespace parquet
+
+#endif // PARQUET_FILE_WRITER_H
+

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -51,7 +51,7 @@ class RowGroupWriter {
 
     // TODO: PARQUET-579
     // virtual void WriteRowGroupStatitics();
-    virtual PageWriter* NextColumn(Compression::type codec) = 0;
+    virtual ColumnWriter* NextColumn() = 0;
     virtual void Close() = 0;
 
     // Return const-poitner to make it clear that this object is not to be copied
@@ -64,7 +64,7 @@ class RowGroupWriter {
   // column. Ownership is solely within the RowGroupWriter.
   // The ColumnWriter is only valid until the next call to NextColumn or Close.
   // TODO: Pass a std::weak_ref?
-  ColumnWriter* NextColumn(Compression::type codec);
+  ColumnWriter* NextColumn();
   void Close();
   int num_columns() const;
   int64_t num_rows() const;
@@ -113,7 +113,7 @@ class ParquetFileWriter {
   //     bool memory_map = true, MemoryAllocator* allocator = default_allocator());
 
   static std::unique_ptr<ParquetFileWriter> Open(
-      std::unique_ptr<OutputStream> sink,
+      std::shared_ptr<OutputStream> sink,
       std::shared_ptr<schema::GroupNode>& schema,
       MemoryAllocator* allocator = default_allocator());
 

--- a/src/parquet/schema/types.cc
+++ b/src/parquet/schema/types.cc
@@ -62,6 +62,10 @@ std::string ColumnPath::ToDotString() const {
   return ss.str();
 }
 
+const std::vector<std::string>& ColumnPath::ToDotVector() const {
+  return path_;
+}
+
 // ----------------------------------------------------------------------
 // Base node
 

--- a/src/parquet/schema/types.h
+++ b/src/parquet/schema/types.h
@@ -88,6 +88,7 @@ class ColumnPath {
 
   std::shared_ptr<ColumnPath> extend(const std::string& node_name) const;
   std::string ToDotString() const;
+  const std::vector<std::string>& ToDotVector() const;
 
  protected:
   std::vector<std::string> path_;


### PR DESCRIPTION
Basic write support with only DataPage as page type, no compression and fixed page sizes. Also allocates and consumes more memory than the optimal solution. But I hope that it is in a state where we can review & merge, so that afterwards the work can be split up.

One outstanding design question for me is `WriteDataPage`. We could pass here a `DataPage` instance but would also need to take care of `num_rows` and `num_values` correctly for the thrift metadata, hoping for good suggestions here.

Also there are numerous TODOs in here for which we need to decide if they should be done as part of the PR or if we should open JIRAs for them.

