### PR TITLE
PARQUET-573: Create a public API for reading and writing file metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,7 +498,7 @@ set(LIBPARQUET_SRCS
   src/parquet/compression/snappy-codec.cc
   src/parquet/compression/gzip-codec.cc
 
-  src/parquet/file/metadata-internal.cc
+  src/parquet/file/metadata.cc
   src/parquet/file/reader.cc
   src/parquet/file/reader-internal.cc
   src/parquet/file/writer.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,6 +498,7 @@ set(LIBPARQUET_SRCS
   src/parquet/compression/snappy-codec.cc
   src/parquet/compression/gzip-codec.cc
 
+  src/parquet/file/metadata-internal.cc
   src/parquet/file/reader.cc
   src/parquet/file/reader-internal.cc
   src/parquet/file/writer.cc

--- a/example/parquet-dump-schema.cc
+++ b/example/parquet-dump-schema.cc
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
 
   try {
     std::unique_ptr<ParquetFileReader> reader = ParquetFileReader::OpenFile(filename);
-    PrintSchema(reader->descr()->schema().get(), std::cout);
+    PrintSchema(reader->metadata()->schema()->schema().get(), std::cout);
   } catch (const std::exception& e) {
     std::cerr << "Parquet error: "
               << e.what()

--- a/example/parquet-dump-schema.cc
+++ b/example/parquet-dump-schema.cc
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
 
   try {
     std::unique_ptr<ParquetFileReader> reader = ParquetFileReader::OpenFile(filename);
-    PrintSchema(reader->metadata()->schema()->schema().get(), std::cout);
+    PrintSchema(reader->metadata()->schema_descriptor()->schema().get(), std::cout);
   } catch (const std::exception& e) {
     std::cerr << "Parquet error: "
               << e.what()

--- a/src/parquet/CMakeLists.txt
+++ b/src/parquet/CMakeLists.txt
@@ -21,8 +21,6 @@ install(FILES
   types.h
   DESTINATION include/parquet)
 
-ADD_PARQUET_TEST(public-api-test
-  LINKAGE shared)
-
+ADD_PARQUET_TEST(public-api-test)
 ADD_PARQUET_TEST(types-test)
 ADD_PARQUET_TEST(reader-test)

--- a/src/parquet/api/reader.h
+++ b/src/parquet/api/reader.h
@@ -23,6 +23,9 @@
 #include "parquet/exception.h"
 #include "parquet/file/reader.h"
 
+// Metadata reader API
+#include "parquet/file/metadata.h"
+
 // Schemas
 #include "parquet/api/schema.h"
 

--- a/src/parquet/column/properties.h
+++ b/src/parquet/column/properties.h
@@ -78,9 +78,9 @@ class PARQUET_EXPORT ReaderProperties {
 
 ReaderProperties PARQUET_EXPORT default_reader_properties();
 
-static int64_t DEFAULT_PAGE_SIZE = 1024 * 1024;
-static bool DEFAULT_IS_DICTIONARY_ENABLED = true;
-static int64_t DEFAULT_DICTIONARY_PAGE_SIZE = DEFAULT_PAGE_SIZE;
+static constexpr int64_t DEFAULT_PAGE_SIZE = 1024 * 1024;
+static constexpr bool DEFAULT_IS_DICTIONARY_ENABLED = true;
+static constexpr int64_t DEFAULT_DICTIONARY_PAGE_SIZE = DEFAULT_PAGE_SIZE;
 static constexpr Encoding::type DEFAULT_ENCODING = Encoding::PLAIN;
 static constexpr ParquetVersion::type DEFAULT_WRITER_VERSION =
     ParquetVersion::PARQUET_1_0;
@@ -240,7 +240,7 @@ class PARQUET_EXPORT WriterProperties {
 
   inline MemoryAllocator* allocator() const { return allocator_; }
 
-  bool dictionary_enabled(const std::shared_ptr<schema::ColumnPath>& path) const {
+  inline bool dictionary_enabled(const std::shared_ptr<schema::ColumnPath>& path) const {
     auto it = dictionary_enabled_.find(path->ToDotString());
     if (it != dictionary_enabled_.end()) { return it->second; }
     return dictionary_enabled_default_;
@@ -259,8 +259,6 @@ class PARQUET_EXPORT WriterProperties {
     if (it != encodings_.end()) { return it->second; }
     return default_encoding_;
   }
-
-  inline Encoding::type level_encoding() const { return Encoding::RLE; }
 
   inline Encoding::type dictionary_encoding() const {
     if (parquet_version_ == ParquetVersion::PARQUET_1_0) {

--- a/src/parquet/column/properties.h
+++ b/src/parquet/column/properties.h
@@ -260,7 +260,7 @@ class PARQUET_EXPORT WriterProperties {
     return default_encoding_;
   }
 
-  inline Encoding::type dictionary_encoding() const {
+  inline Encoding::type dictionary_index_encoding() const {
     if (parquet_version_ == ParquetVersion::PARQUET_1_0) {
       return Encoding::PLAIN_DICTIONARY;
     } else {
@@ -268,7 +268,7 @@ class PARQUET_EXPORT WriterProperties {
     }
   }
 
-  inline Encoding::type dictionary_index_encoding() const {
+  inline Encoding::type dictionary_page_encoding() const {
     if (parquet_version_ == ParquetVersion::PARQUET_1_0) {
       return Encoding::PLAIN_DICTIONARY;
     } else {

--- a/src/parquet/column/properties.h
+++ b/src/parquet/column/properties.h
@@ -151,7 +151,7 @@ class PARQUET_EXPORT WriterProperties {
       return this;
     }
 
-    Builder* set_level_encoding(
+    Builder* level_encoding(
         Encoding::type rep_level_encoding, Encoding::type def_level_encoding) {
       default_rep_level_encoding_ = rep_level_encoding;
       default_def_level_encoding_ = def_level_encoding;
@@ -167,7 +167,7 @@ class PARQUET_EXPORT WriterProperties {
       return this;
     }
 
-    Builder* dictionary_fallback_encodings(Encoding::type rep_level_encoding,
+    Builder* dictionary_fallback_encoding(Encoding::type rep_level_encoding,
         Encoding::type def_level_encoding, Encoding::type fallback_encoding) {
       default_rep_level_encoding_ = rep_level_encoding;
       default_def_level_encoding_ = def_level_encoding;

--- a/src/parquet/column/properties.h
+++ b/src/parquet/column/properties.h
@@ -34,14 +34,6 @@ struct ParquetVersion {
   enum type { PARQUET_1_0, PARQUET_2_0 };
 };
 
-struct ColumnEncodingSet {
-  Encoding::type def_level_encoding;
-  Encoding::type rep_level_encoding;
-  Encoding::type dictionary_encoding;
-  Encoding::type value_encoding;
-  Encoding::type dictionary_fallback_encoding;
-};
-
 static int64_t DEFAULT_BUFFER_SIZE = 0;
 static bool DEFAULT_USE_BUFFERED_STREAM = false;
 
@@ -88,18 +80,13 @@ ReaderProperties PARQUET_EXPORT default_reader_properties();
 static int64_t DEFAULT_PAGE_SIZE = 1024 * 1024;
 static bool DEFAULT_IS_DICTIONARY_ENABLED = true;
 static int64_t DEFAULT_DICTIONARY_PAGE_SIZE = DEFAULT_PAGE_SIZE;
-static int64_t DEFAULT_DICTIONARY_SIZE_THRESHOLD = DEFAULT_PAGE_SIZE;
-static constexpr Encoding::type DEFAULT_DICTIONARY_FALLBACK_ENCODING = Encoding::PLAIN;
-static constexpr Encoding::type DEFAULT_VALUE_ENCODING = Encoding::PLAIN_DICTIONARY;
-static constexpr Encoding::type DEFAULT_DICTIONARY_ENCODING = Encoding::PLAIN_DICTIONARY;
-static constexpr Encoding::type DEFAULT_LEVEL_ENCODING = Encoding::RLE;
+static constexpr Encoding::type DEFAULT_ENCODING = Encoding::PLAIN;
 static constexpr ParquetVersion::type DEFAULT_WRITER_VERSION =
     ParquetVersion::PARQUET_1_0;
 static std::string DEFAULT_CREATED_BY = "Apache parquet-cpp";
 static constexpr Compression::type DEFAULT_COMPRESSION_TYPE = Compression::UNCOMPRESSED;
 
 using ColumnCodecs = std::unordered_map<std::string, Compression::type>;
-using ColumnEncodings = std::unordered_map<std::string, ColumnEncodingSet>;
 
 class PARQUET_EXPORT WriterProperties {
  public:
@@ -109,15 +96,10 @@ class PARQUET_EXPORT WriterProperties {
         : allocator_(default_allocator()),
           dictionary_enabled_(DEFAULT_IS_DICTIONARY_ENABLED),
           dictionary_pagesize_(DEFAULT_DICTIONARY_PAGE_SIZE),
-          dictionary_size_threshold_(DEFAULT_DICTIONARY_SIZE_THRESHOLD),
-          default_rep_level_encoding_(DEFAULT_LEVEL_ENCODING),
-          default_def_level_encoding_(DEFAULT_LEVEL_ENCODING),
-          default_dictionary_encoding_(DEFAULT_DICTIONARY_ENCODING),
-          default_value_encoding_(DEFAULT_VALUE_ENCODING),
-          default_dictionary_fallback_encoding_(DEFAULT_DICTIONARY_FALLBACK_ENCODING),
           pagesize_(DEFAULT_PAGE_SIZE),
           version_(DEFAULT_WRITER_VERSION),
           created_by_(DEFAULT_CREATED_BY),
+          default_encoding_(DEFAULT_ENCODING),
           default_codec_(DEFAULT_COMPRESSION_TYPE) {}
     virtual ~Builder() {}
 
@@ -136,77 +118,34 @@ class PARQUET_EXPORT WriterProperties {
       return this;
     }
 
-    Builder* dictionary_size_threshold(int64_t dictionary_sizet) {
-      dictionary_size_threshold_ = dictionary_sizet;
-      return this;
-    }
-
     Builder* data_pagesize(int64_t pg_size) {
       pagesize_ = pg_size;
       return this;
     }
 
-    Builder* encodings(ColumnEncodings& encodings) {
-      encodings_ = encodings;
-      return this;
-    }
-
-    Builder* level_encoding(
-        Encoding::type rep_level_encoding, Encoding::type def_level_encoding) {
-      default_rep_level_encoding_ = rep_level_encoding;
-      default_def_level_encoding_ = def_level_encoding;
-      return this;
-    }
-
-    Builder* disable_dictionary_encoding(Encoding::type rep_level_encoding,
-        Encoding::type def_level_encoding, Encoding::type value_encoding) {
-      dictionary_enabled_ = false;
-      default_rep_level_encoding_ = rep_level_encoding;
-      default_def_level_encoding_ = def_level_encoding;
-      default_value_encoding_ = value_encoding;
-      return this;
-    }
-
-    Builder* dictionary_fallback_encoding(Encoding::type rep_level_encoding,
-        Encoding::type def_level_encoding, Encoding::type fallback_encoding) {
-      default_rep_level_encoding_ = rep_level_encoding;
-      default_def_level_encoding_ = def_level_encoding;
-      default_dictionary_fallback_encoding_ = fallback_encoding;
-      return this;
-    }
-
-    Builder* dictionary_fallback_encoding(Encoding::type encoding_type) {
-      default_dictionary_fallback_encoding_ = encoding_type;
-      return this;
-    }
-
-    Builder* value_encoding(Encoding::type encoding_type) {
-      default_value_encoding_ = encoding_type;
-      return this;
-    }
-
-    Builder* def_level_encoding(Encoding::type encoding_type) {
-      default_def_level_encoding_ = encoding_type;
-      return this;
-    }
-
-    Builder* rep_level_encoding(Encoding::type encoding_type) {
-      default_rep_level_encoding_ = encoding_type;
-      return this;
-    }
-
     Builder* version(ParquetVersion::type version) {
       version_ = version;
-      if (version == ParquetVersion::PARQUET_2_0) {
-        default_value_encoding_ = Encoding::RLE_DICTIONARY;
-        default_dictionary_encoding_ = Encoding::PLAIN;
-      }
       return this;
     }
 
     Builder* created_by(const std::string& created_by) {
       created_by_ = created_by;
       return this;
+    }
+
+    Builder* encoding(Encoding::type encoding_type) {
+      default_encoding_ = encoding_type;
+      return this;
+    }
+
+    Builder* encoding(const std::string& path, Encoding::type encoding_type) {
+      encodings_[path] = encoding_type;
+      return this;
+    }
+
+    Builder* encoding(
+        const std::shared_ptr<schema::ColumnPath>& path, Encoding::type encoding_type) {
+      return this->encoding(path->ToDotString(), encoding_type);
     }
 
     Builder* compression(Compression::type codec) {
@@ -225,30 +164,22 @@ class PARQUET_EXPORT WriterProperties {
     }
 
     std::shared_ptr<WriterProperties> build() {
-      return std::shared_ptr<WriterProperties>(
-          new WriterProperties(allocator_, dictionary_enabled_, dictionary_pagesize_,
-              dictionary_size_threshold_, default_rep_level_encoding_,
-              default_def_level_encoding_, default_dictionary_encoding_,
-              default_value_encoding_, default_dictionary_fallback_encoding_, encodings_,
-              pagesize_, version_, created_by_, default_codec_, codecs_));
+      return std::shared_ptr<WriterProperties>(new WriterProperties(allocator_,
+          dictionary_enabled_, dictionary_pagesize_, pagesize_, version_, created_by_,
+          default_encoding_, encodings_, default_codec_, codecs_));
     }
 
    private:
     MemoryAllocator* allocator_;
     bool dictionary_enabled_;
     int64_t dictionary_pagesize_;
-    int64_t dictionary_size_threshold_;
-    // Encoding used for each column if not a specialized one is defined as
-    // part of encodings_
-    Encoding::type default_rep_level_encoding_;
-    Encoding::type default_def_level_encoding_;
-    Encoding::type default_dictionary_encoding_;
-    Encoding::type default_value_encoding_;
-    Encoding::type default_dictionary_fallback_encoding_;
-    ColumnEncodings encodings_;
     int64_t pagesize_;
     ParquetVersion::type version_;
     std::string created_by_;
+    // Encoding used for each column if not a specialized one is defined as
+    // part of encodings_
+    Encoding::type default_encoding_;
+    std::unordered_map<std::string, Encoding::type> encodings_;
     // Default compression codec. This will be used for all columns that do
     // not have a specific codec set as part of codecs_
     Compression::type default_codec_;
@@ -259,8 +190,6 @@ class PARQUET_EXPORT WriterProperties {
 
   bool dictionary_enabled() const { return dictionary_enabled_; }
 
-  inline bool dictionary_size_threshold() const { return dictionary_size_threshold_; }
-
   inline int64_t dictionary_pagesize() const { return dictionary_pagesize_; }
 
   inline int64_t data_pagesize() const { return pagesize_; }
@@ -269,46 +198,28 @@ class PARQUET_EXPORT WriterProperties {
 
   inline std::string created_by() const { return parquet_created_by_; }
 
-  inline const ColumnEncodingSet& encodings(
-      const std::shared_ptr<schema::ColumnPath>& path) const {
+  inline Encoding::type encoding(const std::shared_ptr<schema::ColumnPath>& path) const {
     auto it = encodings_.find(path->ToDotString());
     if (it != encodings_.end()) { return it->second; }
-    return default_encodings_;
+    return default_encoding_;
   }
 
-  inline Encoding::type rep_level_encoding(
-      const std::shared_ptr<schema::ColumnPath>& path) const {
-    auto it = encodings_.find(path->ToDotString());
-    if (it != encodings_.end()) { return it->second.rep_level_encoding; }
-    return default_rep_level_encoding_;
+  inline Encoding::type level_encoding() const { return Encoding::RLE; }
+
+  inline Encoding::type dictionary_encoding() const {
+    if (parquet_version_ == ParquetVersion::PARQUET_1_0) {
+      return Encoding::PLAIN_DICTIONARY;
+    } else {
+      return Encoding::RLE_DICTIONARY;
+    }
   }
 
-  inline Encoding::type def_level_encoding(
-      const std::shared_ptr<schema::ColumnPath>& path) const {
-    auto it = encodings_.find(path->ToDotString());
-    if (it != encodings_.end()) { return it->second.def_level_encoding; }
-    return default_def_level_encoding_;
-  }
-
-  inline Encoding::type dictionary_encoding(
-      const std::shared_ptr<schema::ColumnPath>& path) const {
-    auto it = encodings_.find(path->ToDotString());
-    if (it != encodings_.end()) { return it->second.dictionary_encoding; }
-    return default_dictionary_encoding_;
-  }
-
-  inline Encoding::type value_encoding(
-      const std::shared_ptr<schema::ColumnPath>& path) const {
-    auto it = encodings_.find(path->ToDotString());
-    if (it != encodings_.end()) { return it->second.value_encoding; }
-    return default_value_encoding_;
-  }
-
-  inline Encoding::type dictionary_fallback_encoding(
-      const std::shared_ptr<schema::ColumnPath>& path) const {
-    auto it = encodings_.find(path->ToDotString());
-    if (it != encodings_.end()) { return it->second.dictionary_fallback_encoding; }
-    return default_dictionary_fallback_encoding_;
+  inline Encoding::type dictionary_index_encoding() const {
+    if (parquet_version_ == ParquetVersion::PARQUET_1_0) {
+      return Encoding::PLAIN_DICTIONARY;
+    } else {
+      return Encoding::PLAIN;
+    }
   }
 
   inline Compression::type compression(
@@ -320,53 +231,29 @@ class PARQUET_EXPORT WriterProperties {
 
  private:
   explicit WriterProperties(MemoryAllocator* allocator, bool dictionary_enabled,
-      int64_t dictionary_pagesize, int64_t dictionary_size_threshold,
-      Encoding::type rep_level_encoding, Encoding::type def_level_encoding,
-      Encoding::type dictionary_encoding, Encoding::type value_encoding,
-      Encoding::type dictionary_fallback_encoding, const ColumnEncodings& encodings,
-      int64_t pagesize, ParquetVersion::type version, const std::string& created_by,
+      int64_t dictionary_pagesize, int64_t pagesize, ParquetVersion::type version,
+      const std::string& created_by, Encoding::type default_encoding,
+      std::unordered_map<std::string, Encoding::type> encodings,
       Compression::type default_codec, const ColumnCodecs& codecs)
       : allocator_(allocator),
         dictionary_enabled_(dictionary_enabled),
         dictionary_pagesize_(dictionary_pagesize),
-        default_rep_level_encoding_(rep_level_encoding),
-        default_def_level_encoding_(def_level_encoding),
-        default_dictionary_encoding_(dictionary_encoding),
-        default_value_encoding_(value_encoding),
-        default_dictionary_fallback_encoding_(dictionary_fallback_encoding),
-        encodings_(encodings),
         pagesize_(pagesize),
         parquet_version_(version),
         parquet_created_by_(created_by),
+        default_encoding_(default_encoding),
+        encodings_(encodings),
         default_codec_(default_codec),
-        codecs_(codecs) {
-    if (version == ParquetVersion::PARQUET_2_0) {
-      default_value_encoding_ = Encoding::RLE_DICTIONARY;
-      default_dictionary_encoding_ = Encoding::PLAIN;
-    }
-    pagesize_ = DEFAULT_PAGE_SIZE;
-    default_encodings_.def_level_encoding = default_def_level_encoding_;
-    default_encodings_.rep_level_encoding = default_rep_level_encoding_;
-    default_encodings_.dictionary_encoding = default_dictionary_encoding_;
-    default_encodings_.value_encoding = default_value_encoding_;
-    default_encodings_.dictionary_fallback_encoding =
-        default_dictionary_fallback_encoding_;
-  }
+        codecs_(codecs) {}
   MemoryAllocator* allocator_;
   bool dictionary_enabled_;
   int64_t dictionary_pagesize_;
-  int64_t dictionary_size_threshold_;
-  Encoding::type default_rep_level_encoding_;
-  Encoding::type default_def_level_encoding_;
-  Encoding::type default_dictionary_encoding_;
-  Encoding::type default_value_encoding_;
-  Encoding::type default_dictionary_fallback_encoding_;
-  ColumnEncodings encodings_;
   int64_t pagesize_;
   ParquetVersion::type parquet_version_;
   std::string parquet_created_by_;
+  Encoding::type default_encoding_;
+  std::unordered_map<std::string, Encoding::type> encodings_;
   Compression::type default_codec_;
-  ColumnEncodingSet default_encodings_;
   ColumnCodecs codecs_;
 };
 

--- a/src/parquet/column/properties.h
+++ b/src/parquet/column/properties.h
@@ -95,7 +95,7 @@ class PARQUET_EXPORT WriterProperties {
    public:
     Builder()
         : allocator_(default_allocator()),
-          dictionary_enabled_(DEFAULT_IS_DICTIONARY_ENABLED),
+          dictionary_enabled_default_(DEFAULT_IS_DICTIONARY_ENABLED),
           dictionary_pagesize_(DEFAULT_DICTIONARY_PAGE_SIZE),
           pagesize_(DEFAULT_PAGE_SIZE),
           version_(DEFAULT_WRITER_VERSION),

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -195,7 +195,7 @@ std::shared_ptr<ColumnWriter> ColumnWriter::Make(const ColumnDescriptor* descr,
     const WriterProperties* properties) {
   Encoding::type encoding = properties->encoding(descr->path());
   if (properties->dictionary_enabled(descr->path())) {
-    encoding = properties->dictionary_encoding();
+    encoding = properties->dictionary_page_encoding();
   }
   switch (descr->physical_type()) {
     case Type::BOOLEAN:

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -194,7 +194,7 @@ void TypedColumnWriter<Type>::WriteDictionaryPage() {
 std::shared_ptr<ColumnWriter> ColumnWriter::Make(const ColumnDescriptor* descr,
     std::unique_ptr<PageWriter> pager, int64_t expected_rows,
     const WriterProperties* properties) {
-  Encoding::type encoding = properties->value_encoding(descr->path());
+  Encoding::type encoding = properties->encoding(descr->path());
   switch (descr->physical_type()) {
     case Type::BOOLEAN:
       return std::make_shared<BoolWriter>(

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -194,7 +194,7 @@ void TypedColumnWriter<Type>::WriteDictionaryPage() {
 std::shared_ptr<ColumnWriter> ColumnWriter::Make(const ColumnDescriptor* descr,
     std::unique_ptr<PageWriter> pager, int64_t expected_rows,
     const WriterProperties* properties) {
-  Encoding::type encoding = properties->encoding(descr->path());
+  Encoding::type encoding = properties->value_encoding(descr->path());
   switch (descr->physical_type()) {
     case Type::BOOLEAN:
       return std::make_shared<BoolWriter>(

--- a/src/parquet/column/writer.cc
+++ b/src/parquet/column/writer.cc
@@ -182,9 +182,8 @@ void TypedColumnWriter<Type>::WriteDictionaryPage() {
   // TODO Get rid of this deep call
   dict_encoder->mem_pool()->FreeAll();
 
-  Encoding::type dict_encoding = Encoding::PLAIN_DICTIONARY;
-  if (encoding_ == Encoding::RLE_DICTIONARY) { dict_encoding = Encoding::PLAIN; }
-  DictionaryPage page(buffer, dict_encoder->num_entries(), dict_encoding);
+  DictionaryPage page(
+      buffer, dict_encoder->num_entries(), properties_->dictionary_index_encoding());
   total_bytes_written_ += pager_->WriteDictionaryPage(page);
 }
 
@@ -195,6 +194,9 @@ std::shared_ptr<ColumnWriter> ColumnWriter::Make(const ColumnDescriptor* descr,
     std::unique_ptr<PageWriter> pager, int64_t expected_rows,
     const WriterProperties* properties) {
   Encoding::type encoding = properties->encoding(descr->path());
+  if (properties->dictionary_enabled(descr->path())) {
+    encoding = properties->dictionary_encoding();
+  }
   switch (descr->physical_type()) {
     case Type::BOOLEAN:
       return std::make_shared<BoolWriter>(

--- a/src/parquet/file/CMakeLists.txt
+++ b/src/parquet/file/CMakeLists.txt
@@ -16,9 +16,11 @@
 # under the License.
 
 install(FILES
+  metadata.h
   reader.h
   writer.h
   DESTINATION include/parquet/file)
 
 ADD_PARQUET_TEST(file-deserialize-test)
+ADD_PARQUET_TEST(file-metadata-test)
 ADD_PARQUET_TEST(file-serialize-test)

--- a/src/parquet/file/file-metadata-test.cc
+++ b/src/parquet/file/file-metadata-test.cc
@@ -64,8 +64,8 @@ TEST(Metadata, TestBuildAccess) {
   // column metadata
   col1_builder->SetStatistics(stats_int);
   col2_builder->SetStatistics(stats_float);
-  col1_builder->Finish(nrows / 2, 0, 0, 4, 512, 512);
-  col2_builder->Finish(nrows / 2, 0, 0, 4, 512, 512);
+  col1_builder->Finish(nrows / 2, 0, 0, 4, 512, 600, false);
+  col2_builder->Finish(nrows / 2, 0, 0, 4, 512, 600, false);
   rg1_builder->Finish(nrows / 2);
 
   // rowgroup2 metadata
@@ -74,8 +74,8 @@ TEST(Metadata, TestBuildAccess) {
   // column metadata
   col1_builder->SetStatistics(stats_int);
   col2_builder->SetStatistics(stats_float);
-  col1_builder->Finish(nrows / 2, 0, 0, 6, 512, 512);
-  col2_builder->Finish(nrows / 2, 0, 0, 516, 512, 512);
+  col1_builder->Finish(nrows / 2, 0, 0, 6, 512, 600, false);
+  col2_builder->Finish(nrows / 2, 0, 0, 516, 512, 600, false);
   rg2_builder->Finish(nrows / 2);
 
   // Read the metadata
@@ -96,24 +96,26 @@ TEST(Metadata, TestBuildAccess) {
 
   auto rg1_column1 = rg1_accessor->GetColumnMetaData(0);
   auto rg1_column2 = rg1_accessor->GetColumnMetaData(1);
-  ASSERT_EQ(true, rg1_column1->IsStatsSet());
-  ASSERT_EQ(true, rg1_column2->IsStatsSet());
-  ASSERT_EQ("100.100", *rg1_column2->GetStats().min);
-  ASSERT_EQ("200.200", *rg1_column2->GetStats().max);
-  ASSERT_EQ("100", *rg1_column1->GetStats().min);
-  ASSERT_EQ("200", *rg1_column1->GetStats().max);
-  ASSERT_EQ(0, rg1_column1->GetStats().null_count);
-  ASSERT_EQ(0, rg1_column2->GetStats().null_count);
-  ASSERT_EQ(nrows, rg1_column1->GetStats().distinct_count);
-  ASSERT_EQ(nrows, rg1_column2->GetStats().distinct_count);
-  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column1->GetCompression());
-  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column2->GetCompression());
-  ASSERT_EQ(2, rg1_column1->GetEncodings().size());
-  ASSERT_EQ(2, rg1_column2->GetEncodings().size());
-  ASSERT_EQ(512, rg1_column1->GetCompressedSize());
-  ASSERT_EQ(512, rg1_column2->GetCompressedSize());
-  ASSERT_EQ(512, rg1_column1->GetUnCompressedSize());
-  ASSERT_EQ(512, rg1_column2->GetUnCompressedSize());
+  ASSERT_EQ(true, rg1_column1->is_stats_set());
+  ASSERT_EQ(true, rg1_column2->is_stats_set());
+  ASSERT_EQ("100.100", *rg1_column2->Stats().min);
+  ASSERT_EQ("200.200", *rg1_column2->Stats().max);
+  ASSERT_EQ("100", *rg1_column1->Stats().min);
+  ASSERT_EQ("200", *rg1_column1->Stats().max);
+  ASSERT_EQ(0, rg1_column1->Stats().null_count);
+  ASSERT_EQ(0, rg1_column2->Stats().null_count);
+  ASSERT_EQ(nrows, rg1_column1->Stats().distinct_count);
+  ASSERT_EQ(nrows, rg1_column2->Stats().distinct_count);
+  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column1->compression());
+  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column2->compression());
+  ASSERT_EQ(nrows / 2, rg1_column1->num_values());
+  ASSERT_EQ(nrows / 2, rg1_column2->num_values());
+  ASSERT_EQ(2, rg1_column1->Encodings().size());
+  ASSERT_EQ(2, rg1_column2->Encodings().size());
+  ASSERT_EQ(512, rg1_column1->total_compressed_size());
+  ASSERT_EQ(512, rg1_column2->total_compressed_size());
+  ASSERT_EQ(600, rg1_column1->total_uncompressed_size());
+  ASSERT_EQ(600, rg1_column2->total_uncompressed_size());
 
   auto rg2_accessor = f_accessor->GetRowGroupMetaData(1);
   ASSERT_EQ(2, rg2_accessor->num_columns());
@@ -122,24 +124,26 @@ TEST(Metadata, TestBuildAccess) {
 
   auto rg2_column1 = rg2_accessor->GetColumnMetaData(0);
   auto rg2_column2 = rg2_accessor->GetColumnMetaData(1);
-  ASSERT_EQ(true, rg2_column1->IsStatsSet());
-  ASSERT_EQ(true, rg2_column2->IsStatsSet());
-  ASSERT_EQ("100.100", *rg2_column2->GetStats().min);
-  ASSERT_EQ("200.200", *rg2_column2->GetStats().max);
-  ASSERT_EQ("100", *rg2_column1->GetStats().min);
-  ASSERT_EQ("200", *rg2_column1->GetStats().max);
-  ASSERT_EQ(0, rg2_column1->GetStats().null_count);
-  ASSERT_EQ(0, rg2_column2->GetStats().null_count);
-  ASSERT_EQ(nrows, rg2_column1->GetStats().distinct_count);
-  ASSERT_EQ(nrows, rg2_column2->GetStats().distinct_count);
-  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column1->GetCompression());
-  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column2->GetCompression());
-  ASSERT_EQ(2, rg2_column1->GetEncodings().size());
-  ASSERT_EQ(2, rg2_column2->GetEncodings().size());
-  ASSERT_EQ(512, rg2_column1->GetCompressedSize());
-  ASSERT_EQ(512, rg2_column2->GetCompressedSize());
-  ASSERT_EQ(512, rg2_column1->GetUnCompressedSize());
-  ASSERT_EQ(512, rg2_column2->GetUnCompressedSize());
+  ASSERT_EQ(true, rg2_column1->is_stats_set());
+  ASSERT_EQ(true, rg2_column2->is_stats_set());
+  ASSERT_EQ("100.100", *rg2_column2->Stats().min);
+  ASSERT_EQ("200.200", *rg2_column2->Stats().max);
+  ASSERT_EQ("100", *rg2_column1->Stats().min);
+  ASSERT_EQ("200", *rg2_column1->Stats().max);
+  ASSERT_EQ(0, rg2_column1->Stats().null_count);
+  ASSERT_EQ(0, rg2_column2->Stats().null_count);
+  ASSERT_EQ(nrows, rg2_column1->Stats().distinct_count);
+  ASSERT_EQ(nrows, rg2_column2->Stats().distinct_count);
+  ASSERT_EQ(nrows / 2, rg2_column1->num_values());
+  ASSERT_EQ(nrows / 2, rg2_column2->num_values());
+  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column1->compression());
+  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column2->compression());
+  ASSERT_EQ(2, rg2_column1->Encodings().size());
+  ASSERT_EQ(2, rg2_column2->Encodings().size());
+  ASSERT_EQ(512, rg2_column1->total_compressed_size());
+  ASSERT_EQ(512, rg2_column2->total_compressed_size());
+  ASSERT_EQ(600, rg2_column1->total_uncompressed_size());
+  ASSERT_EQ(600, rg2_column2->total_uncompressed_size());
 }
 }  // namespace metadata
 }  // namespace parquet

--- a/src/parquet/file/file-metadata-test.cc
+++ b/src/parquet/file/file-metadata-test.cc
@@ -33,7 +33,7 @@ TEST(Metadata, TestBuildAccess) {
   std::shared_ptr<WriterProperties> props = WriterProperties::Builder().build();
 
   fields.push_back(parquet::schema::Int32("int_col", Repetition::REQUIRED));
-  fields.push_back(parquet::schema::Int32("float_col", Repetition::REQUIRED));
+  fields.push_back(parquet::schema::Float("float_col", Repetition::REQUIRED));
   root = parquet::schema::GroupNode::Make("schema", Repetition::REPEATED, fields);
   schema.Init(root);
 
@@ -53,7 +53,7 @@ TEST(Metadata, TestBuildAccess) {
   stats_float.min = &float_min;
   stats_float.max = &float_max;
 
-  auto f_builder = FileMetaDataBuilder::GetFileMetaDataBuilder(&schema, props);
+  auto f_builder = FileMetaDataBuilder::Make(&schema, props);
   auto rg1_builder = f_builder->AppendRowGroupMetaData();
   auto rg2_builder = f_builder->AppendRowGroupMetaData();
 
@@ -89,23 +89,23 @@ TEST(Metadata, TestBuildAccess) {
   ASSERT_EQ(3, f_accessor->num_schema_elements());
 
   // row group1 metadata
-  auto rg1_accessor = f_accessor->GetRowGroupMetaData(0);
+  auto rg1_accessor = f_accessor->RowGroup(0);
   ASSERT_EQ(2, rg1_accessor->num_columns());
   ASSERT_EQ(nrows / 2, rg1_accessor->num_rows());
   ASSERT_EQ(1024, rg1_accessor->total_byte_size());
 
-  auto rg1_column1 = rg1_accessor->GetColumnMetaData(0);
-  auto rg1_column2 = rg1_accessor->GetColumnMetaData(1);
+  auto rg1_column1 = rg1_accessor->Column(0);
+  auto rg1_column2 = rg1_accessor->Column(1);
   ASSERT_EQ(true, rg1_column1->is_stats_set());
   ASSERT_EQ(true, rg1_column2->is_stats_set());
-  ASSERT_EQ("100.100", *rg1_column2->Stats().min);
-  ASSERT_EQ("200.200", *rg1_column2->Stats().max);
-  ASSERT_EQ("100", *rg1_column1->Stats().min);
-  ASSERT_EQ("200", *rg1_column1->Stats().max);
-  ASSERT_EQ(0, rg1_column1->Stats().null_count);
-  ASSERT_EQ(0, rg1_column2->Stats().null_count);
-  ASSERT_EQ(nrows, rg1_column1->Stats().distinct_count);
-  ASSERT_EQ(nrows, rg1_column2->Stats().distinct_count);
+  ASSERT_EQ("100.100", *rg1_column2->Statistics().min);
+  ASSERT_EQ("200.200", *rg1_column2->Statistics().max);
+  ASSERT_EQ("100", *rg1_column1->Statistics().min);
+  ASSERT_EQ("200", *rg1_column1->Statistics().max);
+  ASSERT_EQ(0, rg1_column1->Statistics().null_count);
+  ASSERT_EQ(0, rg1_column2->Statistics().null_count);
+  ASSERT_EQ(nrows, rg1_column1->Statistics().distinct_count);
+  ASSERT_EQ(nrows, rg1_column2->Statistics().distinct_count);
   ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column1->compression());
   ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column2->compression());
   ASSERT_EQ(nrows / 2, rg1_column1->num_values());
@@ -117,23 +117,23 @@ TEST(Metadata, TestBuildAccess) {
   ASSERT_EQ(600, rg1_column1->total_uncompressed_size());
   ASSERT_EQ(600, rg1_column2->total_uncompressed_size());
 
-  auto rg2_accessor = f_accessor->GetRowGroupMetaData(1);
+  auto rg2_accessor = f_accessor->RowGroup(1);
   ASSERT_EQ(2, rg2_accessor->num_columns());
   ASSERT_EQ(nrows / 2, rg2_accessor->num_rows());
   ASSERT_EQ(1024, rg2_accessor->total_byte_size());
 
-  auto rg2_column1 = rg2_accessor->GetColumnMetaData(0);
-  auto rg2_column2 = rg2_accessor->GetColumnMetaData(1);
+  auto rg2_column1 = rg2_accessor->Column(0);
+  auto rg2_column2 = rg2_accessor->Column(1);
   ASSERT_EQ(true, rg2_column1->is_stats_set());
   ASSERT_EQ(true, rg2_column2->is_stats_set());
-  ASSERT_EQ("100.100", *rg2_column2->Stats().min);
-  ASSERT_EQ("200.200", *rg2_column2->Stats().max);
-  ASSERT_EQ("100", *rg2_column1->Stats().min);
-  ASSERT_EQ("200", *rg2_column1->Stats().max);
-  ASSERT_EQ(0, rg2_column1->Stats().null_count);
-  ASSERT_EQ(0, rg2_column2->Stats().null_count);
-  ASSERT_EQ(nrows, rg2_column1->Stats().distinct_count);
-  ASSERT_EQ(nrows, rg2_column2->Stats().distinct_count);
+  ASSERT_EQ("100.100", *rg2_column2->Statistics().min);
+  ASSERT_EQ("200.200", *rg2_column2->Statistics().max);
+  ASSERT_EQ("100", *rg2_column1->Statistics().min);
+  ASSERT_EQ("200", *rg2_column1->Statistics().max);
+  ASSERT_EQ(0, rg2_column1->Statistics().null_count);
+  ASSERT_EQ(0, rg2_column2->Statistics().null_count);
+  ASSERT_EQ(nrows, rg2_column1->Statistics().distinct_count);
+  ASSERT_EQ(nrows, rg2_column2->Statistics().distinct_count);
   ASSERT_EQ(nrows / 2, rg2_column1->num_values());
   ASSERT_EQ(nrows / 2, rg2_column2->num_values());
   ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column1->compression());

--- a/src/parquet/file/file-metadata-test.cc
+++ b/src/parquet/file/file-metadata-test.cc
@@ -64,8 +64,8 @@ TEST(Metadata, TestBuildAccess) {
   // column metadata
   col1_builder->SetStatistics(stats_int);
   col2_builder->SetStatistics(stats_float);
-  col1_builder->Finish(nrows / 2, 0, 0, 4, 512, 600, false);
-  col2_builder->Finish(nrows / 2, 0, 0, 4, 512, 600, false);
+  col1_builder->Finish(nrows / 2, 4, 0, 10, 512, 600, false);
+  col2_builder->Finish(nrows / 2, 24, 0, 30, 512, 600, false);
   rg1_builder->Finish(nrows / 2);
 
   // rowgroup2 metadata
@@ -74,8 +74,8 @@ TEST(Metadata, TestBuildAccess) {
   // column metadata
   col1_builder->SetStatistics(stats_int);
   col2_builder->SetStatistics(stats_float);
-  col1_builder->Finish(nrows / 2, 0, 0, 6, 512, 600, false);
-  col2_builder->Finish(nrows / 2, 0, 0, 516, 512, 600, false);
+  col1_builder->Finish(nrows / 2, 6, 0, 10, 512, 600, false);
+  col2_builder->Finish(nrows / 2, 16, 0, 26, 512, 600, false);
   rg2_builder->Finish(nrows / 2);
 
   // Read the metadata
@@ -98,24 +98,28 @@ TEST(Metadata, TestBuildAccess) {
   auto rg1_column2 = rg1_accessor->ColumnChunk(1);
   ASSERT_EQ(true, rg1_column1->is_stats_set());
   ASSERT_EQ(true, rg1_column2->is_stats_set());
-  ASSERT_EQ("100.100", *rg1_column2->Statistics().min);
-  ASSERT_EQ("200.200", *rg1_column2->Statistics().max);
-  ASSERT_EQ("100", *rg1_column1->Statistics().min);
-  ASSERT_EQ("200", *rg1_column1->Statistics().max);
-  ASSERT_EQ(0, rg1_column1->Statistics().null_count);
-  ASSERT_EQ(0, rg1_column2->Statistics().null_count);
-  ASSERT_EQ(nrows, rg1_column1->Statistics().distinct_count);
-  ASSERT_EQ(nrows, rg1_column2->Statistics().distinct_count);
+  ASSERT_EQ("100.100", *rg1_column2->statistics().min);
+  ASSERT_EQ("200.200", *rg1_column2->statistics().max);
+  ASSERT_EQ("100", *rg1_column1->statistics().min);
+  ASSERT_EQ("200", *rg1_column1->statistics().max);
+  ASSERT_EQ(0, rg1_column1->statistics().null_count);
+  ASSERT_EQ(0, rg1_column2->statistics().null_count);
+  ASSERT_EQ(nrows, rg1_column1->statistics().distinct_count);
+  ASSERT_EQ(nrows, rg1_column2->statistics().distinct_count);
   ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column1->compression());
   ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column2->compression());
   ASSERT_EQ(nrows / 2, rg1_column1->num_values());
   ASSERT_EQ(nrows / 2, rg1_column2->num_values());
-  ASSERT_EQ(2, rg1_column1->Encodings().size());
-  ASSERT_EQ(2, rg1_column2->Encodings().size());
+  ASSERT_EQ(2, rg1_column1->encodings().size());
+  ASSERT_EQ(2, rg1_column2->encodings().size());
   ASSERT_EQ(512, rg1_column1->total_compressed_size());
   ASSERT_EQ(512, rg1_column2->total_compressed_size());
   ASSERT_EQ(600, rg1_column1->total_uncompressed_size());
   ASSERT_EQ(600, rg1_column2->total_uncompressed_size());
+  ASSERT_EQ(4, rg1_column1->dictionary_page_offset());
+  ASSERT_EQ(24, rg1_column2->dictionary_page_offset());
+  ASSERT_EQ(10, rg1_column1->data_page_offset());
+  ASSERT_EQ(30, rg1_column2->data_page_offset());
 
   auto rg2_accessor = f_accessor->RowGroup(1);
   ASSERT_EQ(2, rg2_accessor->num_columns());
@@ -126,24 +130,28 @@ TEST(Metadata, TestBuildAccess) {
   auto rg2_column2 = rg2_accessor->ColumnChunk(1);
   ASSERT_EQ(true, rg2_column1->is_stats_set());
   ASSERT_EQ(true, rg2_column2->is_stats_set());
-  ASSERT_EQ("100.100", *rg2_column2->Statistics().min);
-  ASSERT_EQ("200.200", *rg2_column2->Statistics().max);
-  ASSERT_EQ("100", *rg2_column1->Statistics().min);
-  ASSERT_EQ("200", *rg2_column1->Statistics().max);
-  ASSERT_EQ(0, rg2_column1->Statistics().null_count);
-  ASSERT_EQ(0, rg2_column2->Statistics().null_count);
-  ASSERT_EQ(nrows, rg2_column1->Statistics().distinct_count);
-  ASSERT_EQ(nrows, rg2_column2->Statistics().distinct_count);
+  ASSERT_EQ("100.100", *rg2_column2->statistics().min);
+  ASSERT_EQ("200.200", *rg2_column2->statistics().max);
+  ASSERT_EQ("100", *rg2_column1->statistics().min);
+  ASSERT_EQ("200", *rg2_column1->statistics().max);
+  ASSERT_EQ(0, rg2_column1->statistics().null_count);
+  ASSERT_EQ(0, rg2_column2->statistics().null_count);
+  ASSERT_EQ(nrows, rg2_column1->statistics().distinct_count);
+  ASSERT_EQ(nrows, rg2_column2->statistics().distinct_count);
   ASSERT_EQ(nrows / 2, rg2_column1->num_values());
   ASSERT_EQ(nrows / 2, rg2_column2->num_values());
   ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column1->compression());
   ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column2->compression());
-  ASSERT_EQ(2, rg2_column1->Encodings().size());
-  ASSERT_EQ(2, rg2_column2->Encodings().size());
+  ASSERT_EQ(2, rg2_column1->encodings().size());
+  ASSERT_EQ(2, rg2_column2->encodings().size());
   ASSERT_EQ(512, rg2_column1->total_compressed_size());
   ASSERT_EQ(512, rg2_column2->total_compressed_size());
   ASSERT_EQ(600, rg2_column1->total_uncompressed_size());
   ASSERT_EQ(600, rg2_column2->total_uncompressed_size());
+  ASSERT_EQ(6, rg2_column1->dictionary_page_offset());
+  ASSERT_EQ(16, rg2_column2->dictionary_page_offset());
+  ASSERT_EQ(10, rg2_column1->data_page_offset());
+  ASSERT_EQ(26, rg2_column2->data_page_offset());
 }
 }  // namespace metadata
 }  // namespace parquet

--- a/src/parquet/file/file-metadata-test.cc
+++ b/src/parquet/file/file-metadata-test.cc
@@ -54,13 +54,13 @@ TEST(Metadata, TestBuildAccess) {
   stats_float.max = &float_max;
 
   auto f_builder = FileMetaDataBuilder::Make(&schema, props);
-  auto rg1_builder = f_builder->AppendRowGroupMetaData();
-  auto rg2_builder = f_builder->AppendRowGroupMetaData();
+  auto rg1_builder = f_builder->AppendRowGroup();
+  auto rg2_builder = f_builder->AppendRowGroup();
 
   // Write the metadata
   // rowgroup1 metadata
-  auto col1_builder = rg1_builder->NextColumnMetaData();
-  auto col2_builder = rg1_builder->NextColumnMetaData();
+  auto col1_builder = rg1_builder->NextColumnChunk();
+  auto col2_builder = rg1_builder->NextColumnChunk();
   // column metadata
   col1_builder->SetStatistics(stats_int);
   col2_builder->SetStatistics(stats_float);
@@ -69,8 +69,8 @@ TEST(Metadata, TestBuildAccess) {
   rg1_builder->Finish(nrows / 2);
 
   // rowgroup2 metadata
-  col1_builder = rg2_builder->NextColumnMetaData();
-  col2_builder = rg2_builder->NextColumnMetaData();
+  col1_builder = rg2_builder->NextColumnChunk();
+  col2_builder = rg2_builder->NextColumnChunk();
   // column metadata
   col1_builder->SetStatistics(stats_int);
   col2_builder->SetStatistics(stats_float);
@@ -94,8 +94,8 @@ TEST(Metadata, TestBuildAccess) {
   ASSERT_EQ(nrows / 2, rg1_accessor->num_rows());
   ASSERT_EQ(1024, rg1_accessor->total_byte_size());
 
-  auto rg1_column1 = rg1_accessor->Column(0);
-  auto rg1_column2 = rg1_accessor->Column(1);
+  auto rg1_column1 = rg1_accessor->ColumnChunk(0);
+  auto rg1_column2 = rg1_accessor->ColumnChunk(1);
   ASSERT_EQ(true, rg1_column1->is_stats_set());
   ASSERT_EQ(true, rg1_column2->is_stats_set());
   ASSERT_EQ("100.100", *rg1_column2->Statistics().min);
@@ -122,8 +122,8 @@ TEST(Metadata, TestBuildAccess) {
   ASSERT_EQ(nrows / 2, rg2_accessor->num_rows());
   ASSERT_EQ(1024, rg2_accessor->total_byte_size());
 
-  auto rg2_column1 = rg2_accessor->Column(0);
-  auto rg2_column2 = rg2_accessor->Column(1);
+  auto rg2_column1 = rg2_accessor->ColumnChunk(0);
+  auto rg2_column2 = rg2_accessor->ColumnChunk(1);
   ASSERT_EQ(true, rg2_column1->is_stats_set());
   ASSERT_EQ(true, rg2_column2->is_stats_set());
   ASSERT_EQ("100.100", *rg2_column2->Statistics().min);

--- a/src/parquet/file/file-metadata-test.cc
+++ b/src/parquet/file/file-metadata-test.cc
@@ -1,0 +1,145 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+#include "parquet/file/metadata.h"
+#include "parquet/schema/descriptor.h"
+#include "parquet/schema/types.h"
+#include "parquet/types.h"
+
+namespace parquet {
+
+namespace metadata {
+
+TEST(Metadata, TestBuildAccess) {
+  parquet::schema::NodeVector fields;
+  parquet::schema::NodePtr root;
+  parquet::SchemaDescriptor schema;
+
+  std::shared_ptr<WriterProperties> props = WriterProperties::Builder().build();
+
+  fields.push_back(parquet::schema::Int32("int_col", Repetition::REQUIRED));
+  fields.push_back(parquet::schema::Int32("float_col", Repetition::REQUIRED));
+  root = parquet::schema::GroupNode::Make("schema", Repetition::REPEATED, fields);
+  schema.Init(root);
+
+  int64_t nrows = 1000;
+  ColumnStatistics stats_int;
+  stats_int.null_count = 0;
+  stats_int.distinct_count = nrows;
+  std::string int_min = std::string("100");
+  std::string int_max = std::string("200");
+  stats_int.min = &int_min;
+  stats_int.max = &int_max;
+  ColumnStatistics stats_float;
+  stats_float.null_count = 0;
+  stats_float.distinct_count = nrows;
+  std::string float_min = std::string("100.100");
+  std::string float_max = std::string("200.200");
+  stats_float.min = &float_min;
+  stats_float.max = &float_max;
+
+  auto f_builder = FileMetaDataBuilder::GetFileMetaDataBuilder(&schema, props);
+  auto rg1_builder = f_builder->AppendRowGroupMetaData();
+  auto rg2_builder = f_builder->AppendRowGroupMetaData();
+
+  // Write the metadata
+  // rowgroup1 metadata
+  auto col1_builder = rg1_builder->NextColumnMetaData();
+  auto col2_builder = rg1_builder->NextColumnMetaData();
+  // column metadata
+  col1_builder->SetStatistics(stats_int);
+  col2_builder->SetStatistics(stats_float);
+  col1_builder->Finish(nrows / 2, 0, 0, 4, 512, 512);
+  col2_builder->Finish(nrows / 2, 0, 0, 4, 512, 512);
+  rg1_builder->Finish(nrows / 2);
+
+  // rowgroup2 metadata
+  col1_builder = rg2_builder->NextColumnMetaData();
+  col2_builder = rg2_builder->NextColumnMetaData();
+  // column metadata
+  col1_builder->SetStatistics(stats_int);
+  col2_builder->SetStatistics(stats_float);
+  col1_builder->Finish(nrows / 2, 0, 0, 6, 512, 512);
+  col2_builder->Finish(nrows / 2, 0, 0, 516, 512, 512);
+  rg2_builder->Finish(nrows / 2);
+
+  // Read the metadata
+  auto f_accessor = f_builder->Finish();
+
+  // file metadata
+  ASSERT_EQ(nrows, f_accessor->num_rows());
+  ASSERT_EQ(2, f_accessor->num_row_groups());
+  ASSERT_EQ(DEFAULT_WRITER_VERSION, f_accessor->version());
+  ASSERT_EQ(DEFAULT_CREATED_BY, f_accessor->created_by());
+  ASSERT_EQ(3, f_accessor->num_schema_elements());
+
+  // row group1 metadata
+  auto rg1_accessor = f_accessor->GetRowGroupMetaData(0);
+  ASSERT_EQ(2, rg1_accessor->num_columns());
+  ASSERT_EQ(nrows / 2, rg1_accessor->num_rows());
+  ASSERT_EQ(1024, rg1_accessor->total_byte_size());
+
+  auto rg1_column1 = rg1_accessor->GetColumnMetaData(0);
+  auto rg1_column2 = rg1_accessor->GetColumnMetaData(1);
+  ASSERT_EQ(true, rg1_column1->IsStatsSet());
+  ASSERT_EQ(true, rg1_column2->IsStatsSet());
+  ASSERT_EQ("100.100", *rg1_column2->GetStats().min);
+  ASSERT_EQ("200.200", *rg1_column2->GetStats().max);
+  ASSERT_EQ("100", *rg1_column1->GetStats().min);
+  ASSERT_EQ("200", *rg1_column1->GetStats().max);
+  ASSERT_EQ(0, rg1_column1->GetStats().null_count);
+  ASSERT_EQ(0, rg1_column2->GetStats().null_count);
+  ASSERT_EQ(nrows, rg1_column1->GetStats().distinct_count);
+  ASSERT_EQ(nrows, rg1_column2->GetStats().distinct_count);
+  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column1->GetCompression());
+  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column2->GetCompression());
+  ASSERT_EQ(2, rg1_column1->GetEncodings().size());
+  ASSERT_EQ(2, rg1_column2->GetEncodings().size());
+  ASSERT_EQ(512, rg1_column1->GetCompressedSize());
+  ASSERT_EQ(512, rg1_column2->GetCompressedSize());
+  ASSERT_EQ(512, rg1_column1->GetUnCompressedSize());
+  ASSERT_EQ(512, rg1_column2->GetUnCompressedSize());
+
+  auto rg2_accessor = f_accessor->GetRowGroupMetaData(1);
+  ASSERT_EQ(2, rg2_accessor->num_columns());
+  ASSERT_EQ(nrows / 2, rg2_accessor->num_rows());
+  ASSERT_EQ(1024, rg2_accessor->total_byte_size());
+
+  auto rg2_column1 = rg2_accessor->GetColumnMetaData(0);
+  auto rg2_column2 = rg2_accessor->GetColumnMetaData(1);
+  ASSERT_EQ(true, rg2_column1->IsStatsSet());
+  ASSERT_EQ(true, rg2_column2->IsStatsSet());
+  ASSERT_EQ("100.100", *rg2_column2->GetStats().min);
+  ASSERT_EQ("200.200", *rg2_column2->GetStats().max);
+  ASSERT_EQ("100", *rg2_column1->GetStats().min);
+  ASSERT_EQ("200", *rg2_column1->GetStats().max);
+  ASSERT_EQ(0, rg2_column1->GetStats().null_count);
+  ASSERT_EQ(0, rg2_column2->GetStats().null_count);
+  ASSERT_EQ(nrows, rg2_column1->GetStats().distinct_count);
+  ASSERT_EQ(nrows, rg2_column2->GetStats().distinct_count);
+  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column1->GetCompression());
+  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column2->GetCompression());
+  ASSERT_EQ(2, rg2_column1->GetEncodings().size());
+  ASSERT_EQ(2, rg2_column2->GetEncodings().size());
+  ASSERT_EQ(512, rg2_column1->GetCompressedSize());
+  ASSERT_EQ(512, rg2_column2->GetCompressedSize());
+  ASSERT_EQ(512, rg2_column1->GetUnCompressedSize());
+  ASSERT_EQ(512, rg2_column2->GetUnCompressedSize());
+}
+}  // namespace metadata
+}  // namespace parquet

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -79,13 +79,13 @@ class TestSerialize : public ::testing::Test {
     auto buffer = sink->GetBuffer();
     std::unique_ptr<RandomAccessSource> source(new BufferReader(buffer));
     auto file_reader = ParquetFileReader::Open(std::move(source));
-    ASSERT_EQ(1, file_reader->num_columns());
-    ASSERT_EQ(1, file_reader->num_row_groups());
-    ASSERT_EQ(100, file_reader->num_rows());
+    ASSERT_EQ(1, file_reader->metadata()->num_columns());
+    ASSERT_EQ(1, file_reader->metadata()->num_row_groups());
+    ASSERT_EQ(100, file_reader->metadata()->num_rows());
 
     auto rg_reader = file_reader->RowGroup(0);
-    ASSERT_EQ(1, rg_reader->num_columns());
-    ASSERT_EQ(100, rg_reader->num_rows());
+    ASSERT_EQ(1, rg_reader->metadata()->num_columns());
+    ASSERT_EQ(100, rg_reader->metadata()->num_rows());
 
     auto col_reader = std::static_pointer_cast<Int64Reader>(rg_reader->Column(0));
     std::vector<int64_t> values_out(100);

--- a/src/parquet/file/metadata-internal.cc
+++ b/src/parquet/file/metadata-internal.cc
@@ -306,14 +306,14 @@ class ColumnMetaDataBuilder::ColumnMetaDataBuilderImpl {
     column_chunk_->meta_data.__set_total_compressed_size(compressed_size);
     std::vector<format::Encoding::type> thrift_encodings;
     thrift_encodings.push_back(ToThrift(properties_->level_encoding()));
-    if (properties_->dictionary_enabled()) {
+    if (properties_->dictionary_enabled(column_->path())) {
       thrift_encodings.push_back(ToThrift(properties_->dictionary_encoding()));
       // add the encoding only if it is unique
       if (properties_->version() == ParquetVersion::PARQUET_2_0) {
         thrift_encodings.push_back(ToThrift(properties_->dictionary_index_encoding()));
       }
     }
-    if (!properties_->dictionary_enabled() || dictionary_fallback) {
+    if (!properties_->dictionary_enabled(column_->path()) || dictionary_fallback) {
       thrift_encodings.push_back(ToThrift(properties_->encoding(column_->path())));
     }
     column_chunk_->meta_data.__set_encodings(thrift_encodings);

--- a/src/parquet/file/metadata-internal.cc
+++ b/src/parquet/file/metadata-internal.cc
@@ -1,0 +1,513 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <vector>
+
+#include "parquet/file/metadata.h"
+#include "parquet/schema/converter.h"
+#include "parquet/thrift/util.h"
+
+namespace parquet {
+
+// MetaData Accessor
+// Column metadata
+class ColumnMetaData::ColumnMetaDataImpl {
+ public:
+  explicit ColumnMetaDataImpl(const format::ColumnChunk* column) : column_(column) {}
+  ~ColumnMetaDataImpl() {}
+
+  // column chunk
+  int64_t file_offset() const { return column_->file_offset; }
+  const std::string& file_path() const { return column_->file_path; }
+
+  // column metadata
+  Type::type type() { return FromThrift(column_->meta_data.type); }
+
+  int64_t num_values() const { return column_->meta_data.num_values; }
+  const std::shared_ptr<schema::ColumnPath> path_in_schema() {
+    return std::make_shared<schema::ColumnPath>(column_->meta_data.path_in_schema);
+  }
+
+  bool IsStatsSet() const { return column_->meta_data.__isset.statistics; }
+
+  ColumnStatistics GetStats() const {
+    const format::ColumnMetaData& meta_data = column_->meta_data;
+
+    ColumnStatistics result;
+    result.null_count = meta_data.statistics.null_count;
+    result.distinct_count = meta_data.statistics.distinct_count;
+    result.max = &meta_data.statistics.max;
+    result.min = &meta_data.statistics.min;
+    return result;
+  }
+
+  Compression::type GetCompression() const {
+    return FromThrift(column_->meta_data.codec);
+  }
+
+  std::vector<Encoding::type> GetEncodings() const {
+    const format::ColumnMetaData& meta_data = column_->meta_data;
+
+    std::vector<Encoding::type> encodings;
+    for (auto encoding : meta_data.encodings) {
+      encodings.push_back(FromThrift(encoding));
+    }
+    return encodings;
+  }
+
+  int64_t GetCompressedSize() const { return column_->meta_data.total_uncompressed_size; }
+
+  int64_t GetUnCompressedSize() const { return column_->meta_data.total_compressed_size; }
+
+ private:
+  const format::ColumnChunk* column_;
+};
+
+std::unique_ptr<ColumnMetaData> ColumnMetaData::GetColumnMetaData(
+    const uint8_t* metadata) {
+  return std::unique_ptr<ColumnMetaData>(new ColumnMetaData(metadata));
+}
+
+ColumnMetaData::ColumnMetaData(const uint8_t* metadata)
+    : impl_{std::unique_ptr<ColumnMetaDataImpl>(new ColumnMetaDataImpl(
+          reinterpret_cast<const format::ColumnChunk*>(metadata)))} {}
+ColumnMetaData::~ColumnMetaData() {}
+
+// column chunk
+int64_t ColumnMetaData::file_offset() const {
+  return impl_->file_offset();
+}
+
+const std::string& ColumnMetaData::file_path() const {
+  return impl_->file_path();
+}
+
+// column metadata
+Type::type ColumnMetaData::type() const {
+  return impl_->type();
+}
+
+int64_t ColumnMetaData::num_values() const {
+  return impl_->num_values();
+}
+
+const std::shared_ptr<schema::ColumnPath> ColumnMetaData::path_in_schema() const {
+  return impl_->path_in_schema();
+}
+
+ColumnStatistics ColumnMetaData::GetStats() const {
+  return impl_->GetStats();
+}
+
+bool ColumnMetaData::IsStatsSet() const {
+  return impl_->IsStatsSet();
+}
+
+Compression::type ColumnMetaData::GetCompression() const {
+  return impl_->GetCompression();
+}
+
+std::vector<Encoding::type> ColumnMetaData::GetEncodings() const {
+  return impl_->GetEncodings();
+}
+
+int64_t ColumnMetaData::GetUnCompressedSize() const {
+  return impl_->GetUnCompressedSize();
+}
+
+int64_t ColumnMetaData::GetCompressedSize() const {
+  return impl_->GetCompressedSize();
+}
+
+// row-group metadata
+class RowGroupMetaData::RowGroupMetaDataImpl {
+ public:
+  explicit RowGroupMetaDataImpl(const format::RowGroup* row_group)
+      : row_group_(row_group) {}
+  ~RowGroupMetaDataImpl() {}
+
+  int num_columns() const { return row_group_->columns.size(); }
+
+  int64_t num_rows() const { return row_group_->num_rows; }
+
+  int64_t total_byte_size() const { return row_group_->total_byte_size; }
+
+  std::unique_ptr<ColumnMetaData> GetColumnMetaData(int i) {
+    DCHECK(i < num_columns()) << "The file only has " << num_columns()
+                              << " columns, requested metadata for column: " << i;
+    return ColumnMetaData::GetColumnMetaData(
+        reinterpret_cast<const uint8_t*>(&row_group_->columns[i]));
+  }
+
+ private:
+  const format::RowGroup* row_group_;
+};
+
+std::unique_ptr<RowGroupMetaData> RowGroupMetaData::GetRowGroupMetaData(
+    const uint8_t* metadata) {
+  return std::unique_ptr<RowGroupMetaData>(new RowGroupMetaData(metadata));
+}
+
+RowGroupMetaData::RowGroupMetaData(const uint8_t* metadata)
+    : impl_{std::unique_ptr<RowGroupMetaDataImpl>(new RowGroupMetaDataImpl(
+          reinterpret_cast<const format::RowGroup*>(metadata)))} {}
+RowGroupMetaData::~RowGroupMetaData() {}
+
+int RowGroupMetaData::num_columns() const {
+  return impl_->num_columns();
+}
+
+int64_t RowGroupMetaData::num_rows() const {
+  return impl_->num_rows();
+}
+
+int64_t RowGroupMetaData::total_byte_size() const {
+  return impl_->total_byte_size();
+}
+
+std::unique_ptr<ColumnMetaData> RowGroupMetaData::GetColumnMetaData(int i) const {
+  return impl_->GetColumnMetaData(i);
+}
+
+// file metadata
+class FileMetaData::FileMetaDataImpl {
+ public:
+  explicit FileMetaDataImpl(const uint8_t* metadata)
+      : metadata_{std::unique_ptr<const format::FileMetaData>(
+            reinterpret_cast<const format::FileMetaData*>(metadata))} {
+    schema::FlatSchemaConverter converter(
+        &metadata_->schema[0], metadata_->schema.size());
+    schema_.Init(converter.Convert());
+  }
+  ~FileMetaDataImpl() {}
+  int64_t num_rows() const { return metadata_->num_rows; }
+  int num_row_groups() const { return metadata_->row_groups.size(); }
+  int32_t version() const { return metadata_->version; }
+  const std::string& created_by() const { return metadata_->created_by; }
+  int num_schema_elements() const { return metadata_->schema.size(); }
+
+  void WriteTo(OutputStream* dst) {
+    SerializeThriftMsg(metadata_.get(), sizeof(format::FileMetaData), dst);
+  }
+
+  std::unique_ptr<RowGroupMetaData> GetRowGroupMetaData(int i) {
+    DCHECK(i < num_row_groups())
+        << "The file only has " << num_row_groups()
+        << " row groups, requested metadata for row group: " << i;
+    return RowGroupMetaData::GetRowGroupMetaData(
+        reinterpret_cast<const uint8_t*>(&metadata_->row_groups[i]));
+  }
+
+  const SchemaDescriptor* schema() const { return &schema_; }
+
+ private:
+  std::unique_ptr<const format::FileMetaData> metadata_;
+  SchemaDescriptor schema_;
+};
+
+std::unique_ptr<FileMetaData> FileMetaData::GetFileMetaData(const uint8_t* metadata) {
+  return std::unique_ptr<FileMetaData>(new FileMetaData(metadata));
+}
+
+FileMetaData::FileMetaData(const uint8_t* metadata)
+    : impl_{std::unique_ptr<FileMetaDataImpl>(new FileMetaDataImpl(metadata))} {}
+FileMetaData::~FileMetaData() {}
+
+std::unique_ptr<RowGroupMetaData> FileMetaData::GetRowGroupMetaData(int i) const {
+  return impl_->GetRowGroupMetaData(i);
+}
+
+int64_t FileMetaData::num_rows() const {
+  return impl_->num_rows();
+}
+
+int FileMetaData::num_row_groups() const {
+  return impl_->num_row_groups();
+}
+
+int32_t FileMetaData::version() const {
+  return impl_->version();
+}
+
+const std::string& FileMetaData::created_by() const {
+  return impl_->created_by();
+}
+
+int FileMetaData::num_schema_elements() const {
+  return impl_->num_schema_elements();
+}
+
+const SchemaDescriptor* FileMetaData::schema() const {
+  return impl_->schema();
+}
+
+void FileMetaData::WriteTo(OutputStream* dst) {
+  return impl_->WriteTo(dst);
+}
+
+// MetaData Builders
+// row-group metadata
+class ColumnMetaDataBuilder::ColumnMetaDataBuilderImpl {
+ public:
+  explicit ColumnMetaDataBuilderImpl(std::shared_ptr<WriterProperties> props,
+      const ColumnDescriptor* column, uint8_t* contents)
+      : properties_(props) {
+    column_chunk_ = reinterpret_cast<format::ColumnChunk*>(contents);
+    column_chunk_->meta_data.__set_type(ToThrift(column->physical_type()));
+    column_chunk_->meta_data.__set_path_in_schema(column->path()->ToDotVector());
+    column_chunk_->meta_data.__set_codec(
+        ToThrift(properties_->compression(column->path())));
+    std::vector<format::Encoding::type> thrift_encodings;
+    std::set<Encoding::type> encodings_set;
+    ColumnEncodings encodings = properties_->encodings(column->path());
+    encodings_set.insert(encodings.def_level_encoding);
+    encodings_set.insert(encodings.rep_level_encoding);
+    encodings_set.insert(encodings.dictionary_encoding);
+    encodings_set.insert(encodings.value_encoding);
+    for (auto encoding : encodings_set) {
+      thrift_encodings.push_back(ToThrift(encoding));
+    }
+    column_chunk_->meta_data.__set_encodings(thrift_encodings);
+  }
+  ~ColumnMetaDataBuilderImpl() {}
+
+  // column chunk
+  void set_file_path(const std::string& val) { column_chunk_->__set_file_path(val); }
+
+  // column metadata
+  // Needed to override the original values when dictionary encoding is converted
+  void set_encodings(const std::set<Encoding::type>& encodings) {
+    std::vector<format::Encoding::type> thrift_encodings;
+    for (auto encoding : encodings) {
+      thrift_encodings.push_back(ToThrift(encoding));
+    }
+    column_chunk_->meta_data.__set_encodings(thrift_encodings);
+  }
+
+  void SetStatistics(const ColumnStatistics& val) {
+    format::Statistics stats;
+    stats.null_count = val.null_count;
+    stats.distinct_count = val.distinct_count;
+    stats.max = *val.max;
+    stats.min = *val.min;
+
+    column_chunk_->meta_data.__set_statistics(stats);
+  }
+
+  void Finish(int64_t num_values, int64_t dictionary_page_offset,
+      int64_t index_page_offset, int64_t data_page_offset, int64_t compressed_size,
+      int64_t uncompressed_size) {
+    if (dictionary_page_offset > 0) {
+      column_chunk_->__set_file_offset(dictionary_page_offset + compressed_size);
+    } else {
+      column_chunk_->__set_file_offset(data_page_offset + compressed_size);
+    }
+    column_chunk_->meta_data.__set_dictionary_page_offset(dictionary_page_offset);
+    column_chunk_->meta_data.__set_index_page_offset(index_page_offset);
+    column_chunk_->meta_data.__set_data_page_offset(data_page_offset);
+    column_chunk_->meta_data.__set_total_uncompressed_size(uncompressed_size);
+    column_chunk_->meta_data.__set_total_compressed_size(compressed_size);
+  }
+
+ private:
+  format::ColumnChunk* column_chunk_;
+  std::shared_ptr<WriterProperties> properties_;
+};
+
+std::unique_ptr<ColumnMetaDataBuilder> ColumnMetaDataBuilder::GetColumnMetaDataBuilder(
+    std::shared_ptr<WriterProperties> props, const ColumnDescriptor* column,
+    uint8_t* contents) {
+  return std::unique_ptr<ColumnMetaDataBuilder>(
+      new ColumnMetaDataBuilder(props, column, contents));
+}
+
+ColumnMetaDataBuilder::ColumnMetaDataBuilder(std::shared_ptr<WriterProperties> props,
+    const ColumnDescriptor* column, uint8_t* contents)
+    : impl_{std::unique_ptr<ColumnMetaDataBuilderImpl>(
+          new ColumnMetaDataBuilderImpl(props, column, contents))} {}
+
+ColumnMetaDataBuilder::~ColumnMetaDataBuilder() {}
+
+void ColumnMetaDataBuilder::set_file_path(const std::string& path) {
+  impl_->set_file_path(path);
+}
+
+void ColumnMetaDataBuilder::set_encodings(const std::set<Encoding::type>& path) {
+  impl_->set_encodings(path);
+}
+
+void ColumnMetaDataBuilder::Finish(int64_t num_values, int64_t dictionary_page_offset,
+    int64_t index_page_offset, int64_t data_page_offset, int64_t compressed_size,
+    int64_t uncompressed_size) {
+  impl_->Finish(num_values, dictionary_page_offset, index_page_offset, data_page_offset,
+      compressed_size, uncompressed_size);
+}
+
+void ColumnMetaDataBuilder::SetStatistics(const ColumnStatistics& result) {
+  impl_->SetStatistics(result);
+}
+
+class RowGroupMetaDataBuilder::RowGroupMetaDataBuilderImpl {
+ public:
+  explicit RowGroupMetaDataBuilderImpl(std::shared_ptr<WriterProperties> props,
+      const SchemaDescriptor* schema, uint8_t* contents)
+      : properties_(props), schema_(schema), current_column_(0) {
+    row_group_ = reinterpret_cast<format::RowGroup*>(contents);
+    initialize_columns(schema->num_columns());
+  }
+  ~RowGroupMetaDataBuilderImpl() {}
+
+  ColumnMetaDataBuilder* NextColumnMetaData() {
+    DCHECK(current_column_ < num_columns())
+        << "The schema only has " << num_columns()
+        << " columns, requested metadata for column: " << current_column_;
+    auto column = schema_->Column(current_column_);
+    auto column_builder = ColumnMetaDataBuilder::GetColumnMetaDataBuilder(properties_,
+        column, reinterpret_cast<uint8_t*>(&row_group_->columns[current_column_++]));
+    auto column_builder_ptr = column_builder.get();
+    column_builders_.push_back(std::move(column_builder));
+    return column_builder_ptr;
+  }
+
+  void Finish(int64_t num_rows) {
+    DCHECK(current_column_ == schema_->num_columns())
+        << "Only " << current_column_ - 1 << " out of " << schema_->num_columns()
+        << " columns are initialized";
+    size_t total_byte_size = 0;
+
+    for (int i = 0; i < schema_->num_columns(); i++) {
+      DCHECK(row_group_->columns[i].file_offset > 0) << "Column " << i
+                                                     << " is not complete.";
+      total_byte_size += row_group_->columns[i].meta_data.total_compressed_size;
+    }
+
+    row_group_->__set_total_byte_size(total_byte_size);
+    row_group_->__set_num_rows(num_rows);
+  }
+
+ private:
+  int num_columns() { return row_group_->columns.size(); }
+
+  void initialize_columns(int ncols) {
+    std::vector<format::ColumnChunk> val;
+    format::ColumnChunk col_chunk;
+    format::ColumnMetaData meta_data;
+    col_chunk.__set_meta_data(meta_data);
+    for (int i = 0; i < ncols; i++) {
+      val.push_back(col_chunk);
+    }
+    row_group_->__set_columns(val);
+  }
+  format::RowGroup* row_group_;
+  std::shared_ptr<WriterProperties> properties_;
+  const SchemaDescriptor* schema_;
+  std::vector<std::unique_ptr<ColumnMetaDataBuilder>> column_builders_;
+  int current_column_;
+};
+
+std::unique_ptr<RowGroupMetaDataBuilder>
+RowGroupMetaDataBuilder::GetRowGroupMetaDataBuilder(
+    std::shared_ptr<WriterProperties> props, const SchemaDescriptor* schema_,
+    uint8_t* contents) {
+  return std::unique_ptr<RowGroupMetaDataBuilder>(
+      new RowGroupMetaDataBuilder(props, schema_, contents));
+}
+
+RowGroupMetaDataBuilder::RowGroupMetaDataBuilder(std::shared_ptr<WriterProperties> props,
+    const SchemaDescriptor* schema_, uint8_t* contents)
+    : impl_{std::unique_ptr<RowGroupMetaDataBuilderImpl>(
+          new RowGroupMetaDataBuilderImpl(props, schema_, contents))} {}
+
+RowGroupMetaDataBuilder::~RowGroupMetaDataBuilder() {}
+
+ColumnMetaDataBuilder* RowGroupMetaDataBuilder::NextColumnMetaData() {
+  return impl_->NextColumnMetaData();
+}
+
+void RowGroupMetaDataBuilder::Finish(int64_t num_rows) {
+  impl_->Finish(num_rows);
+}
+
+// file metadata
+class FileMetaDataBuilder::FileMetaDataBuilderImpl {
+ public:
+  explicit FileMetaDataBuilderImpl(
+      const SchemaDescriptor* schema, std::shared_ptr<WriterProperties> props)
+      : properties_(props), schema_(schema) {
+    metadata_.reset(new format::FileMetaData());
+  }
+  ~FileMetaDataBuilderImpl() {}
+
+  RowGroupMetaDataBuilder* AppendRowGroupMetaData() {
+    auto row_group = std::unique_ptr<format::RowGroup>(new format::RowGroup());
+    auto row_group_builder = RowGroupMetaDataBuilder::GetRowGroupMetaDataBuilder(
+        properties_, schema_, reinterpret_cast<uint8_t*>(row_group.get()));
+    RowGroupMetaDataBuilder* row_group_ptr = row_group_builder.get();
+    row_group_builders_.push_back(std::move(row_group_builder));
+    row_groups_.push_back(std::move(row_group));
+    return row_group_ptr;
+  }
+
+  std::unique_ptr<FileMetaData> Finish() {
+    int64_t total_rows = 0;
+    std::vector<format::RowGroup> row_groups;
+    for (auto row_group = row_groups_.begin(); row_group != row_groups_.end();
+         row_group++) {
+      auto rowgroup = *((*row_group).get());
+      row_groups.push_back(rowgroup);
+      total_rows += rowgroup.num_rows;
+    }
+    metadata_->__set_num_rows(total_rows);
+    metadata_->__set_row_groups(row_groups);
+    metadata_->__set_version(properties_->version());
+    metadata_->__set_created_by(properties_->created_by());
+    parquet::schema::SchemaFlattener flattener(
+        static_cast<parquet::schema::GroupNode*>(schema_->schema().get()),
+        &metadata_->schema);
+    flattener.Flatten();
+    return FileMetaData::GetFileMetaData(reinterpret_cast<uint8_t*>(metadata_.release()));
+  }
+
+ private:
+  std::unique_ptr<format::FileMetaData> metadata_;
+  std::shared_ptr<WriterProperties> properties_;
+  std::vector<std::unique_ptr<format::RowGroup>> row_groups_;
+  std::vector<std::unique_ptr<RowGroupMetaDataBuilder>> row_group_builders_;
+  const SchemaDescriptor* schema_;
+};
+
+std::unique_ptr<FileMetaDataBuilder> FileMetaDataBuilder::GetFileMetaDataBuilder(
+    const SchemaDescriptor* schema, std::shared_ptr<WriterProperties> props) {
+  return std::unique_ptr<FileMetaDataBuilder>(new FileMetaDataBuilder(schema, props));
+}
+
+FileMetaDataBuilder::FileMetaDataBuilder(
+    const SchemaDescriptor* schema, std::shared_ptr<WriterProperties> props)
+    : impl_{std::unique_ptr<FileMetaDataBuilderImpl>(
+          new FileMetaDataBuilderImpl(schema, props))} {}
+
+FileMetaDataBuilder::~FileMetaDataBuilder() {}
+
+RowGroupMetaDataBuilder* FileMetaDataBuilder::AppendRowGroupMetaData() {
+  return impl_->AppendRowGroupMetaData();
+}
+
+std::unique_ptr<FileMetaData> FileMetaDataBuilder::Finish() {
+  return impl_->Finish();
+}
+
+}  // namespace parquet

--- a/src/parquet/file/metadata.cc
+++ b/src/parquet/file/metadata.cc
@@ -24,11 +24,11 @@
 namespace parquet {
 
 // MetaData Accessor
-// Column metadata
-class ColumnMetaData::ColumnMetaDataImpl {
+// ColumnChunk metadata
+class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
  public:
-  explicit ColumnMetaDataImpl(const format::ColumnChunk* column) : column_(column) {}
-  ~ColumnMetaDataImpl() {}
+  explicit ColumnChunkMetaDataImpl(const format::ColumnChunk* column) : column_(column) {}
+  ~ColumnChunkMetaDataImpl() {}
 
   // column chunk
   inline int64_t file_offset() const { return column_->file_offset; }
@@ -56,7 +56,9 @@ class ColumnMetaData::ColumnMetaDataImpl {
     return result;
   }
 
-  inline Compression::type compression() const { return FromThrift(column_->meta_data.codec); }
+  inline Compression::type compression() const {
+    return FromThrift(column_->meta_data.codec);
+  }
 
   std::vector<Encoding::type> Encodings() const {
     const format::ColumnMetaData& meta_data = column_->meta_data;
@@ -76,9 +78,7 @@ class ColumnMetaData::ColumnMetaDataImpl {
     return column_->meta_data.dictionary_page_offset;
   }
 
-  inline int64_t data_page_offset() const {
-    return column_->meta_data.data_page_offset;
-  }
+  inline int64_t data_page_offset() const { return column_->meta_data.data_page_offset; }
 
   inline int64_t index_page_offset() const {
     return column_->meta_data.index_page_offset;
@@ -96,76 +96,74 @@ class ColumnMetaData::ColumnMetaDataImpl {
   const format::ColumnChunk* column_;
 };
 
-std::unique_ptr<ColumnMetaData> ColumnMetaData::Make(
-    const uint8_t* metadata) {
-  return std::unique_ptr<ColumnMetaData>(new ColumnMetaData(metadata));
+std::unique_ptr<ColumnChunkMetaData> ColumnChunkMetaData::Make(const uint8_t* metadata) {
+  return std::unique_ptr<ColumnChunkMetaData>(new ColumnChunkMetaData(metadata));
 }
 
-ColumnMetaData::ColumnMetaData(const uint8_t* metadata)
-    : impl_{std::unique_ptr<ColumnMetaDataImpl>(new ColumnMetaDataImpl(
+ColumnChunkMetaData::ColumnChunkMetaData(const uint8_t* metadata)
+    : impl_{std::unique_ptr<ColumnChunkMetaDataImpl>(new ColumnChunkMetaDataImpl(
           reinterpret_cast<const format::ColumnChunk*>(metadata)))} {}
-ColumnMetaData::~ColumnMetaData() {}
+ColumnChunkMetaData::~ColumnChunkMetaData() {}
 
 // column chunk
-int64_t ColumnMetaData::file_offset() const {
+int64_t ColumnChunkMetaData::file_offset() const {
   return impl_->file_offset();
 }
 
-const std::string& ColumnMetaData::file_path() const {
+const std::string& ColumnChunkMetaData::file_path() const {
   return impl_->file_path();
 }
 
 // column metadata
-Type::type ColumnMetaData::type() const {
+Type::type ColumnChunkMetaData::type() const {
   return impl_->type();
 }
 
-int64_t ColumnMetaData::num_values() const {
+int64_t ColumnChunkMetaData::num_values() const {
   return impl_->num_values();
 }
 
-std::shared_ptr<schema::ColumnPath> ColumnMetaData::path_in_schema() const {
+std::shared_ptr<schema::ColumnPath> ColumnChunkMetaData::path_in_schema() const {
   return impl_->path_in_schema();
 }
 
-const ColumnStatistics ColumnMetaData::Statistics() const {
+const ColumnStatistics ColumnChunkMetaData::Statistics() const {
   return impl_->Statistics();
 }
 
-bool ColumnMetaData::is_stats_set() const {
+bool ColumnChunkMetaData::is_stats_set() const {
   return impl_->is_stats_set();
 }
 
-int64_t ColumnMetaData::has_dictionary_page() const {
+int64_t ColumnChunkMetaData::has_dictionary_page() const {
   return impl_->has_dictionary_page();
 }
 
-int64_t ColumnMetaData::dictionary_page_offset() const {
+int64_t ColumnChunkMetaData::dictionary_page_offset() const {
   return impl_->dictionary_page_offset();
 }
 
-int64_t ColumnMetaData::data_page_offset() const {
+int64_t ColumnChunkMetaData::data_page_offset() const {
   return impl_->data_page_offset();
 }
 
-int64_t ColumnMetaData::index_page_offset() const {
+int64_t ColumnChunkMetaData::index_page_offset() const {
   return impl_->index_page_offset();
 }
 
-
-Compression::type ColumnMetaData::compression() const {
+Compression::type ColumnChunkMetaData::compression() const {
   return impl_->compression();
 }
 
-std::vector<Encoding::type> ColumnMetaData::Encodings() const {
+std::vector<Encoding::type> ColumnChunkMetaData::Encodings() const {
   return impl_->Encodings();
 }
 
-int64_t ColumnMetaData::total_uncompressed_size() const {
+int64_t ColumnChunkMetaData::total_uncompressed_size() const {
   return impl_->total_uncompressed_size();
 }
 
-int64_t ColumnMetaData::total_compressed_size() const {
+int64_t ColumnChunkMetaData::total_compressed_size() const {
   return impl_->total_compressed_size();
 }
 
@@ -182,10 +180,10 @@ class RowGroupMetaData::RowGroupMetaDataImpl {
 
   inline int64_t total_byte_size() const { return row_group_->total_byte_size; }
 
-  std::unique_ptr<ColumnMetaData> Column(int i) {
+  std::unique_ptr<ColumnChunkMetaData> ColumnChunk(int i) {
     DCHECK(i < num_columns()) << "The file only has " << num_columns()
                               << " columns, requested metadata for column: " << i;
-    return ColumnMetaData::Make(
+    return ColumnChunkMetaData::Make(
         reinterpret_cast<const uint8_t*>(&row_group_->columns[i]));
   }
 
@@ -193,8 +191,7 @@ class RowGroupMetaData::RowGroupMetaDataImpl {
   const format::RowGroup* row_group_;
 };
 
-std::unique_ptr<RowGroupMetaData> RowGroupMetaData::Make(
-    const uint8_t* metadata) {
+std::unique_ptr<RowGroupMetaData> RowGroupMetaData::Make(const uint8_t* metadata) {
   return std::unique_ptr<RowGroupMetaData>(new RowGroupMetaData(metadata));
 }
 
@@ -215,16 +212,15 @@ int64_t RowGroupMetaData::total_byte_size() const {
   return impl_->total_byte_size();
 }
 
-std::unique_ptr<ColumnMetaData> RowGroupMetaData::Column(int i) const {
-  return impl_->Column(i);
+std::unique_ptr<ColumnChunkMetaData> RowGroupMetaData::ColumnChunk(int i) const {
+  return impl_->ColumnChunk(i);
 }
 
 // file metadata
 class FileMetaData::FileMetaDataImpl {
  public:
-  friend FileMetaDataBuilder;
   FileMetaDataImpl() {}
- 
+
   explicit FileMetaDataImpl(const uint8_t* metadata, uint32_t* metadata_len) {
     metadata_.reset(new format::FileMetaData);
     DeserializeThriftMsg(metadata, metadata_len, metadata_.get());
@@ -249,25 +245,27 @@ class FileMetaData::FileMetaDataImpl {
         reinterpret_cast<const uint8_t*>(&metadata_->row_groups[i]));
   }
 
-  const SchemaDescriptor* schema() const { return &schema_; }
+  const SchemaDescriptor* schema_descriptor() const { return &schema_; }
 
- protected:
+ private:
+  friend FileMetaDataBuilder;
   std::unique_ptr<format::FileMetaData> metadata_;
   void InitSchema() {
     schema::FlatSchemaConverter converter(
         &metadata_->schema[0], metadata_->schema.size());
     schema_.Init(converter.Convert());
   }
- private:
   SchemaDescriptor schema_;
 };
 
-std::unique_ptr<FileMetaData> FileMetaData::Make(const uint8_t* metadata, uint32_t* metadata_len) {
+std::unique_ptr<FileMetaData> FileMetaData::Make(
+    const uint8_t* metadata, uint32_t* metadata_len) {
   return std::unique_ptr<FileMetaData>(new FileMetaData(metadata, metadata_len));
 }
 
 FileMetaData::FileMetaData(const uint8_t* metadata, uint32_t* metadata_len)
-    : impl_{std::unique_ptr<FileMetaDataImpl>(new FileMetaDataImpl(metadata, metadata_len))} {}
+    : impl_{std::unique_ptr<FileMetaDataImpl>(
+          new FileMetaDataImpl(metadata, metadata_len))} {}
 
 FileMetaData::FileMetaData()
     : impl_{std::unique_ptr<FileMetaDataImpl>(new FileMetaDataImpl())} {}
@@ -302,8 +300,8 @@ int FileMetaData::num_schema_elements() const {
   return impl_->num_schema_elements();
 }
 
-const SchemaDescriptor* FileMetaData::schema() const {
-  return impl_->schema();
+const SchemaDescriptor* FileMetaData::schema_descriptor() const {
+  return impl_->schema_descriptor();
 }
 
 void FileMetaData::WriteTo(OutputStream* dst) {
@@ -312,9 +310,9 @@ void FileMetaData::WriteTo(OutputStream* dst) {
 
 // MetaData Builders
 // row-group metadata
-class ColumnMetaDataBuilder::ColumnMetaDataBuilderImpl {
+class ColumnChunkMetaDataBuilder::ColumnChunkMetaDataBuilderImpl {
  public:
-  explicit ColumnMetaDataBuilderImpl(const std::shared_ptr<WriterProperties>& props,
+  explicit ColumnChunkMetaDataBuilderImpl(const std::shared_ptr<WriterProperties>& props,
       const ColumnDescriptor* column, uint8_t* contents)
       : properties_(props), column_(column) {
     column_chunk_ = reinterpret_cast<format::ColumnChunk*>(contents);
@@ -323,7 +321,7 @@ class ColumnMetaDataBuilder::ColumnMetaDataBuilderImpl {
     column_chunk_->meta_data.__set_codec(
         ToThrift(properties_->compression(column->path())));
   }
-  ~ColumnMetaDataBuilderImpl() {}
+  ~ColumnChunkMetaDataBuilderImpl() {}
 
   // column chunk
   void set_file_path(const std::string& val) { column_chunk_->__set_file_path(val); }
@@ -376,33 +374,33 @@ class ColumnMetaDataBuilder::ColumnMetaDataBuilderImpl {
   const ColumnDescriptor* column_;
 };
 
-std::unique_ptr<ColumnMetaDataBuilder> ColumnMetaDataBuilder::Make(
+std::unique_ptr<ColumnChunkMetaDataBuilder> ColumnChunkMetaDataBuilder::Make(
     const std::shared_ptr<WriterProperties>& props, const ColumnDescriptor* column,
     uint8_t* contents) {
-  return std::unique_ptr<ColumnMetaDataBuilder>(
-      new ColumnMetaDataBuilder(props, column, contents));
+  return std::unique_ptr<ColumnChunkMetaDataBuilder>(
+      new ColumnChunkMetaDataBuilder(props, column, contents));
 }
 
-ColumnMetaDataBuilder::ColumnMetaDataBuilder(
+ColumnChunkMetaDataBuilder::ColumnChunkMetaDataBuilder(
     const std::shared_ptr<WriterProperties>& props, const ColumnDescriptor* column,
     uint8_t* contents)
-    : impl_{std::unique_ptr<ColumnMetaDataBuilderImpl>(
-          new ColumnMetaDataBuilderImpl(props, column, contents))} {}
+    : impl_{std::unique_ptr<ColumnChunkMetaDataBuilderImpl>(
+          new ColumnChunkMetaDataBuilderImpl(props, column, contents))} {}
 
-ColumnMetaDataBuilder::~ColumnMetaDataBuilder() {}
+ColumnChunkMetaDataBuilder::~ColumnChunkMetaDataBuilder() {}
 
-void ColumnMetaDataBuilder::set_file_path(const std::string& path) {
+void ColumnChunkMetaDataBuilder::set_file_path(const std::string& path) {
   impl_->set_file_path(path);
 }
 
-void ColumnMetaDataBuilder::Finish(int64_t num_values, int64_t dictionary_page_offset,
-    int64_t index_page_offset, int64_t data_page_offset, int64_t compressed_size,
-    int64_t uncompressed_size, bool dictionary_fallback) {
+void ColumnChunkMetaDataBuilder::Finish(int64_t num_values,
+    int64_t dictionary_page_offset, int64_t index_page_offset, int64_t data_page_offset,
+    int64_t compressed_size, int64_t uncompressed_size, bool dictionary_fallback) {
   impl_->Finish(num_values, dictionary_page_offset, index_page_offset, data_page_offset,
       compressed_size, uncompressed_size, dictionary_fallback);
 }
 
-void ColumnMetaDataBuilder::SetStatistics(const ColumnStatistics& result) {
+void ColumnChunkMetaDataBuilder::SetStatistics(const ColumnStatistics& result) {
   impl_->SetStatistics(result);
 }
 
@@ -416,13 +414,13 @@ class RowGroupMetaDataBuilder::RowGroupMetaDataBuilderImpl {
   }
   ~RowGroupMetaDataBuilderImpl() {}
 
-  ColumnMetaDataBuilder* NextColumnMetaData() {
+  ColumnChunkMetaDataBuilder* NextColumnChunk() {
     DCHECK(current_column_ < num_columns())
         << "The schema only has " << num_columns()
         << " columns, requested metadata for column: " << current_column_;
     auto column = schema_->Column(current_column_);
-    auto column_builder = ColumnMetaDataBuilder::Make(properties_,
-        column, reinterpret_cast<uint8_t*>(&row_group_->columns[current_column_++]));
+    auto column_builder = ColumnChunkMetaDataBuilder::Make(properties_, column,
+        reinterpret_cast<uint8_t*>(&row_group_->columns[current_column_++]));
     auto column_builder_ptr = column_builder.get();
     column_builders_.push_back(std::move(column_builder));
     return column_builder_ptr;
@@ -452,12 +450,11 @@ class RowGroupMetaDataBuilder::RowGroupMetaDataBuilderImpl {
   format::RowGroup* row_group_;
   const std::shared_ptr<WriterProperties> properties_;
   const SchemaDescriptor* schema_;
-  std::vector<std::unique_ptr<ColumnMetaDataBuilder>> column_builders_;
+  std::vector<std::unique_ptr<ColumnChunkMetaDataBuilder>> column_builders_;
   int current_column_;
 };
 
-std::unique_ptr<RowGroupMetaDataBuilder>
-RowGroupMetaDataBuilder::Make(
+std::unique_ptr<RowGroupMetaDataBuilder> RowGroupMetaDataBuilder::Make(
     const std::shared_ptr<WriterProperties>& props, const SchemaDescriptor* schema_,
     uint8_t* contents) {
   return std::unique_ptr<RowGroupMetaDataBuilder>(
@@ -472,8 +469,8 @@ RowGroupMetaDataBuilder::RowGroupMetaDataBuilder(
 
 RowGroupMetaDataBuilder::~RowGroupMetaDataBuilder() {}
 
-ColumnMetaDataBuilder* RowGroupMetaDataBuilder::NextColumnMetaData() {
-  return impl_->NextColumnMetaData();
+ColumnChunkMetaDataBuilder* RowGroupMetaDataBuilder::NextColumnChunk() {
+  return impl_->NextColumnChunk();
 }
 
 void RowGroupMetaDataBuilder::Finish(int64_t num_rows) {
@@ -483,7 +480,6 @@ void RowGroupMetaDataBuilder::Finish(int64_t num_rows) {
 // file metadata
 class FileMetaDataBuilder::FileMetaDataBuilderImpl {
  public:
-  friend class FileMetaDataImpl;
   explicit FileMetaDataBuilderImpl(
       const SchemaDescriptor* schema, const std::shared_ptr<WriterProperties>& props)
       : properties_(props), schema_(schema) {
@@ -491,7 +487,7 @@ class FileMetaDataBuilder::FileMetaDataBuilderImpl {
   }
   ~FileMetaDataBuilderImpl() {}
 
-  RowGroupMetaDataBuilder* AppendRowGroupMetaData() {
+  RowGroupMetaDataBuilder* AppendRowGroup() {
     auto row_group = std::unique_ptr<format::RowGroup>(new format::RowGroup());
     auto row_group_builder = RowGroupMetaDataBuilder::Make(
         properties_, schema_, reinterpret_cast<uint8_t*>(row_group.get()));
@@ -526,6 +522,7 @@ class FileMetaDataBuilder::FileMetaDataBuilderImpl {
 
  protected:
   std::unique_ptr<format::FileMetaData> metadata_;
+
  private:
   const std::shared_ptr<WriterProperties> properties_;
   std::vector<std::unique_ptr<format::RowGroup>> row_groups_;
@@ -545,8 +542,8 @@ FileMetaDataBuilder::FileMetaDataBuilder(
 
 FileMetaDataBuilder::~FileMetaDataBuilder() {}
 
-RowGroupMetaDataBuilder* FileMetaDataBuilder::AppendRowGroupMetaData() {
-  return impl_->AppendRowGroupMetaData();
+RowGroupMetaDataBuilder* FileMetaDataBuilder::AppendRowGroup() {
+  return impl_->AppendRowGroup();
 }
 
 std::unique_ptr<FileMetaData> FileMetaDataBuilder::Finish() {

--- a/src/parquet/file/metadata.h
+++ b/src/parquet/file/metadata.h
@@ -128,7 +128,7 @@ class PARQUET_EXPORT ColumnMetaDataBuilder {
   // column chunk
   void set_file_path(const std::string& path);
   // column metadata
-  void set_encodings(const std::set<Encoding::type>& val);
+  void SetEncodingsWithDictionaryFallback();
   void SetStatistics(const ColumnStatistics& stats);
 
   // commit the metadata

--- a/src/parquet/file/metadata.h
+++ b/src/parquet/file/metadata.h
@@ -55,9 +55,9 @@ class PARQUET_EXPORT ColumnChunkMetaData {
   int64_t num_values() const;
   std::shared_ptr<schema::ColumnPath> path_in_schema() const;
   bool is_stats_set() const;
-  const ColumnStatistics Statistics() const;
+  const ColumnStatistics& statistics() const;
   Compression::type compression() const;
-  std::vector<Encoding::type> Encodings() const;
+  const std::vector<Encoding::type>& encodings() const;
   int64_t has_dictionary_page() const;
   int64_t dictionary_page_offset() const;
   int64_t data_page_offset() const;

--- a/src/parquet/file/metadata.h
+++ b/src/parquet/file/metadata.h
@@ -52,13 +52,13 @@ class PARQUET_EXPORT ColumnMetaData {
   // column metadata
   Type::type type() const;
   int64_t num_values() const;
-  const std::shared_ptr<schema::ColumnPath> path_in_schema() const;
-  bool IsStatsSet() const;
-  ColumnStatistics GetStats() const;
-  Compression::type GetCompression() const;
-  std::vector<Encoding::type> GetEncodings() const;
-  int64_t GetCompressedSize() const;
-  int64_t GetUnCompressedSize() const;
+  std::shared_ptr<schema::ColumnPath> path_in_schema() const;
+  bool is_stats_set() const;
+  ColumnStatistics Stats() const;
+  Compression::type compression() const;
+  std::vector<Encoding::type> Encodings() const;
+  int64_t total_compressed_size() const;
+  int64_t total_uncompressed_size() const;
 
  private:
   // PIMPL Idiom
@@ -118,23 +118,23 @@ class PARQUET_EXPORT ColumnMetaDataBuilder {
  public:
   // API convenience to get a MetaData reader
   static std::unique_ptr<ColumnMetaDataBuilder> GetColumnMetaDataBuilder(
-      std::shared_ptr<WriterProperties> props, const ColumnDescriptor* column,
+      const std::shared_ptr<WriterProperties>& props, const ColumnDescriptor* column,
       uint8_t* contents);
 
-  explicit ColumnMetaDataBuilder(std::shared_ptr<WriterProperties> props,
+  explicit ColumnMetaDataBuilder(const std::shared_ptr<WriterProperties>& props,
       const ColumnDescriptor* column, uint8_t* contents);
   ~ColumnMetaDataBuilder();
 
   // column chunk
+  // Used when a dataset is spread across multiple files
   void set_file_path(const std::string& path);
   // column metadata
-  void SetEncodingsWithDictionaryFallback();
   void SetStatistics(const ColumnStatistics& stats);
 
   // commit the metadata
   void Finish(int64_t num_values, int64_t dictonary_page_offset,
       int64_t index_page_offset, int64_t data_page_offset, int64_t compressed_size,
-      int64_t uncompressed_size);
+      int64_t uncompressed_size, bool dictionary_fallback);
 
  private:
   // PIMPL Idiom
@@ -146,10 +146,10 @@ class PARQUET_EXPORT RowGroupMetaDataBuilder {
  public:
   // API convenience to get a MetaData reader
   static std::unique_ptr<RowGroupMetaDataBuilder> GetRowGroupMetaDataBuilder(
-      std::shared_ptr<WriterProperties> props, const SchemaDescriptor* schema_,
+      const std::shared_ptr<WriterProperties>& props, const SchemaDescriptor* schema_,
       uint8_t* contents);
 
-  explicit RowGroupMetaDataBuilder(std::shared_ptr<WriterProperties> props,
+  explicit RowGroupMetaDataBuilder(const std::shared_ptr<WriterProperties>& props,
       const SchemaDescriptor* schema_, uint8_t* contents);
   ~RowGroupMetaDataBuilder();
 
@@ -168,10 +168,10 @@ class PARQUET_EXPORT FileMetaDataBuilder {
  public:
   // API convenience to get a MetaData reader
   static std::unique_ptr<FileMetaDataBuilder> GetFileMetaDataBuilder(
-      const SchemaDescriptor* schema, std::shared_ptr<WriterProperties> props);
+      const SchemaDescriptor* schema, const std::shared_ptr<WriterProperties>& props);
 
   explicit FileMetaDataBuilder(
-      const SchemaDescriptor* schema, std::shared_ptr<WriterProperties> props);
+      const SchemaDescriptor* schema, const std::shared_ptr<WriterProperties>& props);
   ~FileMetaDataBuilder();
 
   RowGroupMetaDataBuilder* AppendRowGroupMetaData();

--- a/src/parquet/file/metadata.h
+++ b/src/parquet/file/metadata.h
@@ -1,0 +1,190 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef PARQUET_FILE_METADATA_H
+#define PARQUET_FILE_METADATA_H
+
+#include <string>
+#include <vector>
+#include <set>
+
+#include "parquet/column/properties.h"
+#include "parquet/compression/codec.h"
+#include "parquet/schema/descriptor.h"
+#include "parquet/types.h"
+#include "parquet/util/output.h"
+#include "parquet/util/visibility.h"
+
+namespace parquet {
+
+struct ColumnStatistics {
+  int64_t null_count;
+  int64_t distinct_count;
+  const std::string* min;
+  const std::string* max;
+};
+
+class PARQUET_EXPORT ColumnMetaData {
+ public:
+  // API convenience to get a MetaData accessor
+  static std::unique_ptr<ColumnMetaData> GetColumnMetaData(const uint8_t* metadata);
+
+  explicit ColumnMetaData(const uint8_t* metadata);
+  ~ColumnMetaData();
+
+  // column chunk
+  int64_t file_offset() const;
+  const std::string& file_path() const;
+  // column metadata
+  Type::type type() const;
+  int64_t num_values() const;
+  const std::shared_ptr<schema::ColumnPath> path_in_schema() const;
+  bool IsStatsSet() const;
+  ColumnStatistics GetStats() const;
+  Compression::type GetCompression() const;
+  std::vector<Encoding::type> GetEncodings() const;
+  int64_t GetCompressedSize() const;
+  int64_t GetUnCompressedSize() const;
+
+ private:
+  // PIMPL Idiom
+  class ColumnMetaDataImpl;
+  std::unique_ptr<ColumnMetaDataImpl> impl_;
+};
+
+class PARQUET_EXPORT RowGroupMetaData {
+ public:
+  // API convenience to get a MetaData accessor
+  static std::unique_ptr<RowGroupMetaData> GetRowGroupMetaData(const uint8_t* metadata);
+
+  explicit RowGroupMetaData(const uint8_t* metadata);
+  ~RowGroupMetaData();
+
+  // row-group metadata
+  int num_columns() const;
+  int64_t num_rows() const;
+  int64_t total_byte_size() const;
+  std::unique_ptr<ColumnMetaData> GetColumnMetaData(int i) const;
+
+ private:
+  // PIMPL Idiom
+  class RowGroupMetaDataImpl;
+  std::unique_ptr<RowGroupMetaDataImpl> impl_;
+};
+
+class PARQUET_EXPORT FileMetaData {
+ public:
+  // API convenience to get a MetaData accessor
+  static std::unique_ptr<FileMetaData> GetFileMetaData(const uint8_t* metadata);
+
+  explicit FileMetaData(const uint8_t* metadata);
+  ~FileMetaData();
+
+  // file metadata
+  int64_t num_rows() const;
+  int num_row_groups() const;
+  int32_t version() const;
+  const std::string& created_by() const;
+  int num_schema_elements() const;
+  std::unique_ptr<RowGroupMetaData> GetRowGroupMetaData(int i) const;
+
+  void WriteTo(OutputStream* dst);
+
+  // Return const-pointer to make it clear that this object is not to be copied
+  const SchemaDescriptor* schema() const;
+
+ private:
+  // PIMPL Idiom
+  class FileMetaDataImpl;
+  std::unique_ptr<FileMetaDataImpl> impl_;
+};
+
+// Builder API
+class PARQUET_EXPORT ColumnMetaDataBuilder {
+ public:
+  // API convenience to get a MetaData reader
+  static std::unique_ptr<ColumnMetaDataBuilder> GetColumnMetaDataBuilder(
+      std::shared_ptr<WriterProperties> props, const ColumnDescriptor* column,
+      uint8_t* contents);
+
+  explicit ColumnMetaDataBuilder(std::shared_ptr<WriterProperties> props,
+      const ColumnDescriptor* column, uint8_t* contents);
+  ~ColumnMetaDataBuilder();
+
+  // column chunk
+  void set_file_path(const std::string& path);
+  // column metadata
+  void set_encodings(const std::set<Encoding::type>& val);
+  void SetStatistics(const ColumnStatistics& stats);
+
+  // commit the metadata
+  void Finish(int64_t num_values, int64_t dictonary_page_offset,
+      int64_t index_page_offset, int64_t data_page_offset, int64_t compressed_size,
+      int64_t uncompressed_size);
+
+ private:
+  // PIMPL Idiom
+  class ColumnMetaDataBuilderImpl;
+  std::unique_ptr<ColumnMetaDataBuilderImpl> impl_;
+};
+
+class PARQUET_EXPORT RowGroupMetaDataBuilder {
+ public:
+  // API convenience to get a MetaData reader
+  static std::unique_ptr<RowGroupMetaDataBuilder> GetRowGroupMetaDataBuilder(
+      std::shared_ptr<WriterProperties> props, const SchemaDescriptor* schema_,
+      uint8_t* contents);
+
+  explicit RowGroupMetaDataBuilder(std::shared_ptr<WriterProperties> props,
+      const SchemaDescriptor* schema_, uint8_t* contents);
+  ~RowGroupMetaDataBuilder();
+
+  ColumnMetaDataBuilder* NextColumnMetaData();
+
+  // commit the metadata
+  void Finish(int64_t num_rows);
+
+ private:
+  // PIMPL Idiom
+  class RowGroupMetaDataBuilderImpl;
+  std::unique_ptr<RowGroupMetaDataBuilderImpl> impl_;
+};
+
+class PARQUET_EXPORT FileMetaDataBuilder {
+ public:
+  // API convenience to get a MetaData reader
+  static std::unique_ptr<FileMetaDataBuilder> GetFileMetaDataBuilder(
+      const SchemaDescriptor* schema, std::shared_ptr<WriterProperties> props);
+
+  explicit FileMetaDataBuilder(
+      const SchemaDescriptor* schema, std::shared_ptr<WriterProperties> props);
+  ~FileMetaDataBuilder();
+
+  RowGroupMetaDataBuilder* AppendRowGroupMetaData();
+
+  // commit the metadata
+  std::unique_ptr<FileMetaData> Finish();
+
+ private:
+  // PIMPL Idiom
+  class FileMetaDataBuilderImpl;
+  std::unique_ptr<FileMetaDataBuilderImpl> impl_;
+};
+
+}  // namespace parquet
+
+#endif  // PARQUET_FILE_METADATA_H

--- a/src/parquet/file/metadata.h
+++ b/src/parquet/file/metadata.h
@@ -48,6 +48,7 @@ class PARQUET_EXPORT ColumnMetaData {
 
   // column chunk
   int64_t file_offset() const;
+  // parameter is only used when a dataset is spread across multiple files
   const std::string& file_path() const;
   // column metadata
   Type::type type() const;

--- a/src/parquet/file/reader-internal.cc
+++ b/src/parquet/file/reader-internal.cc
@@ -147,11 +147,10 @@ const RowGroupMetaData* SerializedRowGroup::metadata() const {
 
 std::unique_ptr<PageReader> SerializedRowGroup::GetColumnPageReader(int i) {
   // Read column chunk from the file
-  auto col = row_group_metadata_->Column(i);
+  auto col = row_group_metadata_->ColumnChunk(i);
 
   int64_t col_start = col->data_page_offset();
-  if (col->has_dictionary_page() &&
-      col_start > col->dictionary_page_offset()) {
+  if (col->has_dictionary_page() && col_start > col->dictionary_page_offset()) {
     col_start = col->dictionary_page_offset();
   }
 
@@ -197,7 +196,7 @@ std::shared_ptr<RowGroupReader> SerializedFile::GetRowGroup(int i) {
       new SerializedRowGroup(source_.get(), file_metadata_->RowGroup(i), properties_));
 
   return std::make_shared<RowGroupReader>(
-      file_metadata_->schema(), std::move(contents), properties_.allocator());
+      file_metadata_->schema_descriptor(), std::move(contents), properties_.allocator());
 }
 
 const FileMetaData* SerializedFile::metadata() const {
@@ -237,8 +236,7 @@ void SerializedFile::ParseMetaData() {
     throw ParquetException("Invalid parquet file. Could not read metadata bytes.");
   }
 
-  file_metadata_ =
-      FileMetaData::Make(&metadata_buffer[0], &metadata_len);
+  file_metadata_ = FileMetaData::Make(&metadata_buffer[0], &metadata_len);
 }
 
 }  // namespace parquet

--- a/src/parquet/file/reader-internal.cc
+++ b/src/parquet/file/reader-internal.cc
@@ -219,7 +219,7 @@ int SerializedFile::num_row_groups() const {
   return metadata_->row_groups.size();
 }
 
-const FileMetaData* SerializedFile::GetFileMetaData() {
+const FileMetaData* SerializedFile::metadata() {
   return file_meta_data_.get();
 }
 

--- a/src/parquet/file/reader-internal.cc
+++ b/src/parquet/file/reader-internal.cc
@@ -192,8 +192,8 @@ SerializedFile::~SerializedFile() {
 }
 
 std::shared_ptr<RowGroupReader> SerializedFile::GetRowGroup(int i) {
-  std::unique_ptr<SerializedRowGroup> contents(
-      new SerializedRowGroup(source_.get(), file_metadata_->RowGroup(i), properties_));
+  std::unique_ptr<SerializedRowGroup> contents(new SerializedRowGroup(
+      source_.get(), std::move(file_metadata_->RowGroup(i)), properties_));
 
   return std::make_shared<RowGroupReader>(
       file_metadata_->schema_descriptor(), std::move(contents), properties_.allocator());

--- a/src/parquet/file/reader-internal.cc
+++ b/src/parquet/file/reader-internal.cc
@@ -141,34 +141,27 @@ std::shared_ptr<Page> SerializedPageReader::NextPage() {
   return std::shared_ptr<Page>(nullptr);
 }
 
-// ----------------------------------------------------------------------
-// SerializedRowGroup
-
-int64_t SerializedRowGroup::num_rows() const {
-  return metadata_->num_rows;
-}
-
-int SerializedRowGroup::num_columns() const {
-  return metadata_->columns.size();
+const RowGroupMetaData* SerializedRowGroup::metadata() const {
+  return row_group_metadata_.get();
 }
 
 std::unique_ptr<PageReader> SerializedRowGroup::GetColumnPageReader(int i) {
   // Read column chunk from the file
-  const format::ColumnChunk& col = metadata_->columns[i];
+  auto col = row_group_metadata_->Column(i);
 
-  int64_t col_start = col.meta_data.data_page_offset;
-  if (col.meta_data.__isset.dictionary_page_offset &&
-      col_start > col.meta_data.dictionary_page_offset) {
-    col_start = col.meta_data.dictionary_page_offset;
+  int64_t col_start = col->data_page_offset();
+  if (col->has_dictionary_page() &&
+      col_start > col->dictionary_page_offset()) {
+    col_start = col->dictionary_page_offset();
   }
 
-  int64_t bytes_to_read = col.meta_data.total_compressed_size;
+  int64_t bytes_to_read = col->total_compressed_size();
   std::unique_ptr<InputStream> stream;
 
   stream = properties_.GetStream(source_, col_start, bytes_to_read);
 
   return std::unique_ptr<PageReader>(new SerializedPageReader(
-      std::move(stream), FromThrift(col.meta_data.codec), properties_.allocator()));
+      std::move(stream), col->compression(), properties_.allocator()));
 }
 
 // ----------------------------------------------------------------------
@@ -201,26 +194,14 @@ SerializedFile::~SerializedFile() {
 
 std::shared_ptr<RowGroupReader> SerializedFile::GetRowGroup(int i) {
   std::unique_ptr<SerializedRowGroup> contents(
-      new SerializedRowGroup(source_.get(), &metadata_->row_groups[i], properties_));
+      new SerializedRowGroup(source_.get(), file_metadata_->RowGroup(i), properties_));
 
   return std::make_shared<RowGroupReader>(
-      file_meta_data_->schema(), std::move(contents), properties_.allocator());
+      file_metadata_->schema(), std::move(contents), properties_.allocator());
 }
 
-int64_t SerializedFile::num_rows() const {
-  return metadata_->num_rows;
-}
-
-int SerializedFile::num_columns() const {
-  return file_meta_data_->schema()->num_columns();
-}
-
-int SerializedFile::num_row_groups() const {
-  return metadata_->row_groups.size();
-}
-
-const FileMetaData* SerializedFile::metadata() {
-  return file_meta_data_.get();
+const FileMetaData* SerializedFile::metadata() const {
+  return file_metadata_.get();
 }
 
 SerializedFile::SerializedFile(std::unique_ptr<RandomAccessSource> source,
@@ -256,12 +237,8 @@ void SerializedFile::ParseMetaData() {
     throw ParquetException("Invalid parquet file. Could not read metadata bytes.");
   }
 
-  auto metadata_ptr = std::unique_ptr<format::FileMetaData>(new format::FileMetaData());
-  metadata_ = metadata_ptr.get();
-  DeserializeThriftMsg(&metadata_buffer[0], &metadata_len, metadata_);
-
-  file_meta_data_ =
-      FileMetaData::GetFileMetaData(reinterpret_cast<uint8_t*>(metadata_ptr.release()));
+  file_metadata_ =
+      FileMetaData::Make(&metadata_buffer[0], &metadata_len);
 }
 
 }  // namespace parquet

--- a/src/parquet/file/reader-internal.h
+++ b/src/parquet/file/reader-internal.h
@@ -25,6 +25,7 @@
 #include "parquet/column/page.h"
 #include "parquet/column/properties.h"
 #include "parquet/compression/codec.h"
+#include "parquet/file/metadata.h"
 #include "parquet/file/reader.h"
 #include "parquet/thrift/parquet_types.h"
 #include "parquet/types.h"
@@ -76,12 +77,6 @@ class SerializedRowGroup : public RowGroupReader::Contents {
   virtual int num_columns() const;
   virtual int64_t num_rows() const;
   virtual std::unique_ptr<PageReader> GetColumnPageReader(int i);
-  virtual RowGroupStatistics GetColumnStats(int i) const;
-  virtual bool IsColumnStatsSet(int i) const;
-  virtual Compression::type GetColumnCompression(int i) const;
-  virtual std::vector<Encoding::type> GetColumnEncodings(int i) const;
-  virtual int64_t GetColumnCompressedSize(int i) const;
-  virtual int64_t GetColumnUnCompressedSize(int i) const;
 
  private:
   RandomAccessSource* source_;
@@ -103,6 +98,7 @@ class SerializedFile : public ParquetFileReader::Contents {
       ReaderProperties props = default_reader_properties());
   virtual void Close();
   virtual std::shared_ptr<RowGroupReader> GetRowGroup(int i);
+  virtual const FileMetaData* GetFileMetaData();
   virtual int64_t num_rows() const;
   virtual int num_columns() const;
   virtual int num_row_groups() const;
@@ -114,7 +110,8 @@ class SerializedFile : public ParquetFileReader::Contents {
       std::unique_ptr<RandomAccessSource> source, ReaderProperties props);
 
   std::unique_ptr<RandomAccessSource> source_;
-  format::FileMetaData metadata_;
+  format::FileMetaData* metadata_;
+  std::unique_ptr<FileMetaData> file_meta_data_;
   ReaderProperties properties_;
 
   void ParseMetaData();

--- a/src/parquet/file/reader-internal.h
+++ b/src/parquet/file/reader-internal.h
@@ -70,8 +70,8 @@ class SerializedPageReader : public PageReader {
 // RowGroupReader::Contents implementation for the Parquet file specification
 class SerializedRowGroup : public RowGroupReader::Contents {
  public:
-  SerializedRowGroup(RandomAccessSource* source, std::unique_ptr<RowGroupMetaData> metadata,
-      const ReaderProperties props)
+  SerializedRowGroup(RandomAccessSource* source,
+      std::unique_ptr<RowGroupMetaData> metadata, const ReaderProperties props)
       : source_(source), row_group_metadata_(std::move(metadata)), properties_(props) {}
 
   virtual const RowGroupMetaData* metadata() const;

--- a/src/parquet/file/reader-internal.h
+++ b/src/parquet/file/reader-internal.h
@@ -98,7 +98,7 @@ class SerializedFile : public ParquetFileReader::Contents {
       ReaderProperties props = default_reader_properties());
   virtual void Close();
   virtual std::shared_ptr<RowGroupReader> GetRowGroup(int i);
-  virtual const FileMetaData* GetFileMetaData();
+  virtual const FileMetaData* metadata();
   virtual int64_t num_rows() const;
   virtual int num_columns() const;
   virtual int num_row_groups() const;

--- a/src/parquet/file/reader.cc
+++ b/src/parquet/file/reader.cc
@@ -158,15 +158,16 @@ void ParquetFileReader::DebugPrint(
 
     // Print column metadata
     for (auto i : selected_columns) {
-      ColumnStatistics stats = group_metadata->ColumnChunk(i)->Statistics();
+      auto column_chunk = group_metadata->ColumnChunk(i);
+      const ColumnStatistics stats = column_chunk->statistics();
 
       const ColumnDescriptor* descr = file_metadata->schema_descriptor()->Column(i);
       stream << "Column " << i << std::endl
-             << ", values: " << group_metadata->ColumnChunk(i)->num_values()
-             << ", null values: " << stats.null_count
-             << ", distinct values: " << stats.distinct_count << std::endl;
-      if (group_metadata->ColumnChunk(i)->is_stats_set()) {
-        stream << "  max: " << FormatStatValue(descr->physical_type(), stats.max->c_str())
+             << ", values: " << column_chunk->num_values();
+      if (column_chunk->is_stats_set()) {
+        stream << ", null values: " << stats.null_count
+               << ", distinct values: " << stats.distinct_count << std::endl
+               << "  max: " << FormatStatValue(descr->physical_type(), stats.max->c_str())
                << ", min: "
                << FormatStatValue(descr->physical_type(), stats.min->c_str());
       } else {
@@ -174,16 +175,16 @@ void ParquetFileReader::DebugPrint(
       }
       stream << std::endl
              << "  compression: "
-             << compression_to_string(group_metadata->ColumnChunk(i)->compression())
+             << compression_to_string(column_chunk->compression())
              << ", encodings: ";
-      for (auto encoding : group_metadata->ColumnChunk(i)->Encodings()) {
+      for (auto encoding : column_chunk->encodings()) {
         stream << encoding_to_string(encoding) << " ";
       }
       stream << std::endl
              << "  uncompressed size: "
-             << group_metadata->ColumnChunk(i)->total_uncompressed_size()
+             << column_chunk->total_uncompressed_size()
              << ", compressed size: "
-             << group_metadata->ColumnChunk(i)->total_compressed_size() << std::endl;
+             << column_chunk->total_compressed_size() << std::endl;
     }
 
     if (!print_values) { continue; }

--- a/src/parquet/file/reader.h
+++ b/src/parquet/file/reader.h
@@ -40,6 +40,7 @@ class PARQUET_EXPORT RowGroupReader {
  public:
   // Forward declare the PIMPL
   struct Contents {
+    virtual ~Contents() {}
     virtual std::unique_ptr<PageReader> GetColumnPageReader(int i) = 0;
     virtual const RowGroupMetaData* metadata() const = 0;
   };

--- a/src/parquet/file/reader.h
+++ b/src/parquet/file/reader.h
@@ -79,7 +79,7 @@ class PARQUET_EXPORT ParquetFileReader {
     virtual int64_t num_rows() const = 0;
     virtual int num_columns() const = 0;
     virtual int num_row_groups() const = 0;
-    virtual const FileMetaData* GetFileMetaData() = 0;
+    virtual const FileMetaData* metadata() = 0;
   };
 
   ParquetFileReader();
@@ -104,7 +104,7 @@ class PARQUET_EXPORT ParquetFileReader {
   int num_row_groups() const;
 
   // Returns the file metadata
-  const FileMetaData* GetFileMetaData();
+  const FileMetaData* metadata();
 
   // Returns the file schema descriptor
   const SchemaDescriptor* descr() { return schema_; }

--- a/src/parquet/reader-test.cc
+++ b/src/parquet/reader-test.cc
@@ -68,11 +68,11 @@ TEST_F(TestAllTypesPlain, TestBatchRead) {
   int32_t values[4];
 
   // This file only has 8 rows
-  ASSERT_EQ(8, reader_->num_rows());
+  ASSERT_EQ(8, reader_->metadata()->num_rows());
   // This file only has 1 row group
-  ASSERT_EQ(1, reader_->num_row_groups());
+  ASSERT_EQ(1, reader_->metadata()->num_row_groups());
   // This row group must have 8 rows
-  ASSERT_EQ(8, group->num_rows());
+  ASSERT_EQ(8, group->metadata()->num_rows());
 
   ASSERT_TRUE(col->HasNext());
   int64_t values_read;

--- a/src/parquet/util/bpacking.h
+++ b/src/parquet/util/bpacking.h
@@ -13,6 +13,8 @@
 #ifndef PARQUET_UTIL_BPACKING_H
 #define PARQUET_UTIL_BPACKING_H
 
+#include <stdexcept>
+
 namespace parquet {
 
 inline const uint32_t* unpack1_32(const uint32_t* in, uint32_t* out) {


### PR DESCRIPTION
This patch adds API to read and write metadata as well as improves the writer properties class.
I am planning to add some comments to the code next. Meanwhile, any feedback will be helpful.