### PR TITLE
PARQUET-640: Ensure that gcc 4.9 is used in conda builds

### DIFF
--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -11,6 +11,13 @@ set -x
 #
 source activate "${CONDA_DEFAULT_ENV}"
 
+# Force the use of gcc 4.9 on Linux (was reset by conda-forge toolchain)
+if [ `uname` == Linux ]; then
+    export CC="gcc-4.9"
+    export CXX="g++-4.9"
+fi
+
+
 cd $RECIPE_DIR
 
 # Build dependencies


### PR DESCRIPTION
The toolchain change in https://github.com/apache/parquet-cpp/commit/f334a8b97cd2499799cc74262a52191d04692773 saved a bunch of OS X boilerplate but caused the artifacts to get built with gcc 4.8 by accident.