### PR TITLE
PARQUET-666: Add support for writing dictionaries

### DIFF
--- a/src/parquet/column/column-io-benchmark.cc
+++ b/src/parquet/column/column-io-benchmark.cc
@@ -31,11 +31,11 @@ using schema::PrimitiveNode;
 namespace benchmark {
 
 std::unique_ptr<Int64Writer> BuildWriter(int64_t output_size, OutputStream* dst,
-    ColumnChunk* metadata, ColumnDescriptor* schema) {
+    ColumnChunk* metadata, ColumnDescriptor* schema, const WriterProperties* properties) {
   std::unique_ptr<SerializedPageWriter> pager(
       new SerializedPageWriter(dst, Compression::UNCOMPRESSED, metadata));
-  return std::unique_ptr<Int64Writer>(
-      new Int64Writer(schema, std::move(pager), output_size, Encoding::PLAIN));
+  return std::unique_ptr<Int64Writer>(new Int64Writer(
+      schema, std::move(pager), output_size, Encoding::PLAIN, properties));
 }
 
 std::shared_ptr<ColumnDescriptor> Int64Schema(Repetition::type repetition) {
@@ -62,11 +62,12 @@ static void BM_WriteInt64Column(::benchmark::State& state) {
   std::vector<int16_t> definition_levels(state.range_x(), 1);
   std::vector<int16_t> repetition_levels(state.range_x(), 0);
   std::shared_ptr<ColumnDescriptor> schema = Int64Schema(repetition);
+  std::shared_ptr<parquet::WriterProperties> properties = default_writer_properties();
 
   while (state.KeepRunning()) {
     InMemoryOutputStream dst;
     std::unique_ptr<Int64Writer> writer =
-        BuildWriter(state.range_x(), &dst, &metadata, schema.get());
+        BuildWriter(state.range_x(), &dst, &metadata, schema.get(), properties.get());
     writer->WriteBatch(
         values.size(), definition_levels.data(), repetition_levels.data(), values.data());
     writer->Close();
@@ -97,8 +98,9 @@ static void BM_ReadInt64Column(::benchmark::State& state) {
   std::shared_ptr<ColumnDescriptor> schema = Int64Schema(repetition);
 
   InMemoryOutputStream dst;
+  std::shared_ptr<parquet::WriterProperties> properties = default_writer_properties();
   std::unique_ptr<Int64Writer> writer =
-      BuildWriter(state.range_x(), &dst, &metadata, schema.get());
+      BuildWriter(state.range_x(), &dst, &metadata, schema.get(), properties.get());
   writer->WriteBatch(
       values.size(), definition_levels.data(), repetition_levels.data(), values.data());
   writer->Close();

--- a/src/parquet/column/column-writer-test.cc
+++ b/src/parquet/column/column-writer-test.cc
@@ -69,6 +69,7 @@ class TestPrimitiveWriter : public ::testing::Test {
 
   void SetUp() {
     SetupValuesOut();
+    writer_properties_ = default_writer_properties();
     definition_levels_out_.resize(SMALL_SIZE);
     repetition_levels_out_.resize(SMALL_SIZE);
 
@@ -88,8 +89,9 @@ class TestPrimitiveWriter : public ::testing::Test {
     sink_.reset(new InMemoryOutputStream());
     std::unique_ptr<SerializedPageWriter> pager(
         new SerializedPageWriter(sink_.get(), Compression::UNCOMPRESSED, &metadata_));
-    return std::unique_ptr<TypedColumnWriter<TestType>>(new TypedColumnWriter<TestType>(
-        schema_.get(), std::move(pager), output_size, encoding));
+    return std::unique_ptr<TypedColumnWriter<TestType>>(
+        new TypedColumnWriter<TestType>(schema_.get(), std::move(pager), output_size,
+            encoding, writer_properties_.get()));
   }
 
   void SyncValuesOut();
@@ -139,6 +141,7 @@ class TestPrimitiveWriter : public ::testing::Test {
   format::ColumnChunk metadata_;
   std::shared_ptr<ColumnDescriptor> schema_;
   std::unique_ptr<InMemoryOutputStream> sink_;
+  std::shared_ptr<WriterProperties> writer_properties_;
 };
 
 template <typename TestType>

--- a/src/parquet/column/column-writer-test.cc
+++ b/src/parquet/column/column-writer-test.cc
@@ -186,15 +186,24 @@ typedef ::testing::Types<Int32Type, Int64Type, Int96Type, FloatType, DoubleType,
 
 TYPED_TEST_CASE(TestPrimitiveWriter, TestTypes);
 
+// Dictionary encoding for booleans is not supported.
+typedef ::testing::Types<Int32Type, Int64Type, Int96Type, FloatType, DoubleType,
+    ByteArrayType, FLBAType> TestDictionaryTypes;
+
+template <typename T>
+class TestPrimitiveDictionaryWriter : public TestPrimitiveWriter<T> {};
+
+TYPED_TEST_CASE(TestPrimitiveDictionaryWriter, TestDictionaryTypes);
+
 TYPED_TEST(TestPrimitiveWriter, RequiredPlain) {
   this->TestRequiredWithEncoding(Encoding::PLAIN);
 }
 
-/*
-TYPED_TEST(TestPrimitiveWriter, RequiredDictionary) {
+TYPED_TEST(TestPrimitiveDictionaryWriter, RequiredDictionary) {
   this->TestRequiredWithEncoding(Encoding::PLAIN_DICTIONARY);
 }
 
+/*
 TYPED_TEST(TestPrimitiveWriter, RequiredRLE) {
   this->TestRequiredWithEncoding(Encoding::RLE);
 }

--- a/src/parquet/column/page.h
+++ b/src/parquet/column/page.h
@@ -171,6 +171,8 @@ class PageWriter {
 
   virtual void Close() = 0;
 
+  virtual int64_t WriteDataPage(const DataPage& page) = 0;
+
   virtual int64_t WriteDataPage(int32_t num_rows, int32_t num_values,
       const std::shared_ptr<Buffer>& definition_levels,
       Encoding::type definition_level_encoding,

--- a/src/parquet/column/page.h
+++ b/src/parquet/column/page.h
@@ -45,6 +45,8 @@ class Page {
 
   PageType::type type() const { return type_; }
 
+  std::shared_ptr<Buffer> buffer() const { return buffer_; }
+
   // @returns: a pointer to the page's data
   const uint8_t* data() const { return buffer_->data(); }
 

--- a/src/parquet/column/page.h
+++ b/src/parquet/column/page.h
@@ -177,6 +177,9 @@ class PageWriter {
       const std::shared_ptr<Buffer>& repetition_levels,
       Encoding::type repetition_level_encoding, const std::shared_ptr<Buffer>& values,
       Encoding::type encoding) = 0;
+
+  virtual int64_t WriteDictionaryPage(int32_t num_values,
+      const std::shared_ptr<Buffer>& values, Encoding::type encoding) = 0;
 };
 
 }  // namespace parquet

--- a/src/parquet/column/page.h
+++ b/src/parquet/column/page.h
@@ -173,15 +173,7 @@ class PageWriter {
 
   virtual int64_t WriteDataPage(const DataPage& page) = 0;
 
-  virtual int64_t WriteDataPage(int32_t num_rows, int32_t num_values,
-      const std::shared_ptr<Buffer>& definition_levels,
-      Encoding::type definition_level_encoding,
-      const std::shared_ptr<Buffer>& repetition_levels,
-      Encoding::type repetition_level_encoding, const std::shared_ptr<Buffer>& values,
-      Encoding::type encoding) = 0;
-
-  virtual int64_t WriteDictionaryPage(int32_t num_values,
-      const std::shared_ptr<Buffer>& values, Encoding::type encoding) = 0;
+  virtual int64_t WriteDictionaryPage(const DictionaryPage& page) = 0;
 };
 
 }  // namespace parquet

--- a/src/parquet/column/properties-test.cc
+++ b/src/parquet/column/properties-test.cc
@@ -38,7 +38,6 @@ TEST(TestWriterProperties, Basics) {
 
   ASSERT_EQ(DEFAULT_PAGE_SIZE, props->data_pagesize());
   ASSERT_EQ(DEFAULT_DICTIONARY_PAGE_SIZE, props->dictionary_pagesize());
-  ASSERT_EQ(DEFAULT_IS_DICTIONARY_ENABLED, props->dictionary_enabled());
   ASSERT_EQ(DEFAULT_WRITER_VERSION, props->version());
 }
 

--- a/src/parquet/column/test-util.h
+++ b/src/parquet/column/test-util.h
@@ -191,7 +191,9 @@ void DataPageBuilder<BooleanType>::AppendValues(
     ParquetException::NYI("only plain encoding currently implemented");
   }
   PlainEncoder<BooleanType> encoder(d);
-  encoder.Encode(values, values.size(), sink_);
+  encoder.Put(values, values.size());
+  std::shared_ptr<Buffer> buffer = encoder.FlushValues();
+  sink_->Write(buffer->data(), buffer->size());
 
   num_values_ = std::max(static_cast<int32_t>(values.size()), num_values_);
   encoding_ = encoding;
@@ -234,9 +236,7 @@ class DictionaryPageBuilder {
   // This class writes data and metadata to the passed inputs
   explicit DictionaryPageBuilder(const ColumnDescriptor* d)
       : num_dict_values_(0), have_values_(false) {
-    int type_length = 0;
-    if (TN == Type::FIXED_LEN_BYTE_ARRAY) { type_length = d->type_length(); }
-    encoder_.reset(new DictEncoder<TC>(&pool_, default_allocator(), type_length));
+    encoder_.reset(new DictEncoder<TYPE>(d, &pool_));
   }
 
   ~DictionaryPageBuilder() { pool_.FreeAll(); }
@@ -244,18 +244,10 @@ class DictionaryPageBuilder {
   shared_ptr<Buffer> AppendValues(const vector<TC>& values) {
     int num_values = values.size();
     // Dictionary encoding
-    for (int i = 0; i < num_values; ++i) {
-      encoder_->Put(values[i]);
-    }
+    encoder_->Put(values.data(), num_values);
     num_dict_values_ = encoder_->num_entries();
     have_values_ = true;
-    shared_ptr<OwnedMutableBuffer> rle_indices = std::make_shared<OwnedMutableBuffer>(
-        sizeof(int) * encoder_->EstimatedDataEncodedSize());
-    int actual_bytes =
-        encoder_->WriteIndices(rle_indices->mutable_data(), rle_indices->size());
-    rle_indices->Resize(actual_bytes);
-    encoder_->ClearIndices();
-    return rle_indices;
+    return encoder_->FlushValues();
   }
 
   shared_ptr<Buffer> WriteDict() {
@@ -269,7 +261,7 @@ class DictionaryPageBuilder {
 
  private:
   MemPool pool_;
-  shared_ptr<DictEncoder<TC>> encoder_;
+  shared_ptr<DictEncoder<TYPE>> encoder_;
   int32_t num_dict_values_;
   bool have_values_;
 };

--- a/src/parquet/column/test-util.h
+++ b/src/parquet/column/test-util.h
@@ -132,7 +132,9 @@ class DataPageBuilder {
   void AppendValues(const ColumnDescriptor* d, const vector<T>& values,
       Encoding::type encoding = Encoding::PLAIN) {
     PlainEncoder<Type> encoder(d);
-    encoder.Encode(&values[0], values.size(), sink_);
+    encoder.Put(&values[0], values.size());
+    std::shared_ptr<Buffer> values_sink = encoder.FlushValues();
+    sink_->Write(values_sink->data(), values_sink->size());
 
     num_values_ = std::max(static_cast<int32_t>(values.size()), num_values_);
     encoding_ = encoding;

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -146,9 +146,6 @@ TypedColumnWriter<Type>::TypedColumnWriter(const ColumnDescriptor* schema,
           std::unique_ptr<EncoderType>(new PlainEncoder<Type>(schema, allocator));
       break;
     case Encoding::PLAIN_DICTIONARY:
-      current_encoder_ =
-          std::unique_ptr<EncoderType>(new DictEncoder<Type>(schema, &pool_, allocator));
-      break;
     case Encoding::RLE_DICTIONARY:
       current_encoder_ =
           std::unique_ptr<EncoderType>(new DictEncoder<Type>(schema, &pool_, allocator));

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -120,7 +120,7 @@ int64_t ColumnWriter::Close() {
   // Write all outstanding data to a new page
   if (num_buffered_values_ > 0) { AddDataPage(); }
 
-  for (int i = 0; i < data_page_buffers_.size(); i++) {
+  for (size_t i = 0; i < data_page_buffers_.size(); i++) {
     WriteNewPage(data_page_buffers_[i]);
   }
 

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -102,7 +102,6 @@ void ColumnWriter::AddDataPage() {
       definition_levels->size() + repetition_levels->size() + values->size();
 
   // Concatenate data into a single buffer
-  // TODO: Reuse the (un)compressed_data buffer instead of recreating it each time.
   std::shared_ptr<OwnedMutableBuffer> uncompressed_data =
       std::make_shared<OwnedMutableBuffer>(uncompressed_size, allocator_);
   uint8_t* uncompressed_ptr = uncompressed_data->mutable_data();

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -98,19 +98,17 @@ void ColumnWriter::AddDataPage() {
         RleEncodeLevels(repetition_levels, descr_->max_repetition_level());
   }
 
-  int64_t uncompressed_size = definition_levels->size() +
-                              repetition_levels->size() + values->size();
+  int64_t uncompressed_size =
+      definition_levels->size() + repetition_levels->size() + values->size();
 
   // Concatenate data into a single buffer
   // TODO: Reuse the (un)compressed_data buffer instead of recreating it each time.
   std::shared_ptr<OwnedMutableBuffer> uncompressed_data =
       std::make_shared<OwnedMutableBuffer>(uncompressed_size, allocator_);
   uint8_t* uncompressed_ptr = uncompressed_data->mutable_data();
-  memcpy(uncompressed_ptr, repetition_levels->data(),
-      repetition_levels->size());
+  memcpy(uncompressed_ptr, repetition_levels->data(), repetition_levels->size());
   uncompressed_ptr += repetition_levels->size();
-  memcpy(uncompressed_ptr, definition_levels->data(),
-      definition_levels->size());
+  memcpy(uncompressed_ptr, definition_levels->data(), definition_levels->size());
   uncompressed_ptr += definition_levels->size();
   memcpy(uncompressed_ptr, values->data(), values->size());
   Encoding::type encoding = Encoding::PLAIN;
@@ -186,9 +184,8 @@ void TypedColumnWriter<Type>::WriteDictionaryPage() {
   dict_encoder->mem_pool()->FreeAll();
 
   // TODO: Encodings are hard-coded
-  int64_t bytes_written = pager_->WriteDictionaryPage(
-      dict_encoder->num_entries(), buffer, Encoding::PLAIN_DICTIONARY);
-  total_bytes_written_ += bytes_written;
+  DictionaryPage page(buffer, dict_encoder->num_entries(), Encoding::PLAIN_DICTIONARY);
+  total_bytes_written_ += pager_->WriteDictionaryPage(page);
 }
 
 // ----------------------------------------------------------------------

--- a/src/parquet/column/writer.h
+++ b/src/parquet/column/writer.h
@@ -33,14 +33,6 @@
 
 namespace parquet {
 
-struct DataPageBuffers {
-  int64_t num_buffered_values;
-  int64_t num_buffered_encoded_values;
-  std::shared_ptr<Buffer> definition_levels;
-  std::shared_ptr<Buffer> repetition_levels;
-  std::shared_ptr<Buffer> values;
-};
-
 class PARQUET_EXPORT ColumnWriter {
  public:
   ColumnWriter(const ColumnDescriptor*, std::unique_ptr<PageWriter>,
@@ -67,7 +59,7 @@ class PARQUET_EXPORT ColumnWriter {
   virtual void WriteDictionaryPage() = 0;
 
   void AddDataPage();
-  void WriteNewPage(const DataPage& page);
+  void WriteDataPage(const DataPage& page);
 
   // Write multiple definition levels
   void WriteDefinitionLevels(int64_t num_levels, const int16_t* levels);
@@ -114,7 +106,6 @@ class PARQUET_EXPORT ColumnWriter {
  private:
   void InitSinks();
 
-  std::vector<DataPageBuffers> data_page_buffers_;
   std::vector<DataPage> data_pages_;
 };
 

--- a/src/parquet/column/writer.h
+++ b/src/parquet/column/writer.h
@@ -67,7 +67,7 @@ class PARQUET_EXPORT ColumnWriter {
   virtual void WriteDictionaryPage() = 0;
 
   void AddDataPage();
-  void WriteNewPage(const DataPageBuffers& buffers);
+  void WriteNewPage(const DataPage& page);
 
   // Write multiple definition levels
   void WriteDefinitionLevels(int64_t num_levels, const int16_t* levels);
@@ -115,6 +115,7 @@ class PARQUET_EXPORT ColumnWriter {
   void InitSinks();
 
   std::vector<DataPageBuffers> data_page_buffers_;
+  std::vector<DataPage> data_pages_;
 };
 
 // API to write values to a single column. This is the main client facing API.

--- a/src/parquet/encodings/dictionary-encoding.h
+++ b/src/parquet/encodings/dictionary-encoding.h
@@ -153,19 +153,32 @@ static constexpr double MAX_HASH_LOAD = 0.7;
 /// the dictionary is being constructed. At any time, the buffered values can be
 /// written out with the current dictionary size. More values can then be added to
 /// the encoder, including new dictionary entries.
-class DictEncoderBase {
+template <typename DType>
+class DictEncoder : public Encoder<DType> {
  public:
-  virtual ~DictEncoderBase() { DCHECK(buffered_indices_.empty()); }
+  typedef typename DType::c_type T;
 
-  /// Writes out the encoded dictionary to buffer. buffer must be preallocated to
-  /// dict_encoded_size() bytes.
-  virtual void WriteDict(uint8_t* buffer) = 0;
+  explicit DictEncoder(const ColumnDescriptor* desc, MemPool* pool = nullptr,
+      MemoryAllocator* allocator = default_allocator())
+      : Encoder<DType>(desc, Encoding::PLAIN_DICTIONARY, allocator),
+        allocator_(allocator),
+        pool_(pool),
+        hash_table_size_(INITIAL_HASH_TABLE_SIZE),
+        mod_bitmask_(hash_table_size_ - 1),
+        hash_slots_(0, allocator),
+        dict_encoded_size_(0),
+        type_length_(desc->type_length()) {
+    hash_slots_.Assign(hash_table_size_, HASH_SLOT_EMPTY);
+    if (!CpuInfo::initialized()) { CpuInfo::Init(); }
+  }
 
-  /// The number of entries in the dictionary.
-  virtual int num_entries() const = 0;
+  virtual ~DictEncoder() { DCHECK(buffered_indices_.empty()); }
 
-  /// Clears all the indices (but leaves the dictionary).
-  void ClearIndices() { buffered_indices_.clear(); }
+  // TODO(wesm): think about how to address the construction semantics in
+  // encodings/dictionary-encoding.h
+  void set_mem_pool(MemPool* pool) { pool_ = pool; }
+
+  void set_type_length(int type_length) { type_length_ = type_length; }
 
   /// Returns a conservative estimate of the number of bytes needed to encode the buffered
   /// indices. Used to size the buffer passed to WriteIndices().
@@ -194,18 +207,42 @@ class DictEncoderBase {
 
   int hash_table_size() { return hash_table_size_; }
   int dict_encoded_size() { return dict_encoded_size_; }
+  /// Clears all the indices (but leaves the dictionary).
+  void ClearIndices() { buffered_indices_.clear(); }
 
- protected:
-  explicit DictEncoderBase(MemPool* pool, MemoryAllocator* allocator)
-      : hash_table_size_(INITIAL_HASH_TABLE_SIZE),
-        mod_bitmask_(hash_table_size_ - 1),
-        hash_slots_(0, allocator),
-        allocator_(allocator),
-        pool_(pool),
-        dict_encoded_size_(0) {
-    hash_slots_.Assign(hash_table_size_, HASH_SLOT_EMPTY);
-    if (!CpuInfo::initialized()) { CpuInfo::Init(); }
+  /// Encode value. Note that this does not actually write any data, just
+  /// buffers the value's index to be written later.
+  void Put(const T& value);
+
+  std::shared_ptr<Buffer> FlushValues() override {
+    auto buffer = std::make_shared<OwnedMutableBuffer>(
+        EstimatedDataEncodedSize(), this->allocator_);
+    int result_size = WriteIndices(buffer->mutable_data(), EstimatedDataEncodedSize());
+    ClearIndices();
+    buffer->Resize(result_size);
+    return buffer;
+  };
+
+  void Put(const T* values, int num_values) override {
+    for (int i = 0; i < num_values; i++) {
+      Put(values[i]);
+    }
   }
+
+  /// Writes out the encoded dictionary to buffer. buffer must be preallocated to
+  /// dict_encoded_size() bytes.
+  void WriteDict(uint8_t* buffer);
+
+  MemPool* mem_pool() { return pool_; }
+
+  /// The number of entries in the dictionary.
+  int num_entries() const { return uniques_.size(); }
+
+ private:
+  MemoryAllocator* allocator_;
+
+  // For ByteArray / FixedLenByteArray data. Not owned
+  MemPool* pool_;
 
   /// Size of the table. Must be a power of 2.
   int hash_table_size_;
@@ -218,40 +255,13 @@ class DictEncoderBase {
   //
   // These values correspond to the uniques_ array
   Vector<hash_slot_t> hash_slots_;
-  MemoryAllocator* allocator_;
-
-  // For ByteArray / FixedLenByteArray data. Not owned
-  MemPool* pool_;
 
   /// Indices that have not yet be written out by WriteIndices().
   std::vector<int> buffered_indices_;
 
   /// The number of bytes needed to encode the dictionary.
   int dict_encoded_size_;
-};
 
-template <typename T>
-class DictEncoder : public DictEncoderBase {
- public:
-  explicit DictEncoder(MemPool* pool = nullptr,
-      MemoryAllocator* allocator = default_allocator(), int type_length = -1)
-      : DictEncoderBase(pool, allocator), type_length_(type_length) {}
-
-  // TODO(wesm): think about how to address the construction semantics in
-  // encodings/dictionary-encoding.h
-  void set_mem_pool(MemPool* pool) { pool_ = pool; }
-
-  void set_type_length(int type_length) { type_length_ = type_length; }
-
-  /// Encode value. Note that this does not actually write any data, just
-  /// buffers the value's index to be written later.
-  void Put(const T& value);
-
-  virtual void WriteDict(uint8_t* buffer);
-
-  virtual int num_entries() const { return uniques_.size(); }
-
- private:
   // The unique observed values
   std::vector<T> uniques_;
 
@@ -268,34 +278,35 @@ class DictEncoder : public DictEncoderBase {
   void AddDictKey(const T& value);
 };
 
-template <typename T>
-inline int DictEncoder<T>::Hash(const T& value) const {
+template <typename DType>
+inline int DictEncoder<DType>::Hash(const typename DType::c_type& value) const {
   return HashUtil::Hash(&value, sizeof(value), 0);
 }
 
 template <>
-inline int DictEncoder<ByteArray>::Hash(const ByteArray& value) const {
+inline int DictEncoder<ByteArrayType>::Hash(const ByteArray& value) const {
   return HashUtil::Hash(value.ptr, value.len, 0);
 }
 
 template <>
-inline int DictEncoder<FixedLenByteArray>::Hash(const FixedLenByteArray& value) const {
+inline int DictEncoder<FLBAType>::Hash(const FixedLenByteArray& value) const {
   return HashUtil::Hash(value.ptr, type_length_, 0);
 }
 
-template <typename T>
-inline bool DictEncoder<T>::SlotDifferent(const T& v, hash_slot_t slot) {
+template <typename DType>
+inline bool DictEncoder<DType>::SlotDifferent(
+    const typename DType::c_type& v, hash_slot_t slot) {
   return v != uniques_[slot];
 }
 
 template <>
-inline bool DictEncoder<FixedLenByteArray>::SlotDifferent(
+inline bool DictEncoder<FLBAType>::SlotDifferent(
     const FixedLenByteArray& v, hash_slot_t slot) {
   return 0 != memcmp(v.ptr, uniques_[slot].ptr, type_length_);
 }
 
-template <typename T>
-inline void DictEncoder<T>::Put(const T& v) {
+template <typename DType>
+inline void DictEncoder<DType>::Put(const typename DType::c_type& v) {
   int j = Hash(v) & mod_bitmask_;
   hash_slot_t index = hash_slots_[j];
 
@@ -321,8 +332,8 @@ inline void DictEncoder<T>::Put(const T& v) {
   buffered_indices_.push_back(index);
 }
 
-template <typename T>
-inline void DictEncoder<T>::DoubleTableSize() {
+template <typename DType>
+inline void DictEncoder<DType>::DoubleTableSize() {
   int new_size = hash_table_size_ * 2;
   Vector<hash_slot_t> new_hash_slots(0, allocator_);
   new_hash_slots.Assign(new_size, HASH_SLOT_EMPTY);
@@ -335,7 +346,7 @@ inline void DictEncoder<T>::DoubleTableSize() {
 
     // Compute the hash value mod the new table size to start looking for an
     // empty slot
-    const T& v = uniques_[index];
+    const typename DType::c_type& v = uniques_[index];
 
     // Find an empty slot in the new hash table
     j = Hash(v) & (new_size - 1);
@@ -356,14 +367,14 @@ inline void DictEncoder<T>::DoubleTableSize() {
   hash_slots_.Swap(new_hash_slots);
 }
 
-template <typename T>
-inline void DictEncoder<T>::AddDictKey(const T& v) {
+template <typename DType>
+inline void DictEncoder<DType>::AddDictKey(const typename DType::c_type& v) {
   uniques_.push_back(v);
-  dict_encoded_size_ += sizeof(T);
+  dict_encoded_size_ += sizeof(typename DType::c_type);
 }
 
 template <>
-inline void DictEncoder<ByteArray>::AddDictKey(const ByteArray& v) {
+inline void DictEncoder<ByteArrayType>::AddDictKey(const ByteArray& v) {
   uint8_t* heap = pool_->Allocate(v.len);
   if (UNLIKELY(v.len > 0 && heap == nullptr)) { throw ParquetException("out of memory"); }
   memcpy(heap, v.ptr, v.len);
@@ -372,7 +383,7 @@ inline void DictEncoder<ByteArray>::AddDictKey(const ByteArray& v) {
 }
 
 template <>
-inline void DictEncoder<FixedLenByteArray>::AddDictKey(const FixedLenByteArray& v) {
+inline void DictEncoder<FLBAType>::AddDictKey(const FixedLenByteArray& v) {
   uint8_t* heap = pool_->Allocate(type_length_);
   if (UNLIKELY(type_length_ > 0 && heap == nullptr)) {
     throw ParquetException("out of memory");
@@ -383,15 +394,24 @@ inline void DictEncoder<FixedLenByteArray>::AddDictKey(const FixedLenByteArray& 
   dict_encoded_size_ += type_length_;
 }
 
-template <typename T>
-inline void DictEncoder<T>::WriteDict(uint8_t* buffer) {
+template <typename DType>
+inline void DictEncoder<DType>::WriteDict(uint8_t* buffer) {
   // For primitive types, only a memcpy
-  memcpy(buffer, &uniques_[0], sizeof(T) * uniques_.size());
+  memcpy(buffer, uniques_.data(), sizeof(typename DType::c_type) * uniques_.size());
+}
+
+template <>
+inline void DictEncoder<BooleanType>::WriteDict(uint8_t* buffer) {
+  // For primitive types, only a memcpy
+  // memcpy(buffer, uniques_.data(), sizeof(typename DType::c_type) * uniques_.size());
+  for (size_t i = 0; i < uniques_.size(); i++) {
+    buffer[i] = uniques_[i];
+  }
 }
 
 // ByteArray and FLBA already have the dictionary encoded in their data heaps
 template <>
-inline void DictEncoder<ByteArray>::WriteDict(uint8_t* buffer) {
+inline void DictEncoder<ByteArrayType>::WriteDict(uint8_t* buffer) {
   for (const ByteArray& v : uniques_) {
     memcpy(buffer, reinterpret_cast<const void*>(&v.len), sizeof(uint32_t));
     buffer += sizeof(uint32_t);
@@ -401,14 +421,15 @@ inline void DictEncoder<ByteArray>::WriteDict(uint8_t* buffer) {
 }
 
 template <>
-inline void DictEncoder<FixedLenByteArray>::WriteDict(uint8_t* buffer) {
+inline void DictEncoder<FLBAType>::WriteDict(uint8_t* buffer) {
   for (const FixedLenByteArray& v : uniques_) {
     memcpy(buffer, v.ptr, type_length_);
     buffer += type_length_;
   }
 }
 
-inline int DictEncoderBase::WriteIndices(uint8_t* buffer, int buffer_len) {
+template <typename DType>
+inline int DictEncoder<DType>::WriteIndices(uint8_t* buffer, int buffer_len) {
   // Write bit width in first byte
   *buffer = bit_width();
   ++buffer;

--- a/src/parquet/encodings/dictionary-encoding.h
+++ b/src/parquet/encodings/dictionary-encoding.h
@@ -182,7 +182,7 @@ class DictEncoder : public Encoder<DType> {
 
   /// Returns a conservative estimate of the number of bytes needed to encode the buffered
   /// indices. Used to size the buffer passed to WriteIndices().
-  int EstimatedDataEncodedSize() {
+  int64_t EstimatedDataEncodedSize() override {
     // Note: because of the way RleEncoder::CheckBufferFull() is called, we have to
     // reserve
     // an extra "RleEncoder::MinBufferSize" bytes. These extra bytes won't be used

--- a/src/parquet/encodings/encoder.h
+++ b/src/parquet/encodings/encoder.h
@@ -19,12 +19,14 @@
 #define PARQUET_ENCODINGS_ENCODER_H
 
 #include <cstdint>
+#include <memory>
 
 #include "parquet/exception.h"
 #include "parquet/types.h"
 
 namespace parquet {
 
+class Buffer;
 class ColumnDescriptor;
 class OutputStream;
 
@@ -39,7 +41,8 @@ class Encoder {
 
   virtual ~Encoder() {}
 
-  virtual void Encode(const T* src, int num_values, OutputStream* dst) = 0;
+  virtual std::shared_ptr<Buffer> FlushValues() = 0;
+  virtual void Put(const T* src, int num_values) = 0;
 
   const Encoding::type encoding() const { return encoding_; }
 

--- a/src/parquet/encodings/encoder.h
+++ b/src/parquet/encodings/encoder.h
@@ -41,6 +41,7 @@ class Encoder {
 
   virtual ~Encoder() {}
 
+  virtual int64_t EstimatedDataEncodedSize() = 0;
   virtual std::shared_ptr<Buffer> FlushValues() = 0;
   virtual void Put(const T* src, int num_values) = 0;
 

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -37,7 +37,7 @@ SerializedPageWriter::SerializedPageWriter(OutputStream* sink, Compression::type
     format::ColumnChunk* metadata, MemoryAllocator* allocator)
     : sink_(sink),
       metadata_(metadata),
-      allocator_(allocator),
+      // allocator_(allocator),
       compression_buffer_(std::make_shared<OwnedMutableBuffer>(0, allocator)) {
   compressor_ = Codec::Create(codec);
   // Currently we directly start with the data page

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -52,9 +52,16 @@ class SerializedPageWriter : public PageWriter {
 
   // Compression codec to use.
   std::unique_ptr<Codec> compressor_;
-  OwnedMutableBuffer compression_buffer_;
+  std::shared_ptr<OwnedMutableBuffer> compression_buffer_;
 
   void AddEncoding(Encoding::type encoding);
+  /**
+   * Compress a buffer.
+   *
+   * This method may return compression_buffer_ and thus the resulting memory
+   * is only valid until the next call to Compress().
+   */
+  std::shared_ptr<Buffer> Compress(const std::shared_ptr<Buffer>& buffer);
 };
 
 // RowGroupWriter::Contents implementation for the Parquet file specification

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -49,6 +49,10 @@ class SerializedPageWriter : public PageWriter {
       Encoding::type repetition_level_encoding, const std::shared_ptr<Buffer>& values,
       Encoding::type encoding) override;
 
+  // TODO Refactor that this just takes a DictionaryPage instance.
+  int64_t WriteDictionaryPage(int32_t num_values, const std::shared_ptr<Buffer>& values,
+      Encoding::type encoding) override;
+
   void Close() override;
 
  private:

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -32,7 +32,6 @@ namespace parquet {
 // by a serialized Thrift format::PageHeader indicating the type of each page
 // and the page metadata.
 //
-// TODO: Currently only writes DataPage pages.
 class SerializedPageWriter : public PageWriter {
  public:
   SerializedPageWriter(OutputStream* sink, Compression::type codec,
@@ -42,18 +41,7 @@ class SerializedPageWriter : public PageWriter {
 
   int64_t WriteDataPage(const DataPage& page) override;
 
-  // TODO Refactor that this just takes a DataPage instance.
-  // For this we need to be clear how to handle num_rows and num_values
-  int64_t WriteDataPage(int32_t num_rows, int32_t num_values,
-      const std::shared_ptr<Buffer>& definition_levels,
-      Encoding::type definition_level_encoding,
-      const std::shared_ptr<Buffer>& repetition_levels,
-      Encoding::type repetition_level_encoding, const std::shared_ptr<Buffer>& values,
-      Encoding::type encoding) override;
-
-  // TODO Refactor that this just takes a DictionaryPage instance.
-  int64_t WriteDictionaryPage(int32_t num_values, const std::shared_ptr<Buffer>& values,
-      Encoding::type encoding) override;
+  int64_t WriteDictionaryPage(const DictionaryPage& page) override;
 
   void Close() override;
 

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -40,6 +40,8 @@ class SerializedPageWriter : public PageWriter {
 
   virtual ~SerializedPageWriter() {}
 
+  int64_t WriteDataPage(const DataPage& page) override;
+
   // TODO Refactor that this just takes a DataPage instance.
   // For this we need to be clear how to handle num_rows and num_values
   int64_t WriteDataPage(int32_t num_rows, int32_t num_values,

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -48,7 +48,7 @@ class SerializedPageWriter : public PageWriter {
  private:
   OutputStream* sink_;
   format::ColumnChunk* metadata_;
-  MemoryAllocator* allocator_;
+  // MemoryAllocator* allocator_;
 
   // Compression codec to use.
   std::unique_ptr<Codec> compressor_;


### PR DESCRIPTION
Working version but still some minor stuff to clean up (but I'd be happy for comments).

Had to change the Encoder interface to make it work with dictionary encoding. Also dictionary encoded RowGroups are currently limited to a single DataPage.