### PR TITLE
PARQUET-633: Add version to WriterProperties

### DIFF
--- a/src/parquet/column/properties-test.cc
+++ b/src/parquet/column/properties-test.cc
@@ -34,11 +34,12 @@ TEST(TestReaderProperties, Basics) {
 }
 
 TEST(TestWriterProperties, Basics) {
-  WriterProperties props;
+  std::shared_ptr<WriterProperties> props = WriterProperties::Builder().build();
 
-  ASSERT_EQ(DEFAULT_PAGE_SIZE, props.data_pagesize());
-  ASSERT_EQ(DEFAULT_DICTIONARY_PAGE_SIZE, props.dictionary_pagesize());
-  ASSERT_EQ(DEFAULT_IS_DICTIONARY_ENABLED, props.is_dictionary_enabled());
+  ASSERT_EQ(DEFAULT_PAGE_SIZE, props->data_pagesize());
+  ASSERT_EQ(DEFAULT_DICTIONARY_PAGE_SIZE, props->dictionary_pagesize());
+  ASSERT_EQ(DEFAULT_IS_DICTIONARY_ENABLED, props->dictionary_enabled());
+  ASSERT_EQ(DEFAULT_WRITER_VERSION, props->version());
 }
 
 }  // namespace test

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -25,8 +25,9 @@ namespace parquet {
 // ----------------------------------------------------------------------
 // ColumnWriter
 
-WriterProperties default_writer_properties() {
-  static WriterProperties default_writer_properties;
+std::shared_ptr<WriterProperties> default_writer_properties() {
+  static std::shared_ptr<WriterProperties> default_writer_properties =
+      WriterProperties::Builder().build();
   return default_writer_properties;
 }
 

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -168,9 +168,9 @@ void RowGroupSerializer::Close() {
 
 std::unique_ptr<ParquetFileWriter::Contents> FileSerializer::Open(
     std::shared_ptr<OutputStream> sink, std::shared_ptr<GroupNode>& schema,
-    MemoryAllocator* allocator) {
+    MemoryAllocator* allocator, std::shared_ptr<WriterProperties> properties) {
   std::unique_ptr<ParquetFileWriter::Contents> result(
-      new FileSerializer(sink, schema, allocator));
+      new FileSerializer(sink, schema, allocator, properties));
 
   return result;
 }
@@ -198,6 +198,10 @@ int FileSerializer::num_row_groups() const {
 
 int64_t FileSerializer::num_rows() const {
   return num_rows_;
+}
+
+std::shared_ptr<WriterProperties> FileSerializer::properties() const {
+  return properties_;
 }
 
 RowGroupWriter* FileSerializer::AppendRowGroup(int64_t num_rows) {
@@ -243,12 +247,14 @@ void FileSerializer::WriteMetaData() {
 }
 
 FileSerializer::FileSerializer(std::shared_ptr<OutputStream> sink,
-    std::shared_ptr<GroupNode>& schema, MemoryAllocator* allocator = default_allocator())
+    std::shared_ptr<GroupNode>& schema, MemoryAllocator* allocator,
+    std::shared_ptr<WriterProperties> properties)
     : sink_(sink),
       allocator_(allocator),
       num_row_groups_(0),
       num_rows_(0),
-      is_open_(true) {
+      is_open_(true),
+      properties_(properties) {
   schema_.Init(schema);
   StartFile();
 }

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -168,7 +168,7 @@ void RowGroupSerializer::Close() {
 
 std::unique_ptr<ParquetFileWriter::Contents> FileSerializer::Open(
     std::shared_ptr<OutputStream> sink, std::shared_ptr<GroupNode>& schema,
-    MemoryAllocator* allocator, std::shared_ptr<WriterProperties> properties) {
+    MemoryAllocator* allocator, const std::shared_ptr<WriterProperties>& properties) {
   std::unique_ptr<ParquetFileWriter::Contents> result(
       new FileSerializer(sink, schema, allocator, properties));
 
@@ -200,7 +200,7 @@ int64_t FileSerializer::num_rows() const {
   return num_rows_;
 }
 
-std::shared_ptr<WriterProperties> FileSerializer::properties() const {
+const std::shared_ptr<WriterProperties>& FileSerializer::properties() const {
   return properties_;
 }
 
@@ -248,7 +248,7 @@ void FileSerializer::WriteMetaData() {
 
 FileSerializer::FileSerializer(std::shared_ptr<OutputStream> sink,
     std::shared_ptr<GroupNode>& schema, MemoryAllocator* allocator,
-    std::shared_ptr<WriterProperties> properties)
+    const std::shared_ptr<WriterProperties>& properties)
     : sink_(sink),
       allocator_(allocator),
       num_row_groups_(0),

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -111,13 +111,13 @@ class FileSerializer : public ParquetFileWriter::Contents {
   static std::unique_ptr<ParquetFileWriter::Contents> Open(
       std::shared_ptr<OutputStream> sink, std::shared_ptr<schema::GroupNode>& schema,
       MemoryAllocator* allocator = default_allocator(),
-      std::shared_ptr<WriterProperties> properties = default_writer_properties());
+      const std::shared_ptr<WriterProperties>& properties = default_writer_properties());
 
   void Close() override;
 
   RowGroupWriter* AppendRowGroup(int64_t num_rows) override;
 
-  std::shared_ptr<WriterProperties> properties() const override;
+  const std::shared_ptr<WriterProperties>& properties() const override;
 
   int num_columns() const override;
   int num_row_groups() const override;
@@ -128,7 +128,7 @@ class FileSerializer : public ParquetFileWriter::Contents {
  private:
   explicit FileSerializer(std::shared_ptr<OutputStream> sink,
       std::shared_ptr<schema::GroupNode>& schema, MemoryAllocator* allocator,
-      std::shared_ptr<WriterProperties> properties);
+      const std::shared_ptr<WriterProperties>& properties);
 
   std::shared_ptr<OutputStream> sink_;
   format::FileMetaData metadata_;

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -110,11 +110,14 @@ class FileSerializer : public ParquetFileWriter::Contents {
  public:
   static std::unique_ptr<ParquetFileWriter::Contents> Open(
       std::shared_ptr<OutputStream> sink, std::shared_ptr<schema::GroupNode>& schema,
-      MemoryAllocator* allocator = default_allocator());
+      MemoryAllocator* allocator = default_allocator(),
+      std::shared_ptr<WriterProperties> properties = default_writer_properties());
 
   void Close() override;
 
   RowGroupWriter* AppendRowGroup(int64_t num_rows) override;
+
+  std::shared_ptr<WriterProperties> properties() const override;
 
   int num_columns() const override;
   int num_row_groups() const override;
@@ -124,7 +127,8 @@ class FileSerializer : public ParquetFileWriter::Contents {
 
  private:
   explicit FileSerializer(std::shared_ptr<OutputStream> sink,
-      std::shared_ptr<schema::GroupNode>& schema, MemoryAllocator* allocator);
+      std::shared_ptr<schema::GroupNode>& schema, MemoryAllocator* allocator,
+      std::shared_ptr<WriterProperties> properties);
 
   std::shared_ptr<OutputStream> sink_;
   format::FileMetaData metadata_;
@@ -134,6 +138,7 @@ class FileSerializer : public ParquetFileWriter::Contents {
   int num_rows_;
   bool is_open_;
   std::unique_ptr<RowGroupWriter> row_group_writer_;
+  std::shared_ptr<WriterProperties> properties_;
 
   void StartFile();
   void WriteMetaData();

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -55,7 +55,7 @@ ParquetFileWriter::~ParquetFileWriter() {
 
 std::unique_ptr<ParquetFileWriter> ParquetFileWriter::Open(
     std::shared_ptr<OutputStream> sink, std::shared_ptr<GroupNode>& schema,
-    MemoryAllocator* allocator) {
+    MemoryAllocator* allocator, std::shared_ptr<WriterProperties> properties) {
   auto contents = FileSerializer::Open(sink, schema, allocator);
 
   std::unique_ptr<ParquetFileWriter> result(new ParquetFileWriter());
@@ -78,6 +78,10 @@ void ParquetFileWriter::Close() {
 
 RowGroupWriter* ParquetFileWriter::AppendRowGroup(int64_t num_rows) {
   return contents_->AppendRowGroup(num_rows);
+}
+
+std::shared_ptr<WriterProperties> ParquetFileWriter::properties() const {
+  return contents_->properties();
 }
 
 }  // namespace parquet

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -55,7 +55,7 @@ ParquetFileWriter::~ParquetFileWriter() {
 
 std::unique_ptr<ParquetFileWriter> ParquetFileWriter::Open(
     std::shared_ptr<OutputStream> sink, std::shared_ptr<GroupNode>& schema,
-    MemoryAllocator* allocator, std::shared_ptr<WriterProperties> properties) {
+    MemoryAllocator* allocator, const std::shared_ptr<WriterProperties>& properties) {
   auto contents = FileSerializer::Open(sink, schema, allocator);
 
   std::unique_ptr<ParquetFileWriter> result(new ParquetFileWriter());
@@ -80,7 +80,7 @@ RowGroupWriter* ParquetFileWriter::AppendRowGroup(int64_t num_rows) {
   return contents_->AppendRowGroup(num_rows);
 }
 
-std::shared_ptr<WriterProperties> ParquetFileWriter::properties() const {
+const std::shared_ptr<WriterProperties>& ParquetFileWriter::properties() const {
   return contents_->properties();
 }
 

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -94,7 +94,7 @@ class ParquetFileWriter {
     virtual int num_columns() const = 0;
     virtual int num_row_groups() const = 0;
 
-    virtual std::shared_ptr<WriterProperties> properties() const = 0;
+    virtual const std::shared_ptr<WriterProperties>& properties() const = 0;
 
     // Return const-poitner to make it clear that this object is not to be copied
     const SchemaDescriptor* schema() const { return &schema_; }
@@ -107,7 +107,7 @@ class ParquetFileWriter {
   static std::unique_ptr<ParquetFileWriter> Open(std::shared_ptr<OutputStream> sink,
       std::shared_ptr<schema::GroupNode>& schema,
       MemoryAllocator* allocator = default_allocator(),
-      std::shared_ptr<WriterProperties> properties = default_writer_properties());
+      const std::shared_ptr<WriterProperties>& properties = default_writer_properties());
 
   void Open(std::unique_ptr<Contents> contents);
   void Close();
@@ -145,7 +145,7 @@ class ParquetFileWriter {
   /**
    * Configuartion passed to the writer, e.g. the used Parquet format version.
    */
-  std::shared_ptr<WriterProperties> properties() const;
+  const std::shared_ptr<WriterProperties>& properties() const;
 
   /**
    * Returns the file schema descriptor

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <memory>
 
+#include "parquet/column/properties.h"
 #include "parquet/schema/descriptor.h"
 #include "parquet/schema/types.h"
 #include "parquet/util/mem-allocator.h"
@@ -93,6 +94,8 @@ class ParquetFileWriter {
     virtual int num_columns() const = 0;
     virtual int num_row_groups() const = 0;
 
+    virtual std::shared_ptr<WriterProperties> properties() const = 0;
+
     // Return const-poitner to make it clear that this object is not to be copied
     const SchemaDescriptor* schema() const { return &schema_; }
     SchemaDescriptor schema_;
@@ -103,7 +106,8 @@ class ParquetFileWriter {
 
   static std::unique_ptr<ParquetFileWriter> Open(std::shared_ptr<OutputStream> sink,
       std::shared_ptr<schema::GroupNode>& schema,
-      MemoryAllocator* allocator = default_allocator());
+      MemoryAllocator* allocator = default_allocator(),
+      std::shared_ptr<WriterProperties> properties = default_writer_properties());
 
   void Open(std::unique_ptr<Contents> contents);
   void Close();
@@ -137,6 +141,11 @@ class ParquetFileWriter {
    * Number of started RowGroups.
    */
   int num_row_groups() const;
+
+  /**
+   * Configuartion passed to the writer, e.g. the used Parquet format version.
+   */
+  std::shared_ptr<WriterProperties> properties() const;
 
   /**
    * Returns the file schema descriptor


### PR DESCRIPTION
Yet only exposing the property publicly so I can make use of it in Arrow. 

Also used the interface design from parquet-mr to make the `WriterProperties` immutable so we can safely pass references of them around once they have been passed to a `ParquetFileWriter`.