### PR TITLE
PARQUET-617: Export CC / CXX / LD_LIBRARY_PATH in conda build for custom C++ toolchains

### DIFF
--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -14,6 +14,7 @@ export ZLIB_HOME=$PREFIX
 
 cd ..
 
+rm -rf conda-build
 mkdir conda-build
 
 cp -r thirdparty conda-build/

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -4,6 +4,10 @@ package:
 
 build:
   number: {{environ.get('TRAVIS_BUILD_NUMBER', 0)}}    # [unix]
+  script_env:
+    - CC [linux]
+    - CXX [linux]
+    - LD_LIBRARY_PATH [linux]
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
If you are building the conda package in an environment with multiple GCC toolchains, with the preferred one being one other than the default one, you must explicitly pass these environment variables down in the conda recipe. The `LD_LIBRARY_PATH` is also passed down for finding the gcc stdlib libraries when running the unit tests to verify the package.