### PR TITLE
PARQUET-704: Install scan-all.h

### DIFF
--- a/src/parquet/column/CMakeLists.txt
+++ b/src/parquet/column/CMakeLists.txt
@@ -17,10 +17,11 @@
 
 # Headers: top level
 install(FILES
-  page.h
   levels.h
+  page.h
   properties.h
   reader.h
+  scan-all.h
   scanner.h
   writer.h
   DESTINATION include/parquet/column)


### PR DESCRIPTION
Small detail overlooked in PARQUET-681