### PR TITLE
PARQUET-672: Build dev binary artifacts in debug mode

### DIFF
--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -50,7 +50,7 @@ source thirdparty/versions.sh
 export GTEST_HOME=`pwd`/thirdparty/$GTEST_BASEDIR
 
 cmake \
-    -DCMAKE_BUILD_TYPE=release \
+    -DCMAKE_BUILD_TYPE=debug \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
     -DPARQUET_BUILD_BENCHMARKS=off \
     ..


### PR DESCRIPTION
I will move these builds to conda-forge as soon as possible so we aren't overly reliant on the Travis master builds for development of Apache Arrow