### PR TITLE
PARQUET-626: Disable LLVM toolchain parts of Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,16 +54,23 @@ matrix:
     - $TRAVIS_BUILD_DIR/ci/travis_conda_build.sh
 
 language: cpp
+
+# PARQUET-626: revisit llvm toolchain when/if llvm.org apt repo resurfaces
+
+# before_install:
+# - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
+# - sudo apt-get install -y software-properties-common
+# - sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
+# - sudo apt-add-repository -y "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7
+#   main"
+# - sudo apt-add-repository -y "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.8
+#   main"
+# - sudo apt-get update
+# - sudo apt-get install -y clang-tidy-3.7 clang-format-3.7 cmake
+# - mkdir $TRAVIS_BUILD_DIR/parquet-build
+# - pushd $TRAVIS_BUILD_DIR/parquet-build
+
 before_install:
-- wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
-- sudo apt-get install -y software-properties-common
-- sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
-- sudo apt-add-repository -y "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7
-  main"
-- sudo apt-add-repository -y "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.8
-  main"
-- sudo apt-get update
-- sudo apt-get install -y clang-tidy-3.7 clang-format-3.7 cmake
 - mkdir $TRAVIS_BUILD_DIR/parquet-build
 - pushd $TRAVIS_BUILD_DIR/parquet-build
 

--- a/ci/travis_script_cpp.sh
+++ b/ci/travis_script_cpp.sh
@@ -7,10 +7,12 @@ set -e
 pushd $CPP_BUILD_DIR
 
 make lint
-if [ $TRAVIS_OS_NAME == "linux" ]; then
-  make check-format
-  make check-clang-tidy
-fi
+
+# PARQUET-626: disabled check for now
+# if [ $TRAVIS_OS_NAME == "linux" ]; then
+#   make check-format
+#   make check-clang-tidy
+# fi
 
 if [ $TRAVIS_OS_NAME == "linux" ]; then
   make -j4 || exit 1


### PR DESCRIPTION
Since llvm.org apt repo was taken offline, this patch triages builds until we sort out an alternative (or remove it altogether for now). 