### PR TITLE
PARQUET-634: Consistent private linking of dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,6 +448,10 @@ set(LIBPARQUET_SRCS
   src/parquet/column/writer.cc
   src/parquet/column/scanner.cc
 
+  src/parquet/compression/codec.cc
+  src/parquet/compression/snappy-codec.cc
+  src/parquet/compression/gzip-codec.cc
+
   src/parquet/file/reader.cc
   src/parquet/file/reader-internal.cc
   src/parquet/file/writer.cc
@@ -457,16 +461,23 @@ set(LIBPARQUET_SRCS
   src/parquet/schema/descriptor.cc
   src/parquet/schema/printer.cc
   src/parquet/schema/types.cc
+
+  src/parquet/util/buffer.cc
+  src/parquet/util/cpu-info.cc
+  src/parquet/util/input.cc
+  src/parquet/util/mem-allocator.cc
+  src/parquet/util/mem-pool.cc
+  src/parquet/util/output.cc
 )
 
 set(LIBPARQUET_LINK_LIBS
-  parquet_compression
-  parquet_util
 )
 
 set(LIBPARQUET_PRIVATE_LINK_LIBS
   parquet_thrift
+  snappystatic
   thriftstatic
+  zlibstatic
 )
 
 add_library(parquet_objlib OBJECT

--- a/src/parquet/compression/CMakeLists.txt
+++ b/src/parquet/compression/CMakeLists.txt
@@ -15,19 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-add_library(parquet_compression STATIC
-  codec.cc
-  snappy-codec.cc
-  gzip-codec.cc
-)
-target_link_libraries(parquet_compression
-  snappystatic
-  zlibstatic)
-
-set_target_properties(parquet_compression
-  PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY "${BUILD_OUTPUT_ROOT_DIRECTORY}")
-
 # Headers: compression
 install(FILES
   codec.h

--- a/src/parquet/util/CMakeLists.txt
+++ b/src/parquet/util/CMakeLists.txt
@@ -36,15 +36,6 @@ install(FILES
   sse-util.h
   DESTINATION include/parquet/util)
 
-add_library(parquet_util STATIC
-  buffer.cc
-  cpu-info.cc
-  input.cc
-  mem-allocator.cc
-  mem-pool.cc
-  output.cc
-)
-
 if(PARQUET_BUILD_TESTS)
   add_library(parquet_test_main
 	test_main.cc)


### PR DESCRIPTION
Link all (static) third-party dependencies privately to not expose their API.

Also combine all static libs containing public interfaces into one. To correctly link against parquet_static from another lib, you still need all thirdparty static libs but at least the main parquet static library is only a single one. Will address the scenario "single static lib with all dependencies included" later once we have visibility macros.