### PR TITLE
PARQUET-657: Do not define DISALLOW_COPY_AND_ASSIGN if already defined

### DIFF
--- a/src/parquet/util/macros.h
+++ b/src/parquet/util/macros.h
@@ -21,9 +21,11 @@
 // Useful macros from elsewhere
 
 // From Google gutil
+#ifndef DISALLOW_COPY_AND_ASSIGN
 #define DISALLOW_COPY_AND_ASSIGN(TypeName) \
   TypeName(const TypeName&) = delete;      \
   void operator=(const TypeName&) = delete
+#endif
 
 // ----------------------------------------------------------------------
 // From googletest


### PR DESCRIPTION
This can cause conflicts with other libraries that also use this common macro (from Google's gutil library originally)