### PR TITLE
PARQUET-613: Add a conda (packaging tool) recipe

### DIFF
--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -32,10 +32,10 @@ source thirdparty/versions.sh
 export GTEST_HOME=`pwd`/thirdparty/$GTEST_BASEDIR
 
 cmake \
-	-DCMAKE_BUILD_TYPE=release \
-	-DCMAKE_INSTALL_PREFIX=$PREFIX \
-	-DPARQUET_BUILD_BENCHMARKS=off \
-	..
+    -DCMAKE_BUILD_TYPE=release \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DPARQUET_BUILD_BENCHMARKS=off \
+    ..
 
 make
 ctest -L unittest

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+set -x
+
+cd $RECIPE_DIR
+
+# Build dependencies
+export BOOST_ROOT=$PREFIX
+
+export SNAPPY_HOME=$PREFIX
+export THRIFT_HOME=$PREFIX
+export ZLIB_HOME=$PREFIX
+
+cd ..
+
+mkdir conda-build
+
+cp -r thirdparty conda-build/
+
+# For running the unit tests
+export PARQUET_TEST_DATA=`pwd`/data
+
+cd conda-build
+pwd
+
+# Build googletest for running unit tests
+./thirdparty/download_thirdparty.sh
+./thirdparty/build_thirdparty.sh gtest
+
+source thirdparty/versions.sh
+export GTEST_HOME=`pwd`/thirdparty/$GTEST_BASEDIR
+
+cmake \
+	-DCMAKE_BUILD_TYPE=release \
+	-DCMAKE_INSTALL_PREFIX=$PREFIX \
+	-DPARQUET_BUILD_BENCHMARKS=off \
+	..
+
+make
+ctest -L unittest
+make install

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -25,7 +25,12 @@ cd conda-build
 pwd
 
 # Build googletest for running unit tests
+
+# Work around conda certificate failure
+export PARQUET_INSECURE_CURL=1
+
 ./thirdparty/download_thirdparty.sh
+
 ./thirdparty/build_thirdparty.sh gtest
 
 source thirdparty/versions.sh

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -13,7 +13,6 @@ requirements:
     - zlib
     - snappy
     - thrift-cpp
-    - ca-certificates
     - curl
 
 test:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: parquet-cpp
+  version: "0.1"
+
+build:
+  number: {{environ.get('TRAVIS_BUILD_NUMBER', 0)}}    # [unix]
+  skip: true  # [win]
+
+requirements:
+  build:
+    - boost
+    - cmake
+    - zlib
+    - snappy
+    - thrift-cpp
+    - ca-certificates
+    - curl
+
+test:
+  commands:
+    - test -f $PREFIX/lib/libparquet.so
+    - test -f $PREFIX/include/parquet/api/reader.h
+
+about:
+  home: http://github.com/apache/parquet-cpp
+  license: Apache 2.0
+  summary: 'C++ libraries for the Apache Parquet file format'
+
+extra:
+  recipe-maintainers:
+    - wesm

--- a/thirdparty/download_thirdparty.sh
+++ b/thirdparty/download_thirdparty.sh
@@ -7,11 +7,17 @@ TP_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 source $TP_DIR/versions.sh
 
+: ${PARQUET_INSECURE_CURL=0}
+
 download_extract_and_cleanup() {
-	filename=$TP_DIR/$(basename "$1")
-	curl -L -k "$1" -o $filename
-	tar xzf $filename -C $TP_DIR
-	rm $filename
+    filename=$TP_DIR/$(basename "$1")
+    if [ "$PARQUET_INSECURE_CURL" == "1" ]; then
+        curl -L -k "$1" -o $filename
+    else
+        curl -#LC - "$1" -o $filename
+    fi
+    tar xzf $filename -C $TP_DIR
+    rm $filename
 }
 
 if [ ! -d ${SNAPPY_BASEDIR} ]; then

--- a/thirdparty/download_thirdparty.sh
+++ b/thirdparty/download_thirdparty.sh
@@ -9,7 +9,7 @@ source $TP_DIR/versions.sh
 
 download_extract_and_cleanup() {
 	filename=$TP_DIR/$(basename "$1")
-	curl -#LC - "$1" -o $filename
+	curl -L -k "$1" -o $filename
 	tar xzf $filename -C $TP_DIR
 	rm $filename
 }


### PR DESCRIPTION
Depends on PARQUET-614. With appropriate conda-forge (https://conda-forge.github.io/) patches conda-forge/snappy-feedstock#1 and  conda-forge/zlib-feedstock#4, I'm able to build a conda package for this library. This will make it much easier for Python ecosystem packages that need to use parquet-cpp (e.g. the Python Apache Arrow library). 