### PR TITLE
PARQUET-661: Fix perl hashbang to use perl in environment

### DIFF
--- a/build-support/stacktrace_addr2line.pl
+++ b/build-support/stacktrace_addr2line.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information


### PR DESCRIPTION
As noted in https://github.com/conda-forge/staged-recipes/pull/992, if `perl` is in the path but in a non-standard location, then `ctest` fails. 