### PR TITLE
PARQUET-638: Temporarily disable static linking libstdc++ in the conda builds

### DIFF
--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -45,11 +45,13 @@ export PARQUET_INSECURE_CURL=1
 source thirdparty/versions.sh
 export GTEST_HOME=`pwd`/thirdparty/$GTEST_BASEDIR
 
-if [ `uname` == Linux ]; then
-    SHARED_LINKER_FLAGS='-static-libstdc++'
-elif [ `uname` == Darwin ]; then
-    SHARED_LINKER_FLAGS=''
-fi
+# PARQUET-638, PARQUET-489: This should be restored after symbol visibility is
+# hidden by default
+# if [ `uname` == Linux ]; then
+#     SHARED_LINKER_FLAGS='-static-libstdc++'
+# elif [ `uname` == Darwin ]; then
+#     SHARED_LINKER_FLAGS=''
+# fi
 
 cmake \
     -DCMAKE_BUILD_TYPE=release \


### PR DESCRIPTION
We can re-enable this after we've addressed visibility macros. 