### PR TITLE
PARQUET-656: Revert attempts to make conda artifacts portable

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,7 +12,6 @@ build:
 
 requirements:
   build:
-    - toolchain
     - boost
     - cmake
     - zlib


### PR DESCRIPTION
The toolchain issue is not tractable on an ad hoc basis. I suggest we use a consistent gcc toolchain across the CI environments for Parquet and Arrow, and we can post dev builds for human consumption / testing via conda-forge (where the RHEL devtoolset is there and already working well). Sound good @xhochy?

see also https://github.com/conda-forge/staged-recipes/pull/992