### PR TITLE
PARQUET-592: Support compressed writes

### DIFF
--- a/src/parquet/column/properties.h
+++ b/src/parquet/column/properties.h
@@ -160,7 +160,7 @@ class WriterProperties {
     ColumnCodecs codecs_;
   };
 
-  MemoryAllocator* allocator() { return allocator_; }
+  MemoryAllocator* allocator() const { return allocator_; }
 
   bool dictionary_enabled() const { return dictionary_enabled_; }
 

--- a/src/parquet/column/properties.h
+++ b/src/parquet/column/properties.h
@@ -147,7 +147,7 @@ class WriterProperties {
     std::shared_ptr<WriterProperties> build() {
       return std::shared_ptr<WriterProperties>(new WriterProperties(
           allocator_, dictionary_enabled_, dictionary_pagesize_,
-          pagesize_, version_, default_codec_, std::move(codecs_)));
+          pagesize_, version_, default_codec_, codecs_));
     }
 
    private:

--- a/src/parquet/column/properties.h
+++ b/src/parquet/column/properties.h
@@ -151,9 +151,9 @@ class WriterProperties {
 
   int64_t data_pagesize() const { return pagesize_; }
 
-  ParquetVersion::type version() { return parquet_version_; }
+  ParquetVersion::type version() const { return parquet_version_; }
 
-  Compression::type compression() { return codec_; }
+  Compression::type compression() const { return codec_; }
 
  private:
   explicit WriterProperties(MemoryAllocator* allocator, bool dictionary_enabled,

--- a/src/parquet/column/properties.h
+++ b/src/parquet/column/properties.h
@@ -84,7 +84,7 @@ static constexpr ParquetVersion::type DEFAULT_WRITER_VERSION =
 static constexpr Compression::type DEFAULT_COMPRESSION_TYPE =
     Compression::UNCOMPRESSED;
 
-typedef std::unordered_map<std::string, Compression::type> ColumnCodecs;
+using ColumnCodecs = std::unordered_map<std::string, Compression::type>;
 
 class WriterProperties {
  public:

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -68,8 +68,7 @@ void FileSerializeTest(Compression::type codec_type, NodePtr group_node) {
   auto gnode = std::static_pointer_cast<GroupNode>(group_node);
   std::shared_ptr<WriterProperties> writer_properties =
       std::make_shared<WriterProperties::Builder>()
-      ->set_compression(schema::ColumnPath::FromDotString("schema.int64"), codec_type)
-      ->build();
+      ->compression("schema.int64", codec_type)->build();
   auto file_writer = ParquetFileWriter::Open(sink, gnode, default_allocator(),
       writer_properties);
   auto row_group_writer = file_writer->AppendRowGroup(100);

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -61,56 +61,56 @@ class TestSerialize : public ::testing::Test {
  protected:
   NodePtr node_;
   SchemaDescriptor schema_;
+
+  void FileSerializeTest(Compression::type codec_type) {
+    std::shared_ptr<InMemoryOutputStream> sink(new InMemoryOutputStream());
+    auto gnode = std::static_pointer_cast<GroupNode>(node_);
+    std::shared_ptr<WriterProperties> writer_properties =
+        std::make_shared<WriterProperties::Builder>()
+        ->compression("schema.int64", codec_type)->build();
+    auto file_writer = ParquetFileWriter::Open(sink, gnode, default_allocator(),
+        writer_properties);
+    auto row_group_writer = file_writer->AppendRowGroup(100);
+    auto column_writer = static_cast<Int64Writer*>(row_group_writer->NextColumn());
+    std::vector<int64_t> values(100, 128);
+    column_writer->WriteBatch(values.size(), nullptr, nullptr, values.data());
+    column_writer->Close();
+    row_group_writer->Close();
+    file_writer->Close();
+
+    auto buffer = sink->GetBuffer();
+    std::unique_ptr<RandomAccessSource> source(new BufferReader(buffer));
+    auto file_reader = ParquetFileReader::Open(std::move(source));
+    ASSERT_EQ(1, file_reader->num_columns());
+    ASSERT_EQ(1, file_reader->num_row_groups());
+    ASSERT_EQ(100, file_reader->num_rows());
+
+    auto rg_reader = file_reader->RowGroup(0);
+    ASSERT_EQ(1, rg_reader->num_columns());
+    ASSERT_EQ(100, rg_reader->num_rows());
+
+    auto col_reader = std::static_pointer_cast<Int64Reader>(rg_reader->Column(0));
+    std::vector<int64_t> values_out(100);
+    std::vector<int16_t> def_levels_out(100);
+    std::vector<int16_t> rep_levels_out(100);
+    int64_t values_read;
+    col_reader->ReadBatch(values_out.size(), def_levels_out.data(), rep_levels_out.data(),
+        values_out.data(), &values_read);
+    ASSERT_EQ(100, values_read);
+    ASSERT_EQ(values, values_out);
+  }
 };
 
-void FileSerializeTest(Compression::type codec_type, NodePtr group_node) {
-  std::shared_ptr<InMemoryOutputStream> sink(new InMemoryOutputStream());
-  auto gnode = std::static_pointer_cast<GroupNode>(group_node);
-  std::shared_ptr<WriterProperties> writer_properties =
-      std::make_shared<WriterProperties::Builder>()
-      ->compression("schema.int64", codec_type)->build();
-  auto file_writer = ParquetFileWriter::Open(sink, gnode, default_allocator(),
-      writer_properties);
-  auto row_group_writer = file_writer->AppendRowGroup(100);
-  auto column_writer = static_cast<Int64Writer*>(row_group_writer->NextColumn());
-  std::vector<int64_t> values(100, 128);
-  column_writer->WriteBatch(values.size(), nullptr, nullptr, values.data());
-  column_writer->Close();
-  row_group_writer->Close();
-  file_writer->Close();
-
-  auto buffer = sink->GetBuffer();
-  std::unique_ptr<RandomAccessSource> source(new BufferReader(buffer));
-  auto file_reader = ParquetFileReader::Open(std::move(source));
-  ASSERT_EQ(1, file_reader->num_columns());
-  ASSERT_EQ(1, file_reader->num_row_groups());
-  ASSERT_EQ(100, file_reader->num_rows());
-
-  auto rg_reader = file_reader->RowGroup(0);
-  ASSERT_EQ(1, rg_reader->num_columns());
-  ASSERT_EQ(100, rg_reader->num_rows());
-
-  auto col_reader = std::static_pointer_cast<Int64Reader>(rg_reader->Column(0));
-  std::vector<int64_t> values_out(100);
-  std::vector<int16_t> def_levels_out(100);
-  std::vector<int16_t> rep_levels_out(100);
-  int64_t values_read;
-  col_reader->ReadBatch(values_out.size(), def_levels_out.data(), rep_levels_out.data(),
-      values_out.data(), &values_read);
-  ASSERT_EQ(100, values_read);
-  ASSERT_EQ(values, values_out);
-}
-
 TEST_F(TestSerialize, SmallFileUncompressed) {
-  FileSerializeTest(Compression::UNCOMPRESSED, node_);
+  FileSerializeTest(Compression::UNCOMPRESSED);
 }
 
 TEST_F(TestSerialize, SmallFileSnappy) {
-  FileSerializeTest(Compression::SNAPPY, node_);
+  FileSerializeTest(Compression::SNAPPY);
 }
 
 TEST_F(TestSerialize, SmallFileGzip) {
-  FileSerializeTest(Compression::GZIP, node_);
+  FileSerializeTest(Compression::GZIP);
 }
 
 }  // namespace test

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -67,7 +67,9 @@ void FileSerializeTest(Compression::type codec_type, NodePtr group_node) {
   std::shared_ptr<InMemoryOutputStream> sink(new InMemoryOutputStream());
   auto gnode = std::static_pointer_cast<GroupNode>(group_node);
   std::shared_ptr<WriterProperties> writer_properties =
-    std::make_shared<WriterProperties::Builder>()->compression(codec_type)->build();
+      std::make_shared<WriterProperties::Builder>()
+      ->set_compression(schema::ColumnPath::FromDotString("schema.int64"), codec_type)
+      ->build();
   auto file_writer = ParquetFileWriter::Open(sink, gnode, default_allocator(),
       writer_properties);
   auto row_group_writer = file_writer->AppendRowGroup(100);

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -64,37 +64,45 @@ class TestSerialize : public ::testing::Test {
 };
 
 TEST_F(TestSerialize, SmallFile) {
-  std::shared_ptr<InMemoryOutputStream> sink(new InMemoryOutputStream());
-  auto gnode = std::static_pointer_cast<GroupNode>(node_);
-  auto file_writer = ParquetFileWriter::Open(sink, gnode);
-  auto row_group_writer = file_writer->AppendRowGroup(100);
-  auto column_writer = static_cast<Int64Writer*>(row_group_writer->NextColumn());
-  std::vector<int64_t> values(100, 128);
-  column_writer->WriteBatch(values.size(), nullptr, nullptr, values.data());
-  column_writer->Close();
-  row_group_writer->Close();
-  file_writer->Close();
 
-  auto buffer = sink->GetBuffer();
-  std::unique_ptr<RandomAccessSource> source(new BufferReader(buffer));
-  auto file_reader = ParquetFileReader::Open(std::move(source));
-  ASSERT_EQ(1, file_reader->num_columns());
-  ASSERT_EQ(1, file_reader->num_row_groups());
-  ASSERT_EQ(100, file_reader->num_rows());
+  Compression::type codec_types[3] = {Compression::UNCOMPRESSED, Compression::GZIP, Compression::SNAPPY};
 
-  auto rg_reader = file_reader->RowGroup(0);
-  ASSERT_EQ(1, rg_reader->num_columns());
-  ASSERT_EQ(100, rg_reader->num_rows());
+  for (auto codec_type : codec_types) {
+    std::shared_ptr<InMemoryOutputStream> sink(new InMemoryOutputStream());
+    auto gnode = std::static_pointer_cast<GroupNode>(node_);
+    std::shared_ptr<WriterProperties> writer_properties =
+      std::make_shared<WriterProperties::Builder>()->compression(codec_type)->build();
+    auto file_writer = ParquetFileWriter::Open(sink, gnode, default_allocator(),
+        writer_properties);
+    auto row_group_writer = file_writer->AppendRowGroup(100);
+    auto column_writer = static_cast<Int64Writer*>(row_group_writer->NextColumn());
+    std::vector<int64_t> values(100, 128);
+    column_writer->WriteBatch(values.size(), nullptr, nullptr, values.data());
+    column_writer->Close();
+    row_group_writer->Close();
+    file_writer->Close();
 
-  auto col_reader = std::static_pointer_cast<Int64Reader>(rg_reader->Column(0));
-  std::vector<int64_t> values_out(100);
-  std::vector<int16_t> def_levels_out(100);
-  std::vector<int16_t> rep_levels_out(100);
-  int64_t values_read;
-  col_reader->ReadBatch(values_out.size(), def_levels_out.data(), rep_levels_out.data(),
-      values_out.data(), &values_read);
-  ASSERT_EQ(100, values_read);
-  ASSERT_EQ(values, values_out);
+    auto buffer = sink->GetBuffer();
+    std::unique_ptr<RandomAccessSource> source(new BufferReader(buffer));
+    auto file_reader = ParquetFileReader::Open(std::move(source));
+    ASSERT_EQ(1, file_reader->num_columns());
+    ASSERT_EQ(1, file_reader->num_row_groups());
+    ASSERT_EQ(100, file_reader->num_rows());
+
+    auto rg_reader = file_reader->RowGroup(0);
+    ASSERT_EQ(1, rg_reader->num_columns());
+    ASSERT_EQ(100, rg_reader->num_rows());
+
+    auto col_reader = std::static_pointer_cast<Int64Reader>(rg_reader->Column(0));
+    std::vector<int64_t> values_out(100);
+    std::vector<int16_t> def_levels_out(100);
+    std::vector<int16_t> rep_levels_out(100);
+    int64_t values_read;
+    col_reader->ReadBatch(values_out.size(), def_levels_out.data(), rep_levels_out.data(),
+        values_out.data(), &values_read);
+    ASSERT_EQ(100, values_read);
+    ASSERT_EQ(values, values_out);
+  }
 }
 
 }  // namespace test

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -63,46 +63,53 @@ class TestSerialize : public ::testing::Test {
   SchemaDescriptor schema_;
 };
 
-TEST_F(TestSerialize, SmallFile) {
+void FileSerializeTest(Compression::type codec_type, NodePtr group_node) {
+  std::shared_ptr<InMemoryOutputStream> sink(new InMemoryOutputStream());
+  auto gnode = std::static_pointer_cast<GroupNode>(group_node);
+  std::shared_ptr<WriterProperties> writer_properties =
+    std::make_shared<WriterProperties::Builder>()->compression(codec_type)->build();
+  auto file_writer = ParquetFileWriter::Open(sink, gnode, default_allocator(),
+      writer_properties);
+  auto row_group_writer = file_writer->AppendRowGroup(100);
+  auto column_writer = static_cast<Int64Writer*>(row_group_writer->NextColumn());
+  std::vector<int64_t> values(100, 128);
+  column_writer->WriteBatch(values.size(), nullptr, nullptr, values.data());
+  column_writer->Close();
+  row_group_writer->Close();
+  file_writer->Close();
 
-  Compression::type codec_types[3] = {Compression::UNCOMPRESSED, Compression::GZIP, Compression::SNAPPY};
+  auto buffer = sink->GetBuffer();
+  std::unique_ptr<RandomAccessSource> source(new BufferReader(buffer));
+  auto file_reader = ParquetFileReader::Open(std::move(source));
+  ASSERT_EQ(1, file_reader->num_columns());
+  ASSERT_EQ(1, file_reader->num_row_groups());
+  ASSERT_EQ(100, file_reader->num_rows());
 
-  for (auto codec_type : codec_types) {
-    std::shared_ptr<InMemoryOutputStream> sink(new InMemoryOutputStream());
-    auto gnode = std::static_pointer_cast<GroupNode>(node_);
-    std::shared_ptr<WriterProperties> writer_properties =
-      std::make_shared<WriterProperties::Builder>()->compression(codec_type)->build();
-    auto file_writer = ParquetFileWriter::Open(sink, gnode, default_allocator(),
-        writer_properties);
-    auto row_group_writer = file_writer->AppendRowGroup(100);
-    auto column_writer = static_cast<Int64Writer*>(row_group_writer->NextColumn());
-    std::vector<int64_t> values(100, 128);
-    column_writer->WriteBatch(values.size(), nullptr, nullptr, values.data());
-    column_writer->Close();
-    row_group_writer->Close();
-    file_writer->Close();
+  auto rg_reader = file_reader->RowGroup(0);
+  ASSERT_EQ(1, rg_reader->num_columns());
+  ASSERT_EQ(100, rg_reader->num_rows());
 
-    auto buffer = sink->GetBuffer();
-    std::unique_ptr<RandomAccessSource> source(new BufferReader(buffer));
-    auto file_reader = ParquetFileReader::Open(std::move(source));
-    ASSERT_EQ(1, file_reader->num_columns());
-    ASSERT_EQ(1, file_reader->num_row_groups());
-    ASSERT_EQ(100, file_reader->num_rows());
+  auto col_reader = std::static_pointer_cast<Int64Reader>(rg_reader->Column(0));
+  std::vector<int64_t> values_out(100);
+  std::vector<int16_t> def_levels_out(100);
+  std::vector<int16_t> rep_levels_out(100);
+  int64_t values_read;
+  col_reader->ReadBatch(values_out.size(), def_levels_out.data(), rep_levels_out.data(),
+      values_out.data(), &values_read);
+  ASSERT_EQ(100, values_read);
+  ASSERT_EQ(values, values_out);
+}
 
-    auto rg_reader = file_reader->RowGroup(0);
-    ASSERT_EQ(1, rg_reader->num_columns());
-    ASSERT_EQ(100, rg_reader->num_rows());
+TEST_F(TestSerialize, SmallFileUncompressed) {
+  FileSerializeTest(Compression::UNCOMPRESSED, node_);
+}
 
-    auto col_reader = std::static_pointer_cast<Int64Reader>(rg_reader->Column(0));
-    std::vector<int64_t> values_out(100);
-    std::vector<int16_t> def_levels_out(100);
-    std::vector<int16_t> rep_levels_out(100);
-    int64_t values_read;
-    col_reader->ReadBatch(values_out.size(), def_levels_out.data(), rep_levels_out.data(),
-        values_out.data(), &values_read);
-    ASSERT_EQ(100, values_read);
-    ASSERT_EQ(values, values_out);
-  }
+TEST_F(TestSerialize, SmallFileSnappy) {
+  FileSerializeTest(Compression::SNAPPY, node_);
+}
+
+TEST_F(TestSerialize, SmallFileGzip) {
+  FileSerializeTest(Compression::GZIP, node_);
 }
 
 }  // namespace test

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -68,8 +68,7 @@ class TestSerialize : public ::testing::Test {
     std::shared_ptr<WriterProperties> writer_properties =
         std::make_shared<WriterProperties::Builder>()
         ->compression("schema.int64", codec_type)->build();
-    auto file_writer = ParquetFileWriter::Open(sink, gnode, default_allocator(),
-        writer_properties);
+    auto file_writer = ParquetFileWriter::Open(sink, gnode, writer_properties);
     auto row_group_writer = file_writer->AppendRowGroup(100);
     auto column_writer = static_cast<Int64Writer*>(row_group_writer->NextColumn());
     std::vector<int64_t> values(100, 128);

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -66,8 +66,7 @@ class TestSerialize : public ::testing::Test {
     std::shared_ptr<InMemoryOutputStream> sink(new InMemoryOutputStream());
     auto gnode = std::static_pointer_cast<GroupNode>(node_);
     std::shared_ptr<WriterProperties> writer_properties =
-        std::make_shared<WriterProperties::Builder>()
-        ->compression("schema.int64", codec_type)->build();
+        WriterProperties::Builder().compression("schema.int64", codec_type)->build();
     auto file_writer = ParquetFileWriter::Open(sink, gnode, writer_properties);
     auto row_group_writer = file_writer->AppendRowGroup(100);
     auto column_writer = static_cast<Int64Writer*>(row_group_writer->NextColumn());

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -80,7 +80,8 @@ int64_t SerializedPageWriter::WriteDataPage(int32_t num_rows, int32_t num_values
     uncompressed_ptr = uncompressed_data->mutable_data();
     int64_t max_compressed_size = compressor_->MaxCompressedLen(
         uncompressed_size, uncompressed_ptr);
-    compressed_data = std::make_shared<OwnedMutableBuffer>(max_compressed_size);
+    compressed_data = std::make_shared<OwnedMutableBuffer>(max_compressed_size,
+        allocator_);
     compressed_size = compressor_->Compress(uncompressed_size, uncompressed_ptr,
         max_compressed_size, compressed_data->mutable_data());
   }
@@ -215,7 +216,7 @@ RowGroupWriter* FileSerializer::AppendRowGroup(int64_t num_rows) {
   format::RowGroup* rg_metadata = &row_group_metadata_.data()[rgm_size];
   std::unique_ptr<RowGroupWriter::Contents> contents(
       new RowGroupSerializer(num_rows, &schema_, sink_.get(),
-                             rg_metadata, allocator_, properties()));
+                             rg_metadata, allocator_, properties().get()));
   row_group_writer_.reset(new RowGroupWriter(std::move(contents), allocator_));
   return row_group_writer_.get();
 }

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -170,9 +170,9 @@ void RowGroupSerializer::Close() {
 
 std::unique_ptr<ParquetFileWriter::Contents> FileSerializer::Open(
     std::shared_ptr<OutputStream> sink, std::shared_ptr<GroupNode>& schema,
-    MemoryAllocator* allocator, const std::shared_ptr<WriterProperties>& properties) {
+    const std::shared_ptr<WriterProperties>& properties) {
   std::unique_ptr<ParquetFileWriter::Contents> result(
-      new FileSerializer(sink, schema, allocator, properties));
+      new FileSerializer(sink, schema, properties));
 
   return result;
 }
@@ -216,7 +216,7 @@ RowGroupWriter* FileSerializer::AppendRowGroup(int64_t num_rows) {
   format::RowGroup* rg_metadata = &row_group_metadata_.data()[rgm_size];
   std::unique_ptr<RowGroupWriter::Contents> contents(
       new RowGroupSerializer(num_rows, &schema_, sink_.get(),
-                             rg_metadata, allocator_, properties().get()));
+                             rg_metadata, properties().get()));
   row_group_writer_.reset(new RowGroupWriter(std::move(contents), allocator_));
   return row_group_writer_.get();
 }
@@ -250,10 +250,10 @@ void FileSerializer::WriteMetaData() {
 }
 
 FileSerializer::FileSerializer(std::shared_ptr<OutputStream> sink,
-    std::shared_ptr<GroupNode>& schema, MemoryAllocator* allocator,
+    std::shared_ptr<GroupNode>& schema,
     const std::shared_ptr<WriterProperties>& properties)
     : sink_(sink),
-      allocator_(allocator),
+      allocator_(properties->allocator()),
       num_row_groups_(0),
       num_rows_(0),
       is_open_(true),

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -142,8 +142,8 @@ ColumnWriter* RowGroupSerializer::NextColumn() {
   col_meta->__isset.meta_data = true;
   col_meta->meta_data.__set_type(ToThrift(column_descr->physical_type()));
   col_meta->meta_data.__set_path_in_schema(column_descr->path()->ToDotVector());
-  std::unique_ptr<PageWriter> pager(
-      new SerializedPageWriter(sink_, properties_->compression(), col_meta, allocator_));
+  std::unique_ptr<PageWriter> pager(new SerializedPageWriter(sink_,
+      properties_->compression(column_descr->path()), col_meta, allocator_));
   current_column_writer_ =
       ColumnWriter::Make(column_descr, std::move(pager), num_rows_, allocator_);
   return current_column_writer_.get();

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -77,7 +77,7 @@ int64_t SerializedPageWriter::WriteDataPage(int32_t num_rows, int32_t num_values
   int64_t compressed_size = uncompressed_size;
   std::shared_ptr<OwnedMutableBuffer> compressed_data = uncompressed_data;
   if (compressor_) {
-    uncompressed_ptr = uncompressed_data->mutable_data();
+    const uint8_t* uncompressed_ptr = uncompressed_data->data();
     int64_t max_compressed_size = compressor_->MaxCompressedLen(
         uncompressed_size, uncompressed_ptr);
     compressed_data = std::make_shared<OwnedMutableBuffer>(max_compressed_size,

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -68,13 +68,13 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
  public:
   RowGroupSerializer(int64_t num_rows, const SchemaDescriptor* schema, OutputStream* sink,
       format::RowGroup* metadata, MemoryAllocator* allocator,
-      const std::shared_ptr<WriterProperties>& properties)
+      const WriterProperties* props)
       : num_rows_(num_rows),
         schema_(schema),
         sink_(sink),
         metadata_(metadata),
         allocator_(allocator),
-        properties_(properties),
+        properties_(props),
         total_bytes_written_(0),
         closed_(false),
         current_column_index_(-1) {
@@ -98,7 +98,7 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
   OutputStream* sink_;
   format::RowGroup* metadata_;
   MemoryAllocator* allocator_;
-  std::shared_ptr<WriterProperties> properties_;
+  const WriterProperties* properties_;
   int64_t total_bytes_written_;
   bool closed_;
 

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -67,12 +67,14 @@ class SerializedPageWriter : public PageWriter {
 class RowGroupSerializer : public RowGroupWriter::Contents {
  public:
   RowGroupSerializer(int64_t num_rows, const SchemaDescriptor* schema, OutputStream* sink,
-      format::RowGroup* metadata, MemoryAllocator* allocator)
+      format::RowGroup* metadata, MemoryAllocator* allocator,
+      const std::shared_ptr<WriterProperties>& properties)
       : num_rows_(num_rows),
         schema_(schema),
         sink_(sink),
         metadata_(metadata),
         allocator_(allocator),
+        properties_(properties),
         total_bytes_written_(0),
         closed_(false),
         current_column_index_(-1) {
@@ -96,6 +98,7 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
   OutputStream* sink_;
   format::RowGroup* metadata_;
   MemoryAllocator* allocator_;
+  std::shared_ptr<WriterProperties> properties_;
   int64_t total_bytes_written_;
   bool closed_;
 

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -68,13 +68,13 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
  public:
   RowGroupSerializer(int64_t num_rows, const SchemaDescriptor* schema, OutputStream* sink,
       format::RowGroup* metadata, MemoryAllocator* allocator,
-      const WriterProperties* props)
+      const WriterProperties* properties)
       : num_rows_(num_rows),
         schema_(schema),
         sink_(sink),
         metadata_(metadata),
         allocator_(allocator),
-        properties_(props),
+        properties_(properties),
         total_bytes_written_(0),
         closed_(false),
         current_column_index_(-1) {

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -67,13 +67,12 @@ class SerializedPageWriter : public PageWriter {
 class RowGroupSerializer : public RowGroupWriter::Contents {
  public:
   RowGroupSerializer(int64_t num_rows, const SchemaDescriptor* schema, OutputStream* sink,
-      format::RowGroup* metadata, MemoryAllocator* allocator,
-      const WriterProperties* properties)
+      format::RowGroup* metadata, const WriterProperties* properties)
       : num_rows_(num_rows),
         schema_(schema),
         sink_(sink),
         metadata_(metadata),
-        allocator_(allocator),
+        allocator_(properties->allocator()),
         properties_(properties),
         total_bytes_written_(0),
         closed_(false),
@@ -113,7 +112,6 @@ class FileSerializer : public ParquetFileWriter::Contents {
  public:
   static std::unique_ptr<ParquetFileWriter::Contents> Open(
       std::shared_ptr<OutputStream> sink, std::shared_ptr<schema::GroupNode>& schema,
-      MemoryAllocator* allocator = default_allocator(),
       const std::shared_ptr<WriterProperties>& properties = default_writer_properties());
 
   void Close() override;
@@ -130,7 +128,7 @@ class FileSerializer : public ParquetFileWriter::Contents {
 
  private:
   explicit FileSerializer(std::shared_ptr<OutputStream> sink,
-      std::shared_ptr<schema::GroupNode>& schema, MemoryAllocator* allocator,
+      std::shared_ptr<schema::GroupNode>& schema,
       const std::shared_ptr<WriterProperties>& properties);
 
   std::shared_ptr<OutputStream> sink_;

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -56,7 +56,7 @@ ParquetFileWriter::~ParquetFileWriter() {
 std::unique_ptr<ParquetFileWriter> ParquetFileWriter::Open(
     std::shared_ptr<OutputStream> sink, std::shared_ptr<GroupNode>& schema,
     MemoryAllocator* allocator, const std::shared_ptr<WriterProperties>& properties) {
-  auto contents = FileSerializer::Open(sink, schema, allocator);
+  auto contents = FileSerializer::Open(sink, schema, allocator, properties);
 
   std::unique_ptr<ParquetFileWriter> result(new ParquetFileWriter());
   result->Open(std::move(contents));

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -55,8 +55,8 @@ ParquetFileWriter::~ParquetFileWriter() {
 
 std::unique_ptr<ParquetFileWriter> ParquetFileWriter::Open(
     std::shared_ptr<OutputStream> sink, std::shared_ptr<GroupNode>& schema,
-    MemoryAllocator* allocator, const std::shared_ptr<WriterProperties>& properties) {
-  auto contents = FileSerializer::Open(sink, schema, allocator, properties);
+    const std::shared_ptr<WriterProperties>& properties) {
+  auto contents = FileSerializer::Open(sink, schema, properties);
 
   std::unique_ptr<ParquetFileWriter> result(new ParquetFileWriter());
   result->Open(std::move(contents));

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -55,8 +55,8 @@ ParquetFileWriter::~ParquetFileWriter() {
 
 std::unique_ptr<ParquetFileWriter> ParquetFileWriter::Open(
     std::shared_ptr<OutputStream> sink, std::shared_ptr<GroupNode>& schema,
-    MemoryAllocator* allocator, const std::shared_ptr<WriterProperties>& props) {
-  auto contents = FileSerializer::Open(sink, schema, allocator, props);
+    MemoryAllocator* allocator, const std::shared_ptr<WriterProperties>& properties) {
+  auto contents = FileSerializer::Open(sink, schema, allocator, properties);
 
   std::unique_ptr<ParquetFileWriter> result(new ParquetFileWriter());
   result->Open(std::move(contents));

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -55,8 +55,8 @@ ParquetFileWriter::~ParquetFileWriter() {
 
 std::unique_ptr<ParquetFileWriter> ParquetFileWriter::Open(
     std::shared_ptr<OutputStream> sink, std::shared_ptr<GroupNode>& schema,
-    MemoryAllocator* allocator, const std::shared_ptr<WriterProperties>& properties) {
-  auto contents = FileSerializer::Open(sink, schema, allocator, properties);
+    MemoryAllocator* allocator, const std::shared_ptr<WriterProperties>& props) {
+  auto contents = FileSerializer::Open(sink, schema, allocator, props);
 
   std::unique_ptr<ParquetFileWriter> result(new ParquetFileWriter());
   result->Open(std::move(contents));

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -106,7 +106,6 @@ class ParquetFileWriter {
 
   static std::unique_ptr<ParquetFileWriter> Open(std::shared_ptr<OutputStream> sink,
       std::shared_ptr<schema::GroupNode>& schema,
-      MemoryAllocator* allocator = default_allocator(),
       const std::shared_ptr<WriterProperties>& properties = default_writer_properties());
 
   void Open(std::unique_ptr<Contents> contents);

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -143,7 +143,7 @@ class ParquetFileWriter {
   int num_row_groups() const;
 
   /**
-   * Configuartion passed to the writer, e.g. the used Parquet format version.
+   * Configuration passed to the writer, e.g. the used Parquet format version.
    */
   const std::shared_ptr<WriterProperties>& properties() const;
 


### PR DESCRIPTION
Hello,

I'm working on compressed writes and would like some advice:

* What would be the preferred way to pass down per-column codec settings? `Builder::set_column_codec(column index (?), Compression::type)`? 
* It appears that there's some duplication in `ParquetFileWriter::Open`, namely, there is an allocator included into `WriterProperties` — I presume this should be cleaned up via a separate PR?
