### PR TITLE
Incorrect count written to "num_values" in column metadata

### DIFF
--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -109,7 +109,7 @@ int64_t SerializedPageWriter::WriteDataPage(int32_t num_rows, int32_t num_values
 
   metadata_->meta_data.total_uncompressed_size += uncompressed_size + header_size;
   metadata_->meta_data.total_compressed_size += compressed_size + header_size;
-  metadata_->meta_data.num_values += num_values;
+  metadata_->meta_data.num_values += num_rows;
 
   return sink_->Tell() - start_pos;
 }


### PR DESCRIPTION
The the num_values in meta_data associated with ColumnChunk is incorrectly
set to the number of actual values present excluding the null values. It
should be the total number of values including the Null values.

If we create a parquet file with a schema with optional fields the
"num_values" field in the meta data gets set incorrectly. Such a parquet
file cannot be read using the parquet-tools in parquet-mr.

Signed-off-by: Anand Mitra <anand.mitra@gmail.com>