### PR TITLE
PARQUET-653: Build conda artifacts with -static-libstdc++ again

### DIFF
--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -52,13 +52,11 @@ export PARQUET_INSECURE_CURL=1
 source thirdparty/versions.sh
 export GTEST_HOME=`pwd`/thirdparty/$GTEST_BASEDIR
 
-# PARQUET-638, PARQUET-489: This should be restored after symbol visibility is
-# hidden by default
-# if [ `uname` == Linux ]; then
-#     SHARED_LINKER_FLAGS='-static-libstdc++'
-# elif [ `uname` == Darwin ]; then
-#     SHARED_LINKER_FLAGS=''
-# fi
+if [ `uname` == Linux ]; then
+    SHARED_LINKER_FLAGS='-static-libstdc++'
+elif [ `uname` == Darwin ]; then
+    SHARED_LINKER_FLAGS=''
+fi
 
 cmake \
     -DCMAKE_BUILD_TYPE=release \


### PR DESCRIPTION
The final stage of this work will be to move dev/testing packaging builds to centos6 images on Circle CI (this may be possible in Travis -- which allows you to use docker -- but easier with Circle CI) 