### PR TITLE
PARQUET-618: Automate posting conda build artifacts to anaconda.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,22 @@ addons:
     - gcc-4.9
     - g++-4.9
     - valgrind
-    - libboost-all-dev             #needed for thrift cpp compilation
-    - libssl-dev                   #needed for thrift cpp compilation
-    - libtool                      #needed for thrift cpp compilation
-    - bison                        #needed for thrift cpp compilation
-    - flex                         #needed for thrift cpp compilation
-    - pkg-config                   #needed for thrift cpp compilation
-
+    - libboost-dev
+    - libboost-program-options-dev
+    - libboost-test-dev
+    - libssl-dev
+    - libtool
+    - bison
+    - flex
+    - pkg-config
 matrix:
   include:
   - compiler: gcc
     os: linux
     before_script:
     - source $TRAVIS_BUILD_DIR/ci/before_script_travis.sh
-    - cmake -DCMAKE_CXX_FLAGS="-Werror" -DPARQUET_TEST_MEMCHECK=ON -DPARQUET_BUILD_BENCHMARKS=ON -DPARQUET_GENERATE_COVERAGE=1 $TRAVIS_BUILD_DIR
+    - cmake -DCMAKE_CXX_FLAGS="-Werror" -DPARQUET_TEST_MEMCHECK=ON -DPARQUET_BUILD_BENCHMARKS=ON
+      -DPARQUET_GENERATE_COVERAGE=1 $TRAVIS_BUILD_DIR
     - export PARQUET_TEST_DATA=$TRAVIS_BUILD_DIR/data
   - compiler: clang
     os: linux
@@ -31,14 +33,30 @@ matrix:
     before_install:
     - mkdir $TRAVIS_BUILD_DIR/parquet-build
     - pushd $TRAVIS_BUILD_DIR/parquet-build
+  - compiler: gcc
+    os: linux
+    before_script:
+    - export CC="gcc-4.9"
+    - export CXX="g++-4.9"
+    script:
+    - $TRAVIS_BUILD_DIR/ci/travis_conda_build.sh
+  - os: osx
+    compiler: clang
+    addons:
+    before_script:
+    before_install:
+    script:
+    - $TRAVIS_BUILD_DIR/ci/travis_conda_build.sh
 
 language: cpp
 before_install:
 - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
 - sudo apt-get install -y software-properties-common
 - sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
-- sudo apt-add-repository -y "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main"
-- sudo apt-add-repository -y "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.8 main"
+- sudo apt-add-repository -y "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7
+  main"
+- sudo apt-add-repository -y "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.8
+  main"
 - sudo apt-get update
 - sudo apt-get install -y clang-tidy-3.7 clang-format-3.7 cmake
 - mkdir $TRAVIS_BUILD_DIR/parquet-build
@@ -51,3 +69,7 @@ before_script:
 
 script:
 - $TRAVIS_BUILD_DIR/ci/travis_script_cpp.sh
+
+env:
+  global:
+  - secure: UwV+KbTekNy3nBBRHxUsKlcEWMBjoyY/2A1Z7lTVpRbp3bNJzFxQcT3jI1lvmuHKGjKxtF0FNAOSNyg+0DRONxwnFxS8nPFJh8D01wL6jff8NcWM9B9Gqfa9CmQmCzcc0l17G55lHYBddvVwn7A1oL9zQY2EGLAAaueZOy1DsRE=

--- a/ci/travis_conda_build.sh
+++ b/ci/travis_conda_build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ $TRAVIS_OS_NAME == "linux" ]; then
+  MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh"
+else
+  MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh"
+fi
+
+wget -O miniconda.sh $MINICONDA_URL
+MINICONDA=$TRAVIS_BUILD_DIR/miniconda
+bash miniconda.sh -b -p $MINICONDA
+export PATH="$MINICONDA/bin:$PATH"
+conda update -y -q conda
+conda info -a
+
+conda config --set show_channel_urls yes
+conda config --add channels conda-forge
+conda config --add channels apache
+
+conda install --yes conda-build jinja2 anaconda-client
+
+cd $TRAVIS_BUILD_DIR
+
+conda build conda.recipe
+
+CONDA_PACKAGE=`conda build --output conda.recipe | grep bz2`
+
+if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST == "false" ]; then
+  anaconda --token $ANACONDA_TOKEN upload $CONDA_PACKAGE --user apache --channel dev;
+fi

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -12,6 +12,19 @@ export SNAPPY_HOME=$PREFIX
 export THRIFT_HOME=$PREFIX
 export ZLIB_HOME=$PREFIX
 
+if [ "$(uname)" == "Darwin" ]; then
+  # C++11 finagling for Mac OSX
+  export CC=clang
+  export CXX=clang++
+  export MACOSX_VERSION_MIN="10.7"
+  CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
+  CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
+  export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
+  export LDFLAGS="${LDFLAGS} -stdlib=libc++ -std=c++11"
+  export LINKFLAGS="${LDFLAGS}"
+  export MACOSX_DEPLOYMENT_TARGET=10.7
+fi
+
 cd ..
 
 rm -rf conda-build

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -3,8 +3,7 @@ package:
   version: "0.1"
 
 build:
-  # number: {{environ.get('TRAVIS_BUILD_NUMBER', 0)}}    # [unix]
-  number: 0    # [unix]
+  number: {{environ.get('TRAVIS_BUILD_NUMBER', 0)}}    # [unix]
   script_env:
     - CC [linux]
     - CXX [linux]

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -3,7 +3,8 @@ package:
   version: "0.1"
 
 build:
-  number: {{environ.get('TRAVIS_BUILD_NUMBER', 0)}}    # [unix]
+  # number: {{environ.get('TRAVIS_BUILD_NUMBER', 0)}}    # [unix]
+  number: 0    # [unix]
   script_env:
     - CC [linux]
     - CXX [linux]
@@ -21,7 +22,7 @@ requirements:
 
 test:
   commands:
-    - test -f $PREFIX/lib/libparquet.so
+    - test -f $PREFIX/lib/libparquet.so               # [linux]
     - test -f $PREFIX/include/parquet/api/reader.h
 
 about:


### PR DESCRIPTION
This will enable Python or other conda users to be able to install portable `libparquet` dev binaries into their conda environments (e.g. for `libarrow_parquet` to depend on). 