### PR TITLE
PARQUET-625: Improve RLE read performance

### DIFF
--- a/src/parquet/column/level-benchmark.cc
+++ b/src/parquet/column/level-benchmark.cc
@@ -25,7 +25,6 @@ namespace parquet {
 namespace benchmark {
 
 static void BM_RleEncoding(::benchmark::State& state) {
-  // TODO: More than just all 0s
   std::vector<int16_t> levels(state.range_x(), 0);
   int64_t n = 0;
   std::generate(levels.begin(), levels.end(),
@@ -48,7 +47,6 @@ BENCHMARK(BM_RleEncoding)->RangePair(1024, 65536, 1, 16);
 
 static void BM_RleDecoding(::benchmark::State& state) {
   LevelEncoder level_encoder;
-  // TODO: More than just all 0s
   std::vector<int16_t> levels(state.range_x(), 0);
   int64_t n = 0;
   std::generate(levels.begin(), levels.end(),

--- a/src/parquet/column/level-benchmark.cc
+++ b/src/parquet/column/level-benchmark.cc
@@ -27,6 +27,9 @@ namespace benchmark {
 static void BM_RleEncoding(::benchmark::State& state) {
   // TODO: More than just all 0s
   std::vector<int16_t> levels(state.range_x(), 0);
+  int64_t n = 0;
+  std::generate(levels.begin(), levels.end(),
+      [&state, &n] { return (n++ % state.range_y()) == 0; });
   int16_t max_level = 1;
   int64_t rle_size = LevelEncoder::MaxBufferSize(Encoding::RLE, max_level, levels.size());
   auto buffer_rle = std::make_shared<OwnedMutableBuffer>(rle_size);
@@ -38,20 +41,25 @@ static void BM_RleEncoding(::benchmark::State& state) {
     level_encoder.Encode(levels.size(), levels.data());
   }
   state.SetBytesProcessed(state.iterations() * state.range_x() * sizeof(int16_t));
+  state.SetItemsProcessed(state.iterations() * state.range_x());
 }
 
-BENCHMARK(BM_RleEncoding)->Range(1024, 65536);
+BENCHMARK(BM_RleEncoding)->RangePair(1024, 65536, 1, 16);
 
 static void BM_RleDecoding(::benchmark::State& state) {
   LevelEncoder level_encoder;
   // TODO: More than just all 0s
   std::vector<int16_t> levels(state.range_x(), 0);
+  int64_t n = 0;
+  std::generate(levels.begin(), levels.end(),
+      [&state, &n] { return (n++ % state.range_y()) == 0; });
   int16_t max_level = 1;
   int64_t rle_size = LevelEncoder::MaxBufferSize(Encoding::RLE, max_level, levels.size());
-  auto buffer_rle = std::make_shared<OwnedMutableBuffer>(rle_size);
-  level_encoder.Init(Encoding::RLE, max_level, levels.size(), buffer_rle->mutable_data(),
-      buffer_rle->size());
+  auto buffer_rle = std::make_shared<OwnedMutableBuffer>(rle_size + sizeof(uint32_t));
+  level_encoder.Init(Encoding::RLE, max_level, levels.size(),
+      buffer_rle->mutable_data() + sizeof(uint32_t), rle_size);
   level_encoder.Encode(levels.size(), levels.data());
+  reinterpret_cast<uint32_t*>(buffer_rle->mutable_data())[0] = level_encoder.len();
 
   while (state.KeepRunning()) {
     LevelDecoder level_decoder;
@@ -60,9 +68,10 @@ static void BM_RleDecoding(::benchmark::State& state) {
   }
 
   state.SetBytesProcessed(state.iterations() * state.range_x() * sizeof(int16_t));
+  state.SetItemsProcessed(state.iterations() * state.range_x());
 }
 
-BENCHMARK(BM_RleDecoding)->Range(1024, 65536);
+BENCHMARK(BM_RleDecoding)->RangePair(1024, 65536, 1, 16);
 
 }  // namespace benchmark
 

--- a/src/parquet/column/levels.h
+++ b/src/parquet/column/levels.h
@@ -156,10 +156,7 @@ class LevelDecoder {
 
     int num_values = std::min(num_values_remaining_, batch_size);
     if (encoding_ == Encoding::RLE) {
-      for (int i = 0; i < num_values; ++i) {
-        if (!rle_decoder_->Get(levels + i)) { break; }
-        ++num_decoded;
-      }
+      num_decoded = rle_decoder_->GetBatch(levels, num_values);
     } else {
       for (int i = 0; i < num_values; ++i) {
         if (!bit_packed_decoder_->GetValue(bit_width_, levels + i)) { break; }

--- a/src/parquet/util/rle-encoding.h
+++ b/src/parquet/util/rle-encoding.h
@@ -112,7 +112,7 @@ class RleDecoder {
 
   /// Gets a batch of values.  Returns the number of decoded elements.
   template <typename T>
-  uint32_t GetBatch(T* values, uint32_t batch_size);
+  int GetBatch(T* values, int batch_size);
 
  protected:
   BitReader bit_reader_;
@@ -272,9 +272,9 @@ inline bool RleDecoder::Get(T* val) {
 }
 
 template <typename T>
-inline uint32_t RleDecoder::GetBatch(T* values, uint32_t batch_size) {
+inline int RleDecoder::GetBatch(T* values, int batch_size) {
   DCHECK_GE(bit_width_, 0);
-  uint32_t values_read = 0;
+  int values_read = 0;
 
   while (values_read < batch_size) {
     if (UNLIKELY(literal_count_ == 0 && repeat_count_ == 0)) {
@@ -282,15 +282,15 @@ inline uint32_t RleDecoder::GetBatch(T* values, uint32_t batch_size) {
     }
 
     if (LIKELY(repeat_count_ > 0)) {
-      uint32_t repeat_batch = std::min(batch_size - values_read, repeat_count_);
+      int repeat_batch = std::min(batch_size - values_read, static_cast<int>(repeat_count_));
       std::fill(
           values + values_read, values + values_read + repeat_batch, current_value_);
       repeat_count_ -= repeat_batch;
       values_read += repeat_batch;
     } else {
       DCHECK_GT(literal_count_, 0);
-      uint32_t literal_batch = std::min(batch_size - values_read, literal_count_);
-      for (uint32_t i = 0; i < literal_batch; i++) {
+      int literal_batch = std::min(batch_size - values_read, static_cast<int>(literal_count_));
+      for (int i = 0; i < literal_batch; i++) {
         bool result = bit_reader_.GetValue(bit_width_, values + values_read + i);
         DCHECK(result);
       }

--- a/src/parquet/util/rle-encoding.h
+++ b/src/parquet/util/rle-encoding.h
@@ -282,14 +282,16 @@ inline int RleDecoder::GetBatch(T* values, int batch_size) {
     }
 
     if (LIKELY(repeat_count_ > 0)) {
-      int repeat_batch = std::min(batch_size - values_read, static_cast<int>(repeat_count_));
+      int repeat_batch =
+          std::min(batch_size - values_read, static_cast<int>(repeat_count_));
       std::fill(
           values + values_read, values + values_read + repeat_batch, current_value_);
       repeat_count_ -= repeat_batch;
       values_read += repeat_batch;
     } else {
       DCHECK_GT(literal_count_, 0);
-      int literal_batch = std::min(batch_size - values_read, static_cast<int>(literal_count_));
+      int literal_batch =
+          std::min(batch_size - values_read, static_cast<int>(literal_count_));
       for (int i = 0; i < literal_batch; i++) {
         bool result = bit_reader_.GetValue(bit_width_, values + values_read + i);
         DCHECK(result);

--- a/src/parquet/util/rle-test.cc
+++ b/src/parquet/util/rle-test.cc
@@ -195,12 +195,22 @@ void ValidateRle(const vector<int>& values, int bit_width, uint8_t* expected_enc
   }
 
   // Verify read
-  RleDecoder decoder(buffer, len, bit_width);
-  for (size_t i = 0; i < values.size(); ++i) {
-    uint64_t val;
-    bool result = decoder.Get(&val);
-    EXPECT_TRUE(result);
-    EXPECT_EQ(values[i], val);
+  {
+    RleDecoder decoder(buffer, len, bit_width);
+    for (size_t i = 0; i < values.size(); ++i) {
+      uint64_t val;
+      bool result = decoder.Get(&val);
+      EXPECT_TRUE(result);
+      EXPECT_EQ(values[i], val);
+    }
+  }
+
+  // Verify batch read
+  {
+    RleDecoder decoder(buffer, len, bit_width);
+    vector<int> values_read(values.size());
+    ASSERT_EQ(values.size(), decoder.GetBatch(values_read.data(), values.size()));
+    EXPECT_EQ(values, values_read);
   }
 }
 
@@ -217,11 +227,24 @@ bool CheckRoundTrip(const vector<int>& values, int bit_width) {
   int encoded_len = encoder.Flush();
   int out = 0;
 
-  RleDecoder decoder(buffer, encoded_len, bit_width);
-  for (size_t i = 0; i < values.size(); ++i) {
-    EXPECT_TRUE(decoder.Get(&out));
-    if (values[i] != out) { return false; }
+  {
+    RleDecoder decoder(buffer, encoded_len, bit_width);
+    for (size_t i = 0; i < values.size(); ++i) {
+      EXPECT_TRUE(decoder.Get(&out));
+      if (values[i] != out) { return false; }
+    }
   }
+
+  // Verify batch read
+  {
+    RleDecoder decoder(buffer, len, bit_width);
+    vector<int> values_read(values.size());
+    if (values.size() != decoder.GetBatch(values_read.data(), values.size())) {
+      return false;
+    }
+    if (values != values_read) { return false; }
+  }
+
   return true;
 }
 

--- a/src/parquet/util/rle-test.cc
+++ b/src/parquet/util/rle-test.cc
@@ -239,7 +239,8 @@ bool CheckRoundTrip(const vector<int>& values, int bit_width) {
   {
     RleDecoder decoder(buffer, len, bit_width);
     vector<int> values_read(values.size());
-    if (values.size() != decoder.GetBatch(values_read.data(), values.size())) {
+    if (static_cast<int>(values.size()) !=
+        decoder.GetBatch(values_read.data(), values.size())) {
       return false;
     }
     if (values != values_read) { return false; }


### PR DESCRIPTION
Also fixes the RLE decoding benchmark which did not pass the size to the
buffer.