### PR TITLE
PARQUET-646: Add options to make developing with clang and 3rd-party gcc easier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,19 @@ if (APPLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()
 
+# Determine compiler version
+include(CompilerInfo)
+
+if ("${COMPILER_FAMILY}" STREQUAL "clang")
+  # Using Clang with ccache causes a bunch of spurious warnings that are
+  # purportedly fixed in the next version of ccache. See the following for details:
+  #
+  #   http://petereisentraut.blogspot.com/2011/05/ccache-and-clang.html
+  #   http://petereisentraut.blogspot.com/2011/09/ccache-and-clang-part-2.html
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CLANG_OPTIONS}")
+endif()
+
 ############################################################
 # Includes
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,22 @@ In general, many of the APIs at the layers are interface based for extensibility
 minimize the cost of virtual calls, the APIs should be batch-centric. For example,
 encoding should operate on batches of values rather than a single value.
 
+## Using clang with a custom gcc toolchain
+
+Suppose you are building libraries with a thirdparty gcc toolchain (not a
+built-in system one) on Linux. To use clang for development while linking to
+the proper toolchain, you can do (for out of source builds):
+
+```shell
+export CMAKE_CLANG_OPTIONS=--gcc-toolchain=$TOOLCHAIN/gcc-4.9.2
+
+export CC=$TOOLCHAIN/llvm-3.7.0/bin/clang
+export CXX=$TOOLCHAIN/llvm-3.7.0/bin/clang++
+
+cmake -DCMAKE_CLANG_OPTIONS=$CMAKE_CLANG_OPTIONS \
+	  -DCMAKE_CXX_FLAGS="-Werror" ..
+```
+
 ## Code Coverage
 
 To build with `gcov` code coverage and upload results to http://coveralls.io or
@@ -216,7 +232,6 @@ And the coveralls upload script:
 ```
 coveralls -t $PARQUET_CPP_COVERAGE_TOKEN --gcov-options '\-l' -r $PARQUET_ROOT --exclude $PARQUET_ROOT/thirdparty --exclude $PARQUET_ROOT/build --exclude $NATIVE_TOOLCHAIN --exclude $PARQUET_ROOT/src/parquet/thrift
 ```
-
 
 Note that `gcov` throws off artifacts from the STL, so I excluded my toolchain
 root stored in `$NATIVE_TOOLCHAIN` to avoid a cluttered coverage report.

--- a/cmake_modules/CompilerInfo.cmake
+++ b/cmake_modules/CompilerInfo.cmake
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Sets COMPILER_FAMILY to 'clang' or 'gcc'
+# Sets COMPILER_VERSION to the version
+execute_process(COMMAND "${CMAKE_CXX_COMPILER}" -v
+                ERROR_VARIABLE COMPILER_VERSION_FULL)
+message(INFO " ${COMPILER_VERSION_FULL}")
+
+# clang on Linux and Mac OS X before 10.9
+if("${COMPILER_VERSION_FULL}" MATCHES ".*clang version.*")
+  set(COMPILER_FAMILY "clang")
+  string(REGEX REPLACE ".*clang version ([0-9]+\\.[0-9]+).*" "\\1"
+    COMPILER_VERSION "${COMPILER_VERSION_FULL}")
+# clang on Mac OS X 10.9 and later
+elseif("${COMPILER_VERSION_FULL}" MATCHES ".*based on LLVM.*")
+  set(COMPILER_FAMILY "clang")
+  string(REGEX REPLACE ".*based on LLVM ([0-9]+\\.[0.9]+).*" "\\1"
+    COMPILER_VERSION "${COMPILER_VERSION_FULL}")
+
+# clang on Mac OS X, XCode 7.
+elseif("${COMPILER_VERSION_FULL}" MATCHES ".*clang-7")
+  set(COMPILER_FAMILY "clang")
+  set(COMPILER_VERSION "3.7.0svn")
+
+# gcc
+elseif("${COMPILER_VERSION_FULL}" MATCHES ".*gcc version.*")
+  set(COMPILER_FAMILY "gcc")
+  string(REGEX REPLACE ".*gcc version ([0-9\\.]+).*" "\\1"
+    COMPILER_VERSION "${COMPILER_VERSION_FULL}")
+else()
+  message(FATAL_ERROR "Unknown compiler. Version info:\n${COMPILER_VERSION_FULL}")
+endif()
+message("Selected compiler ${COMPILER_FAMILY} ${COMPILER_VERSION}")

--- a/src/parquet/schema/types.h
+++ b/src/parquet/schema/types.h
@@ -191,7 +191,7 @@ class PrimitiveNode : public Node {
         name, repetition, type, logical_type, length, precision, scale));
   }
 
-  virtual bool Equals(const Node* other) const;
+  bool Equals(const Node* other) const override;
 
   Type::type physical_type() const { return physical_type_; }
 
@@ -200,7 +200,7 @@ class PrimitiveNode : public Node {
   const DecimalMetadata& decimal_metadata() const { return decimal_metadata_; }
 
   void ToParquet(void* opaque_element) const override;
-  virtual void Visit(Visitor* visitor);
+  void Visit(Visitor* visitor) override;
   void VisitConst(ConstVisitor* visitor) const override;
 
  private:
@@ -241,14 +241,14 @@ class GroupNode : public Node {
     return NodePtr(new GroupNode(name, repetition, fields, logical_type));
   }
 
-  virtual bool Equals(const Node* other) const;
+  bool Equals(const Node* other) const override;
 
   const NodePtr& field(int i) const { return fields_[i]; }
 
   int field_count() const { return fields_.size(); }
 
   void ToParquet(void* opaque_element) const override;
-  virtual void Visit(Visitor* visitor);
+  void Visit(Visitor* visitor) override;
   void VisitConst(ConstVisitor* visitor) const override;
 
  private:


### PR DESCRIPTION
Also fixed some clang compiler warnings. See additions to `README.md` for more.