### PR TITLE
PARQUET-635: Use conda-forge toolchain, statically link libstdc++ on Linux

### DIFF
--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -3,6 +3,14 @@
 set -e
 set -x
 
+# FIXME: This is a hack to make sure the environment is activated.
+# The reason this is required is due to the conda-build issue
+# mentioned below.
+#
+# https://github.com/conda/conda-build/issues/910
+#
+source activate "${CONDA_DEFAULT_ENV}"
+
 cd $RECIPE_DIR
 
 # Build dependencies
@@ -11,19 +19,6 @@ export BOOST_ROOT=$PREFIX
 export SNAPPY_HOME=$PREFIX
 export THRIFT_HOME=$PREFIX
 export ZLIB_HOME=$PREFIX
-
-if [ "$(uname)" == "Darwin" ]; then
-  # C++11 finagling for Mac OSX
-  export CC=clang
-  export CXX=clang++
-  export MACOSX_VERSION_MIN="10.7"
-  CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
-  CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
-  export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
-  export LDFLAGS="${LDFLAGS} -stdlib=libc++ -std=c++11"
-  export LINKFLAGS="${LDFLAGS}"
-  export MACOSX_DEPLOYMENT_TARGET=10.7
-fi
 
 cd ..
 
@@ -50,9 +45,16 @@ export PARQUET_INSECURE_CURL=1
 source thirdparty/versions.sh
 export GTEST_HOME=`pwd`/thirdparty/$GTEST_BASEDIR
 
+if [ `uname` == Linux ]; then
+    SHARED_LINKER_FLAGS='-static-libstdc++'
+elif [ `uname` == Darwin ]; then
+    SHARED_LINKER_FLAGS=''
+fi
+
 cmake \
     -DCMAKE_BUILD_TYPE=release \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_SHARED_LINKER_FLAGS=$SHARED_LINKER_FLAGS \
     -DPARQUET_BUILD_BENCHMARKS=off \
     ..
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,6 +12,7 @@ build:
 
 requirements:
   build:
+    - toolchain
     - boost
     - cmake
     - zlib


### PR DESCRIPTION
This will avoid portability issues across different Linux environments. 