### PR TITLE
PARQUET-659: Export extern templates for typed column reader/writer classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,7 +505,9 @@ add_library(parquet_objlib OBJECT
 
 set_property(TARGET parquet_objlib PROPERTY POSITION_INDEPENDENT_CODE 1)
 
-if(NOT APPLE)
+if(APPLE)
+  set(SHARED_LINK_FLAGS "-undefined dynamic_lookup")
+elseif()
   # Localize thirdparty symbols using a linker version script. This hides them
   # from the client application. The OS X linker does not support the
   # version-script option.
@@ -514,9 +516,6 @@ endif()
 
 if (PARQUET_BUILD_SHARED)
     add_library(parquet_shared SHARED $<TARGET_OBJECTS:parquet_objlib>)
-    if(APPLE)
-        set_target_properties(parquet_shared PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-    endif()
     set_target_properties(parquet_shared
       PROPERTIES
       LIBRARY_OUTPUT_DIRECTORY "${BUILD_OUTPUT_ROOT_DIRECTORY}"

--- a/src/parquet/column/reader.h
+++ b/src/parquet/column/reader.h
@@ -205,6 +205,15 @@ typedef TypedColumnReader<DoubleType> DoubleReader;
 typedef TypedColumnReader<ByteArrayType> ByteArrayReader;
 typedef TypedColumnReader<FLBAType> FixedLenByteArrayReader;
 
+extern template class PARQUET_EXPORT TypedColumnReader<BooleanType>;
+extern template class PARQUET_EXPORT TypedColumnReader<Int32Type>;
+extern template class PARQUET_EXPORT TypedColumnReader<Int64Type>;
+extern template class PARQUET_EXPORT TypedColumnReader<Int96Type>;
+extern template class PARQUET_EXPORT TypedColumnReader<FloatType>;
+extern template class PARQUET_EXPORT TypedColumnReader<DoubleType>;
+extern template class PARQUET_EXPORT TypedColumnReader<ByteArrayType>;
+extern template class PARQUET_EXPORT TypedColumnReader<FLBAType>;
+
 }  // namespace parquet
 
 #endif  // PARQUET_COLUMN_READER_H

--- a/src/parquet/column/writer.h
+++ b/src/parquet/column/writer.h
@@ -191,6 +191,15 @@ typedef TypedColumnWriter<DoubleType> DoubleWriter;
 typedef TypedColumnWriter<ByteArrayType> ByteArrayWriter;
 typedef TypedColumnWriter<FLBAType> FixedLenByteArrayWriter;
 
+extern template class PARQUET_EXPORT TypedColumnWriter<BooleanType>;
+extern template class PARQUET_EXPORT TypedColumnWriter<Int32Type>;
+extern template class PARQUET_EXPORT TypedColumnWriter<Int64Type>;
+extern template class PARQUET_EXPORT TypedColumnWriter<Int96Type>;
+extern template class PARQUET_EXPORT TypedColumnWriter<FloatType>;
+extern template class PARQUET_EXPORT TypedColumnWriter<DoubleType>;
+extern template class PARQUET_EXPORT TypedColumnWriter<ByteArrayType>;
+extern template class PARQUET_EXPORT TypedColumnWriter<FLBAType>;
+
 }  // namespace parquet
 
 #endif  // PARQUET_COLUMN_READER_H


### PR DESCRIPTION
While we've already force-instantiated these template classes, they were not visible across the board. gcc on Linux has no problem with it, but found that the Arrow OS X builds were core dumping (with a misleading error message) because of it. The test suites pass locally for me now. 