### PR TITLE
PARQUET-711: Use metadata builders in parquet writer

### DIFF
--- a/src/parquet/column/column-io-benchmark.cc
+++ b/src/parquet/column/column-io-benchmark.cc
@@ -25,13 +25,12 @@
 
 namespace parquet {
 
-using format::ColumnChunk;
 using schema::PrimitiveNode;
 
 namespace benchmark {
 
 std::unique_ptr<Int64Writer> BuildWriter(int64_t output_size, OutputStream* dst,
-    ColumnChunk* metadata, ColumnDescriptor* schema, const WriterProperties* properties) {
+    ColumnChunkMetaDataBuilder* metadata, ColumnDescriptor* schema, const WriterProperties* properties) {
   std::unique_ptr<SerializedPageWriter> pager(
       new SerializedPageWriter(dst, Compression::UNCOMPRESSED, metadata));
   return std::unique_ptr<Int64Writer>(new Int64Writer(
@@ -57,17 +56,18 @@ void SetBytesProcessed(::benchmark::State& state, Repetition::type repetition) {
 
 template <Repetition::type repetition>
 static void BM_WriteInt64Column(::benchmark::State& state) {
-  format::ColumnChunk metadata;
+  format::ColumnChunk thrift_metadata;
   std::vector<int64_t> values(state.range_x(), 128);
   std::vector<int16_t> definition_levels(state.range_x(), 1);
   std::vector<int16_t> repetition_levels(state.range_x(), 0);
   std::shared_ptr<ColumnDescriptor> schema = Int64Schema(repetition);
   std::shared_ptr<parquet::WriterProperties> properties = default_writer_properties();
+  auto metadata = parquet::ColumnChunkMetaDataBuilder::Make(properties, schema.get(), reinterpret_cast<uint8_t*>(&thrift_metadata)); 
 
   while (state.KeepRunning()) {
     InMemoryOutputStream dst;
     std::unique_ptr<Int64Writer> writer =
-        BuildWriter(state.range_x(), &dst, &metadata, schema.get(), properties.get());
+        BuildWriter(state.range_x(), &dst, metadata.get(), schema.get(), properties.get());
     writer->WriteBatch(
         values.size(), definition_levels.data(), repetition_levels.data(), values.data());
     writer->Close();
@@ -91,16 +91,17 @@ std::unique_ptr<Int64Reader> BuildReader(
 
 template <Repetition::type repetition>
 static void BM_ReadInt64Column(::benchmark::State& state) {
-  format::ColumnChunk metadata;
+  format::ColumnChunk thrift_metadata;
   std::vector<int64_t> values(state.range_x(), 128);
   std::vector<int16_t> definition_levels(state.range_x(), 1);
   std::vector<int16_t> repetition_levels(state.range_x(), 0);
   std::shared_ptr<ColumnDescriptor> schema = Int64Schema(repetition);
+  std::shared_ptr<parquet::WriterProperties> properties = default_writer_properties();
+  auto metadata = parquet::ColumnChunkMetaDataBuilder::Make(properties, schema.get(), reinterpret_cast<uint8_t*>(&thrift_metadata)); 
 
   InMemoryOutputStream dst;
-  std::shared_ptr<parquet::WriterProperties> properties = default_writer_properties();
   std::unique_ptr<Int64Writer> writer =
-      BuildWriter(state.range_x(), &dst, &metadata, schema.get(), properties.get());
+      BuildWriter(state.range_x(), &dst, metadata.get(), schema.get(), properties.get());
   writer->WriteBatch(
       values.size(), definition_levels.data(), repetition_levels.data(), values.data());
   writer->Close();

--- a/src/parquet/column/column-io-benchmark.cc
+++ b/src/parquet/column/column-io-benchmark.cc
@@ -30,7 +30,8 @@ using schema::PrimitiveNode;
 namespace benchmark {
 
 std::unique_ptr<Int64Writer> BuildWriter(int64_t output_size, OutputStream* dst,
-    ColumnChunkMetaDataBuilder* metadata, ColumnDescriptor* schema, const WriterProperties* properties) {
+    ColumnChunkMetaDataBuilder* metadata, ColumnDescriptor* schema,
+    const WriterProperties* properties) {
   std::unique_ptr<SerializedPageWriter> pager(
       new SerializedPageWriter(dst, Compression::UNCOMPRESSED, metadata));
   return std::unique_ptr<Int64Writer>(new Int64Writer(
@@ -62,12 +63,13 @@ static void BM_WriteInt64Column(::benchmark::State& state) {
   std::vector<int16_t> repetition_levels(state.range_x(), 0);
   std::shared_ptr<ColumnDescriptor> schema = Int64Schema(repetition);
   std::shared_ptr<parquet::WriterProperties> properties = default_writer_properties();
-  auto metadata = parquet::ColumnChunkMetaDataBuilder::Make(properties, schema.get(), reinterpret_cast<uint8_t*>(&thrift_metadata)); 
+  auto metadata = parquet::ColumnChunkMetaDataBuilder::Make(
+      properties, schema.get(), reinterpret_cast<uint8_t*>(&thrift_metadata));
 
   while (state.KeepRunning()) {
     InMemoryOutputStream dst;
-    std::unique_ptr<Int64Writer> writer =
-        BuildWriter(state.range_x(), &dst, metadata.get(), schema.get(), properties.get());
+    std::unique_ptr<Int64Writer> writer = BuildWriter(
+        state.range_x(), &dst, metadata.get(), schema.get(), properties.get());
     writer->WriteBatch(
         values.size(), definition_levels.data(), repetition_levels.data(), values.data());
     writer->Close();
@@ -97,7 +99,8 @@ static void BM_ReadInt64Column(::benchmark::State& state) {
   std::vector<int16_t> repetition_levels(state.range_x(), 0);
   std::shared_ptr<ColumnDescriptor> schema = Int64Schema(repetition);
   std::shared_ptr<parquet::WriterProperties> properties = default_writer_properties();
-  auto metadata = parquet::ColumnChunkMetaDataBuilder::Make(properties, schema.get(), reinterpret_cast<uint8_t*>(&thrift_metadata)); 
+  auto metadata = parquet::ColumnChunkMetaDataBuilder::Make(
+      properties, schema.get(), reinterpret_cast<uint8_t*>(&thrift_metadata));
 
   InMemoryOutputStream dst;
   std::unique_ptr<Int64Writer> writer =

--- a/src/parquet/column/column-io-benchmark.cc
+++ b/src/parquet/column/column-io-benchmark.cc
@@ -99,7 +99,7 @@ static void BM_ReadInt64Column(::benchmark::State& state) {
   std::vector<int16_t> repetition_levels(state.range_x(), 0);
   std::shared_ptr<ColumnDescriptor> schema = Int64Schema(repetition);
   std::shared_ptr<parquet::WriterProperties> properties = default_writer_properties();
-  auto metadata = parquet::ColumnChunkMetaDataBuilder::Make(
+  auto metadata = ColumnChunkMetaDataBuilder::Make(
       properties, schema.get(), reinterpret_cast<uint8_t*>(&thrift_metadata));
 
   InMemoryOutputStream dst;

--- a/src/parquet/column/column-io-benchmark.cc
+++ b/src/parquet/column/column-io-benchmark.cc
@@ -62,8 +62,8 @@ static void BM_WriteInt64Column(::benchmark::State& state) {
   std::vector<int16_t> definition_levels(state.range_x(), 1);
   std::vector<int16_t> repetition_levels(state.range_x(), 0);
   std::shared_ptr<ColumnDescriptor> schema = Int64Schema(repetition);
-  std::shared_ptr<parquet::WriterProperties> properties = default_writer_properties();
-  auto metadata = parquet::ColumnChunkMetaDataBuilder::Make(
+  std::shared_ptr<WriterProperties> properties = default_writer_properties();
+  auto metadata = ColumnChunkMetaDataBuilder::Make(
       properties, schema.get(), reinterpret_cast<uint8_t*>(&thrift_metadata));
 
   while (state.KeepRunning()) {
@@ -98,7 +98,7 @@ static void BM_ReadInt64Column(::benchmark::State& state) {
   std::vector<int16_t> definition_levels(state.range_x(), 1);
   std::vector<int16_t> repetition_levels(state.range_x(), 0);
   std::shared_ptr<ColumnDescriptor> schema = Int64Schema(repetition);
-  std::shared_ptr<parquet::WriterProperties> properties = default_writer_properties();
+  std::shared_ptr<WriterProperties> properties = default_writer_properties();
   auto metadata = ColumnChunkMetaDataBuilder::Make(
       properties, schema.get(), reinterpret_cast<uint8_t*>(&thrift_metadata));
 

--- a/src/parquet/column/column-writer-test.cc
+++ b/src/parquet/column/column-writer-test.cc
@@ -72,8 +72,9 @@ class TestPrimitiveWriter : public ::testing::Test {
     writer_properties_ = default_writer_properties();
     definition_levels_out_.resize(SMALL_SIZE);
     repetition_levels_out_.resize(SMALL_SIZE);
-
+    
     SetUpSchemaRequired();
+    metadata_accessor_ = parquet::ColumnChunkMetaData::Make(reinterpret_cast<uint8_t*>(&thrift_metadata_)); 
   }
 
   void BuildReader() {
@@ -87,8 +88,9 @@ class TestPrimitiveWriter : public ::testing::Test {
   std::shared_ptr<TypedColumnWriter<TestType>> BuildWriter(
       int64_t output_size = SMALL_SIZE, Encoding::type encoding = Encoding::PLAIN) {
     sink_.reset(new InMemoryOutputStream());
+    metadata_ = parquet::ColumnChunkMetaDataBuilder::Make(writer_properties_, schema_.get(), reinterpret_cast<uint8_t*>(&thrift_metadata_)); 
     std::unique_ptr<SerializedPageWriter> pager(
-        new SerializedPageWriter(sink_.get(), Compression::UNCOMPRESSED, &metadata_));
+        new SerializedPageWriter(sink_.get(), Compression::UNCOMPRESSED, metadata_.get()));
     WriterProperties::Builder wp_builder;
     if (encoding == Encoding::PLAIN_DICTIONARY || encoding == Encoding::RLE_DICTIONARY) {
       wp_builder.enable_dictionary();
@@ -127,7 +129,7 @@ class TestPrimitiveWriter : public ::testing::Test {
   }
 
   int64_t metadata_num_values() const {
-    return metadata_.meta_data.num_values;
+    return metadata_accessor_->num_values();
   }
 
  protected:
@@ -152,7 +154,9 @@ class TestPrimitiveWriter : public ::testing::Test {
 
  private:
   NodePtr node_;
-  format::ColumnChunk metadata_;
+  format::ColumnChunk thrift_metadata_;
+  std::unique_ptr<ColumnChunkMetaDataBuilder> metadata_;
+  std::unique_ptr<ColumnChunkMetaData> metadata_accessor_;
   std::shared_ptr<ColumnDescriptor> schema_;
   std::unique_ptr<InMemoryOutputStream> sink_;
   std::shared_ptr<WriterProperties> writer_properties_;

--- a/src/parquet/column/column-writer-test.cc
+++ b/src/parquet/column/column-writer-test.cc
@@ -75,7 +75,7 @@ class TestPrimitiveWriter : public ::testing::Test {
 
     SetUpSchemaRequired();
     metadata_accessor_ =
-        parquet::ColumnChunkMetaData::Make(reinterpret_cast<uint8_t*>(&thrift_metadata_));
+        ColumnChunkMetaData::Make(reinterpret_cast<uint8_t*>(&thrift_metadata_));
   }
 
   void BuildReader() {
@@ -89,7 +89,7 @@ class TestPrimitiveWriter : public ::testing::Test {
   std::shared_ptr<TypedColumnWriter<TestType>> BuildWriter(
       int64_t output_size = SMALL_SIZE, Encoding::type encoding = Encoding::PLAIN) {
     sink_.reset(new InMemoryOutputStream());
-    metadata_ = parquet::ColumnChunkMetaDataBuilder::Make(
+    metadata_ = ColumnChunkMetaDataBuilder::Make(
         writer_properties_, schema_.get(), reinterpret_cast<uint8_t*>(&thrift_metadata_));
     std::unique_ptr<SerializedPageWriter> pager(new SerializedPageWriter(
         sink_.get(), Compression::UNCOMPRESSED, metadata_.get()));

--- a/src/parquet/column/column-writer-test.cc
+++ b/src/parquet/column/column-writer-test.cc
@@ -72,9 +72,10 @@ class TestPrimitiveWriter : public ::testing::Test {
     writer_properties_ = default_writer_properties();
     definition_levels_out_.resize(SMALL_SIZE);
     repetition_levels_out_.resize(SMALL_SIZE);
-    
+
     SetUpSchemaRequired();
-    metadata_accessor_ = parquet::ColumnChunkMetaData::Make(reinterpret_cast<uint8_t*>(&thrift_metadata_)); 
+    metadata_accessor_ =
+        parquet::ColumnChunkMetaData::Make(reinterpret_cast<uint8_t*>(&thrift_metadata_));
   }
 
   void BuildReader() {
@@ -88,9 +89,10 @@ class TestPrimitiveWriter : public ::testing::Test {
   std::shared_ptr<TypedColumnWriter<TestType>> BuildWriter(
       int64_t output_size = SMALL_SIZE, Encoding::type encoding = Encoding::PLAIN) {
     sink_.reset(new InMemoryOutputStream());
-    metadata_ = parquet::ColumnChunkMetaDataBuilder::Make(writer_properties_, schema_.get(), reinterpret_cast<uint8_t*>(&thrift_metadata_)); 
-    std::unique_ptr<SerializedPageWriter> pager(
-        new SerializedPageWriter(sink_.get(), Compression::UNCOMPRESSED, metadata_.get()));
+    metadata_ = parquet::ColumnChunkMetaDataBuilder::Make(
+        writer_properties_, schema_.get(), reinterpret_cast<uint8_t*>(&thrift_metadata_));
+    std::unique_ptr<SerializedPageWriter> pager(new SerializedPageWriter(
+        sink_.get(), Compression::UNCOMPRESSED, metadata_.get()));
     WriterProperties::Builder wp_builder;
     if (encoding == Encoding::PLAIN_DICTIONARY || encoding == Encoding::RLE_DICTIONARY) {
       wp_builder.enable_dictionary();
@@ -128,9 +130,7 @@ class TestPrimitiveWriter : public ::testing::Test {
     ASSERT_EQ(this->values_, this->values_out_);
   }
 
-  int64_t metadata_num_values() const {
-    return metadata_accessor_->num_values();
-  }
+  int64_t metadata_num_values() const { return metadata_accessor_->num_values(); }
 
  protected:
   int64_t values_read_;

--- a/src/parquet/file/file-metadata-test.cc
+++ b/src/parquet/file/file-metadata-test.cc
@@ -54,8 +54,8 @@ TEST(Metadata, TestBuildAccess) {
   stats_float.max = &float_max;
 
   auto f_builder = FileMetaDataBuilder::Make(&schema, props);
-  auto rg1_builder = f_builder->AppendRowGroup();
-  auto rg2_builder = f_builder->AppendRowGroup();
+  auto rg1_builder = f_builder->AppendRowGroup(nrows / 2);
+  auto rg2_builder = f_builder->AppendRowGroup(nrows / 2);
 
   // Write the metadata
   // rowgroup1 metadata
@@ -66,7 +66,7 @@ TEST(Metadata, TestBuildAccess) {
   col2_builder->SetStatistics(stats_float);
   col1_builder->Finish(nrows / 2, 4, 0, 10, 512, 600, false);
   col2_builder->Finish(nrows / 2, 24, 0, 30, 512, 600, false);
-  rg1_builder->Finish(nrows / 2);
+  rg1_builder->Finish();
 
   // rowgroup2 metadata
   col1_builder = rg2_builder->NextColumnChunk();
@@ -76,7 +76,7 @@ TEST(Metadata, TestBuildAccess) {
   col2_builder->SetStatistics(stats_float);
   col1_builder->Finish(nrows / 2, 6, 0, 10, 512, 600, false);
   col2_builder->Finish(nrows / 2, 16, 0, 26, 512, 600, false);
-  rg2_builder->Finish(nrows / 2);
+  rg2_builder->Finish();
 
   // Read the metadata
   auto f_accessor = f_builder->Finish();

--- a/src/parquet/file/file-metadata-test.cc
+++ b/src/parquet/file/file-metadata-test.cc
@@ -66,7 +66,7 @@ TEST(Metadata, TestBuildAccess) {
   col2_builder->SetStatistics(stats_float);
   col1_builder->Finish(nrows / 2, 4, 0, 10, 512, 600, false);
   col2_builder->Finish(nrows / 2, 24, 0, 30, 512, 600, false);
-  rg1_builder->Finish();
+  rg1_builder->Finish(1024);
 
   // rowgroup2 metadata
   col1_builder = rg2_builder->NextColumnChunk();
@@ -76,7 +76,7 @@ TEST(Metadata, TestBuildAccess) {
   col2_builder->SetStatistics(stats_float);
   col1_builder->Finish(nrows / 2, 6, 0, 10, 512, 600, false);
   col2_builder->Finish(nrows / 2, 16, 0, 26, 512, 600, false);
-  rg2_builder->Finish();
+  rg2_builder->Finish(1024);
 
   // Read the metadata
   auto f_accessor = f_builder->Finish();

--- a/src/parquet/file/metadata.cc
+++ b/src/parquet/file/metadata.cc
@@ -409,7 +409,7 @@ void ColumnChunkMetaDataBuilder::Finish(int64_t num_values,
 }
 
 const ColumnDescriptor* ColumnChunkMetaDataBuilder::descriptor() const {
-    return impl_->descriptor(); 
+  return impl_->descriptor();
 }
 
 void ColumnChunkMetaDataBuilder::SetStatistics(const ColumnStatistics& result) {
@@ -418,8 +418,9 @@ void ColumnChunkMetaDataBuilder::SetStatistics(const ColumnStatistics& result) {
 
 class RowGroupMetaDataBuilder::RowGroupMetaDataBuilderImpl {
  public:
-  explicit RowGroupMetaDataBuilderImpl(int64_t num_rows, const std::shared_ptr<WriterProperties>& props,
-      const SchemaDescriptor* schema, uint8_t* contents)
+  explicit RowGroupMetaDataBuilderImpl(int64_t num_rows,
+      const std::shared_ptr<WriterProperties>& props, const SchemaDescriptor* schema,
+      uint8_t* contents)
       : properties_(props), schema_(schema), current_column_(0) {
     row_group_ = reinterpret_cast<format::RowGroup*>(contents);
     InitializeColumns(schema->num_columns());
@@ -455,8 +456,8 @@ class RowGroupMetaDataBuilder::RowGroupMetaDataBuilderImpl {
   }
 
   int num_columns() { return row_group_->columns.size(); }
- private:
 
+ private:
   void InitializeColumns(int ncols) { row_group_->columns.resize(ncols); }
 
   format::RowGroup* row_group_;
@@ -506,8 +507,8 @@ class FileMetaDataBuilder::FileMetaDataBuilderImpl {
 
   RowGroupMetaDataBuilder* AppendRowGroup(int64_t num_rows) {
     auto row_group = std::unique_ptr<format::RowGroup>(new format::RowGroup());
-    auto row_group_builder = RowGroupMetaDataBuilder::Make(num_rows,
-        properties_, schema_, reinterpret_cast<uint8_t*>(row_group.get()));
+    auto row_group_builder = RowGroupMetaDataBuilder::Make(
+        num_rows, properties_, schema_, reinterpret_cast<uint8_t*>(row_group.get()));
     RowGroupMetaDataBuilder* row_group_ptr = row_group_builder.get();
     row_group_builders_.push_back(std::move(row_group_builder));
     row_groups_.push_back(std::move(row_group));

--- a/src/parquet/file/metadata.cc
+++ b/src/parquet/file/metadata.cc
@@ -258,7 +258,7 @@ class FileMetaData::FileMetaDataImpl {
         reinterpret_cast<const uint8_t*>(&metadata_->row_groups[i]), &schema_);
   }
 
-  const SchemaDescriptor* schema_descriptor() const { return &schema_; }
+  const SchemaDescriptor* schema() const { return &schema_; }
 
  private:
   friend FileMetaDataBuilder;
@@ -313,8 +313,8 @@ int FileMetaData::num_schema_elements() const {
   return impl_->num_schema_elements();
 }
 
-const SchemaDescriptor* FileMetaData::schema_descriptor() const {
-  return impl_->schema_descriptor();
+const SchemaDescriptor* FileMetaData::schema() const {
+  return impl_->schema();
 }
 
 void FileMetaData::WriteTo(OutputStream* dst) {
@@ -381,7 +381,7 @@ class ColumnChunkMetaDataBuilder::ColumnChunkMetaDataBuilderImpl {
     column_chunk_->meta_data.__set_encodings(thrift_encodings);
   }
 
-  const ColumnDescriptor* descriptor() const { return column_; }
+  const ColumnDescriptor* descr() const { return column_; }
 
  private:
   format::ColumnChunk* column_chunk_;
@@ -415,8 +415,8 @@ void ColumnChunkMetaDataBuilder::Finish(int64_t num_values,
       compressed_size, uncompressed_size, dictionary_fallback);
 }
 
-const ColumnDescriptor* ColumnChunkMetaDataBuilder::descriptor() const {
-  return impl_->descriptor();
+const ColumnDescriptor* ColumnChunkMetaDataBuilder::descr() const {
+  return impl_->descr();
 }
 
 void ColumnChunkMetaDataBuilder::SetStatistics(const ColumnStatistics& result) {
@@ -547,7 +547,7 @@ class FileMetaDataBuilder::FileMetaDataBuilderImpl {
     metadata_->__set_version(properties_->version());
     metadata_->__set_created_by(properties_->created_by());
     parquet::schema::SchemaFlattener flattener(
-        static_cast<parquet::schema::GroupNode*>(schema_->schema().get()),
+        static_cast<parquet::schema::GroupNode*>(schema_->schema_root().get()),
         &metadata_->schema);
     flattener.Flatten();
     auto file_meta_data = std::unique_ptr<FileMetaData>(new FileMetaData());

--- a/src/parquet/file/metadata.h
+++ b/src/parquet/file/metadata.h
@@ -172,7 +172,7 @@ class PARQUET_EXPORT RowGroupMetaDataBuilder {
   int num_columns();
 
   // commit the metadata
-  void Finish();
+  void Finish(int64_t total_bytes_written);
 
  private:
   explicit RowGroupMetaDataBuilder(int64_t num_rows,

--- a/src/parquet/file/metadata.h
+++ b/src/parquet/file/metadata.h
@@ -144,7 +144,8 @@ class PARQUET_EXPORT ColumnChunkMetaDataBuilder {
   // column metadata
   // ownership of min/max is with ColumnChunkMetadata
   void SetStatistics(const ColumnStatistics& stats);
-
+  // get the column descriptor
+  const ColumnDescriptor* descriptor() const;
   // commit the metadata
   void Finish(int64_t num_values, int64_t dictonary_page_offset,
       int64_t index_page_offset, int64_t data_page_offset, int64_t compressed_size,
@@ -161,19 +162,20 @@ class PARQUET_EXPORT ColumnChunkMetaDataBuilder {
 class PARQUET_EXPORT RowGroupMetaDataBuilder {
  public:
   // API convenience to get a MetaData reader
-  static std::unique_ptr<RowGroupMetaDataBuilder> Make(
+  static std::unique_ptr<RowGroupMetaDataBuilder> Make(int64_t num_rows,
       const std::shared_ptr<WriterProperties>& props, const SchemaDescriptor* schema_,
       uint8_t* contents);
 
   ~RowGroupMetaDataBuilder();
 
   ColumnChunkMetaDataBuilder* NextColumnChunk();
+  int num_columns();
 
   // commit the metadata
-  void Finish(int64_t num_rows);
+  void Finish();
 
  private:
-  explicit RowGroupMetaDataBuilder(const std::shared_ptr<WriterProperties>& props,
+  explicit RowGroupMetaDataBuilder(int64_t num_rows, const std::shared_ptr<WriterProperties>& props,
       const SchemaDescriptor* schema_, uint8_t* contents);
   // PIMPL Idiom
   class RowGroupMetaDataBuilderImpl;
@@ -188,7 +190,7 @@ class PARQUET_EXPORT FileMetaDataBuilder {
 
   ~FileMetaDataBuilder();
 
-  RowGroupMetaDataBuilder* AppendRowGroup();
+  RowGroupMetaDataBuilder* AppendRowGroup(int64_t num_rows);
 
   // commit the metadata
   std::unique_ptr<FileMetaData> Finish();

--- a/src/parquet/file/metadata.h
+++ b/src/parquet/file/metadata.h
@@ -175,8 +175,9 @@ class PARQUET_EXPORT RowGroupMetaDataBuilder {
   void Finish();
 
  private:
-  explicit RowGroupMetaDataBuilder(int64_t num_rows, const std::shared_ptr<WriterProperties>& props,
-      const SchemaDescriptor* schema_, uint8_t* contents);
+  explicit RowGroupMetaDataBuilder(int64_t num_rows,
+      const std::shared_ptr<WriterProperties>& props, const SchemaDescriptor* schema_,
+      uint8_t* contents);
   // PIMPL Idiom
   class RowGroupMetaDataBuilderImpl;
   std::unique_ptr<RowGroupMetaDataBuilderImpl> impl_;

--- a/src/parquet/file/metadata.h
+++ b/src/parquet/file/metadata.h
@@ -117,7 +117,7 @@ class PARQUET_EXPORT FileMetaData {
   void WriteTo(OutputStream* dst);
 
   // Return const-pointer to make it clear that this object is not to be copied
-  const SchemaDescriptor* schema_descriptor() const;
+  const SchemaDescriptor* schema() const;
 
  private:
   friend FileMetaDataBuilder;
@@ -145,7 +145,7 @@ class PARQUET_EXPORT ColumnChunkMetaDataBuilder {
   // ownership of min/max is with ColumnChunkMetadata
   void SetStatistics(const ColumnStatistics& stats);
   // get the column descriptor
-  const ColumnDescriptor* descriptor() const;
+  const ColumnDescriptor* descr() const;
   // commit the metadata
   void Finish(int64_t num_values, int64_t dictonary_page_offset,
       int64_t index_page_offset, int64_t data_page_offset, int64_t compressed_size,

--- a/src/parquet/file/reader.cc
+++ b/src/parquet/file/reader.cc
@@ -126,7 +126,7 @@ void ParquetFileReader::DebugPrint(
   stream << "Total rows: " << file_metadata->num_rows() << "\n";
   stream << "Number of RowGroups: " << file_metadata->num_row_groups() << "\n";
   stream << "Number of Real Columns: "
-         << file_metadata->schema_descriptor()->group()->field_count() << "\n";
+         << file_metadata->schema()->group_node()->field_count() << "\n";
 
   if (selected_columns.size() == 0) {
     for (int i = 0; i < file_metadata->num_columns(); i++) {
@@ -143,7 +143,7 @@ void ParquetFileReader::DebugPrint(
   stream << "Number of Columns: " << file_metadata->num_columns() << "\n";
   stream << "Number of Selected Columns: " << selected_columns.size() << "\n";
   for (auto i : selected_columns) {
-    const ColumnDescriptor* descr = file_metadata->schema_descriptor()->Column(i);
+    const ColumnDescriptor* descr = file_metadata->schema()->Column(i);
     stream << "Column " << i << ": " << descr->name() << " ("
            << TypeToString(descr->physical_type()) << ")" << std::endl;
   }
@@ -162,7 +162,7 @@ void ParquetFileReader::DebugPrint(
       auto column_chunk = group_metadata->ColumnChunk(i);
       const ColumnStatistics stats = column_chunk->statistics();
 
-      const ColumnDescriptor* descr = file_metadata->schema_descriptor()->Column(i);
+      const ColumnDescriptor* descr = file_metadata->schema()->Column(i);
       stream << "Column " << i << std::endl << ", values: " << column_chunk->num_values();
       if (column_chunk->is_stats_set()) {
         stream << ", null values: " << stats.null_count
@@ -201,7 +201,7 @@ void ParquetFileReader::DebugPrint(
       std::string fmt = ss.str();
 
       snprintf(buffer, bufsize, fmt.c_str(),
-          file_metadata->schema_descriptor()->Column(i)->name().c_str());
+          file_metadata->schema()->Column(i)->name().c_str());
       stream << buffer;
 
       // This is OK in this method as long as the RowGroupReader does not get

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -144,7 +144,7 @@ ColumnWriter* RowGroupSerializer::NextColumn() {
   // Throws an error if more columns are being written
   auto col_meta = metadata_->NextColumnChunk();
 
-  if (current_column_writer_) { current_column_writer_->Close(); }
+  if (current_column_writer_) { total_bytes_written_ = current_column_writer_->Close(); }
 
   const ColumnDescriptor* column_descr = col_meta->descriptor();
   std::unique_ptr<PageWriter> pager(
@@ -160,11 +160,11 @@ void RowGroupSerializer::Close() {
     closed_ = true;
 
     if (current_column_writer_) {
-      current_column_writer_->Close();
+      total_bytes_written_ = current_column_writer_->Close();
       current_column_writer_.reset();
     }
     // Ensures all columns have been written
-    metadata_->Finish();
+    metadata_->Finish(total_bytes_written_);
   }
 }
 

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -146,12 +146,12 @@ ColumnWriter* RowGroupSerializer::NextColumn() {
 
   if (current_column_writer_) { total_bytes_written_ = current_column_writer_->Close(); }
 
-  const ColumnDescriptor* column_descr = col_meta->descriptor();
+  const ColumnDescriptor* column_descr = col_meta->descr();
   std::unique_ptr<PageWriter> pager(
       new SerializedPageWriter(sink_, properties_->compression(column_descr->path()),
           col_meta, properties_->allocator()));
-  current_column_writer_ = ColumnWriter::Make(
-      col_meta->descriptor(), std::move(pager), num_rows_, properties_);
+  current_column_writer_ =
+      ColumnWriter::Make(col_meta->descr(), std::move(pager), num_rows_, properties_);
   return current_column_writer_.get();
 }
 

--- a/src/parquet/file/writer-internal.cc
+++ b/src/parquet/file/writer-internal.cc
@@ -34,25 +34,22 @@ static constexpr uint8_t PARQUET_MAGIC[4] = {'P', 'A', 'R', '1'};
 // SerializedPageWriter
 
 SerializedPageWriter::SerializedPageWriter(OutputStream* sink, Compression::type codec,
-    format::ColumnChunk* metadata, MemoryAllocator* allocator)
+    ColumnChunkMetaDataBuilder* metadata, MemoryAllocator* allocator)
     : sink_(sink),
       metadata_(metadata),
-      // allocator_(allocator),
+      num_values_(0),
+      dictionary_page_offset_(0),
+      data_page_offset_(0),
+      total_uncompressed_size_(0),
+      total_compressed_size_(0),
       compression_buffer_(std::make_shared<OwnedMutableBuffer>(0, allocator)) {
   compressor_ = Codec::Create(codec);
-  // Currently we directly start with the data page
-  metadata_->meta_data.__set_data_page_offset(sink_->Tell());
-  metadata_->meta_data.__set_codec(ToThrift(codec));
 }
 
-void SerializedPageWriter::Close() {}
-
-void SerializedPageWriter::AddEncoding(Encoding::type encoding) {
-  auto it = std::find(metadata_->meta_data.encodings.begin(),
-      metadata_->meta_data.encodings.end(), ToThrift(encoding));
-  if (it != metadata_->meta_data.encodings.end()) {
-    metadata_->meta_data.encodings.push_back(ToThrift(encoding));
-  }
+void SerializedPageWriter::Close() {
+  // index_page_offset = 0 since they are not supported
+  // TODO: Remove default fallback = 'false' when implemented
+  metadata_->Finish(num_values_, dictionary_page_offset_, 0, data_page_offset_, total_compressed_size_, total_uncompressed_size_, false);
 }
 
 std::shared_ptr<Buffer> SerializedPageWriter::Compress(
@@ -91,13 +88,16 @@ int64_t SerializedPageWriter::WriteDataPage(const DataPage& page) {
   // TODO(PARQUET-594) crc checksum
 
   int64_t start_pos = sink_->Tell();
+  if (data_page_offset_ == 0) {
+    data_page_offset_ = start_pos;
+  }
   SerializeThriftMsg(&page_header, sizeof(format::PageHeader), sink_);
   int64_t header_size = sink_->Tell() - start_pos;
   sink_->Write(compressed_data->data(), compressed_data->size());
 
-  metadata_->meta_data.total_uncompressed_size += uncompressed_size + header_size;
-  metadata_->meta_data.total_compressed_size += compressed_data->size() + header_size;
-  metadata_->meta_data.num_values += page.num_values();
+  total_uncompressed_size_ += uncompressed_size + header_size;
+  total_compressed_size_ += compressed_data->size() + header_size;
+  num_values_ += page.num_values();
 
   return sink_->Tell() - start_pos;
 }
@@ -119,12 +119,15 @@ int64_t SerializedPageWriter::WriteDictionaryPage(const DictionaryPage& page) {
   // TODO(PARQUET-594) crc checksum
 
   int64_t start_pos = sink_->Tell();
+  if (dictionary_page_offset_ == 0) {
+    dictionary_page_offset_ = start_pos;
+  }
   SerializeThriftMsg(&page_header, sizeof(format::PageHeader), sink_);
   int64_t header_size = sink_->Tell() - start_pos;
   sink_->Write(compressed_data->data(), compressed_data->size());
 
-  metadata_->meta_data.total_uncompressed_size += uncompressed_size + header_size;
-  metadata_->meta_data.total_compressed_size += compressed_data->size() + header_size;
+  total_uncompressed_size_ += uncompressed_size + header_size;
+  total_compressed_size_ += compressed_data->size() + header_size;
 
   return sink_->Tell() - start_pos;
 }
@@ -133,50 +136,37 @@ int64_t SerializedPageWriter::WriteDictionaryPage(const DictionaryPage& page) {
 // RowGroupSerializer
 
 int RowGroupSerializer::num_columns() const {
-  return schema_->num_columns();
+  return metadata_->num_columns();
 }
 
 int64_t RowGroupSerializer::num_rows() const {
   return num_rows_;
 }
 
-const SchemaDescriptor* RowGroupSerializer::schema() const {
-  return schema_;
-}
-
 ColumnWriter* RowGroupSerializer::NextColumn() {
-  if (current_column_index_ == schema_->num_columns() - 1) {
-    throw ParquetException("All columns have already been written.");
-  }
-  current_column_index_++;
+  // Throws an error if more columns are being written
+  auto col_meta = metadata_->NextColumnChunk();
 
-  if (current_column_writer_) { total_bytes_written_ += current_column_writer_->Close(); }
+  if (current_column_writer_) { current_column_writer_->Close(); }
 
-  const ColumnDescriptor* column_descr = schema_->Column(current_column_index_);
-  format::ColumnChunk* col_meta = &metadata_->columns[current_column_index_];
-  col_meta->__isset.meta_data = true;
-  col_meta->meta_data.__set_type(ToThrift(column_descr->physical_type()));
-  col_meta->meta_data.__set_path_in_schema(column_descr->path()->ToDotVector());
+  const ColumnDescriptor* column_descr = col_meta->descriptor();
   std::unique_ptr<PageWriter> pager(new SerializedPageWriter(
-      sink_, properties_->compression(column_descr->path()), col_meta, allocator_));
+      sink_, properties_->compression(column_descr->path()), col_meta, properties_->allocator()));
   current_column_writer_ =
-      ColumnWriter::Make(column_descr, std::move(pager), num_rows_, properties_);
+      ColumnWriter::Make(col_meta->descriptor(), std::move(pager), num_rows_, properties_);
   return current_column_writer_.get();
 }
 
 void RowGroupSerializer::Close() {
   if (!closed_) {
     closed_ = true;
-    if (current_column_index_ != schema_->num_columns() - 1) {
-      throw ParquetException("Not all column were written in the current rowgroup.");
-    }
-
+    
     if (current_column_writer_) {
-      total_bytes_written_ += current_column_writer_->Close();
+      current_column_writer_->Close();
       current_column_writer_.reset();
     }
-
-    metadata_->__set_total_byte_size(total_bytes_written_);
+    //Ensures all columns have been written
+    metadata_->Finish();
   }
 }
 
@@ -196,7 +186,7 @@ void FileSerializer::Close() {
   if (is_open_) {
     if (row_group_writer_) { row_group_writer_->Close(); }
     row_group_writer_.reset();
-
+   
     // Write magic bytes and metadata
     WriteMetaData();
 
@@ -225,13 +215,10 @@ RowGroupWriter* FileSerializer::AppendRowGroup(int64_t num_rows) {
   if (row_group_writer_) { row_group_writer_->Close(); }
   num_rows_ += num_rows;
   num_row_groups_++;
-
-  auto rgm_size = row_group_metadata_.size();
-  row_group_metadata_.resize(rgm_size + 1);
-  format::RowGroup* rg_metadata = &row_group_metadata_.data()[rgm_size];
+  auto rg_metadata = metadata_->AppendRowGroup(num_rows);
   std::unique_ptr<RowGroupWriter::Contents> contents(new RowGroupSerializer(
-      num_rows, &schema_, sink_.get(), rg_metadata, properties_.get()));
-  row_group_writer_.reset(new RowGroupWriter(std::move(contents), allocator_));
+      num_rows, sink_.get(), rg_metadata, properties_.get()));
+  row_group_writer_.reset(new RowGroupWriter(std::move(contents)));
   return row_group_writer_.get();
 }
 
@@ -243,19 +230,9 @@ void FileSerializer::WriteMetaData() {
   // Write MetaData
   uint32_t metadata_len = sink_->Tell();
 
-  SchemaFlattener flattener(
-      static_cast<GroupNode*>(schema_.schema().get()), &metadata_.schema);
-  flattener.Flatten();
-
-  // TODO: Currently we only write version 1 files
-  metadata_.__set_version(1);
-  metadata_.__set_num_rows(num_rows_);
-  metadata_.__set_row_groups(row_group_metadata_);
-  // TODO(PARQUET-595) Support key_value_metadata
-  // TODO(PARQUET-590) Get from WriterProperties
-  metadata_.__set_created_by("parquet-cpp");
-
-  SerializeThriftMsg(&metadata_, 1024, sink_.get());
+  // Get a FileMetaData
+  auto metadata = metadata_->Finish();
+  metadata->WriteTo(sink_.get());
   metadata_len = sink_->Tell() - metadata_len;
 
   // Write Footer
@@ -267,12 +244,12 @@ FileSerializer::FileSerializer(std::shared_ptr<OutputStream> sink,
     const std::shared_ptr<GroupNode>& schema,
     const std::shared_ptr<WriterProperties>& properties)
     : sink_(sink),
-      allocator_(properties->allocator()),
-      num_row_groups_(0),
-      num_rows_(0),
       is_open_(true),
-      properties_(properties) {
+      properties_(properties),
+      num_row_groups_(0),
+      num_rows_(0) {
   schema_.Init(schema);
+  metadata_ = FileMetaDataBuilder::Make(&schema_, properties);
   StartFile();
 }
 

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -34,7 +34,9 @@ namespace parquet {
 // and the page metadata.
 class SerializedPageWriter : public PageWriter {
  public:
-  SerializedPageWriter(OutputStream* sink, Compression::type codec, ColumnChunkMetaDataBuilder* metadata, MemoryAllocator* allocator = default_allocator());
+  SerializedPageWriter(OutputStream* sink, Compression::type codec,
+      ColumnChunkMetaDataBuilder* metadata,
+      MemoryAllocator* allocator = default_allocator());
 
   virtual ~SerializedPageWriter() {}
 
@@ -75,8 +77,7 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
         sink_(sink),
         metadata_(std::move(metadata)),
         properties_(properties),
-        closed_(false) {
-  }
+        closed_(false) {}
 
   int num_columns() const override;
   int64_t num_rows() const override;
@@ -132,7 +133,7 @@ class FileSerializer : public ParquetFileWriter::Contents {
   int64_t num_rows_;
   std::unique_ptr<FileMetaDataBuilder> metadata_;
   std::unique_ptr<RowGroupWriter> row_group_writer_;
-  
+
   void StartFile();
   void WriteMetaData();
 };

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -97,7 +97,6 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
   int64_t total_bytes_written_;
   bool closed_;
 
-  int64_t current_column_index_;
   std::shared_ptr<ColumnWriter> current_column_writer_;
 };
 

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -75,7 +75,7 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
       RowGroupMetaDataBuilder* metadata, const WriterProperties* properties)
       : num_rows_(num_rows),
         sink_(sink),
-        metadata_(std::move(metadata)),
+        metadata_(metadata),
         properties_(properties),
         total_bytes_written_(0),
         closed_(false) {}

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -23,6 +23,7 @@
 
 #include "parquet/column/page.h"
 #include "parquet/compression/codec.h"
+#include "parquet/file/metadata.h"
 #include "parquet/file/writer.h"
 #include "parquet/thrift/parquet_types.h"
 
@@ -31,11 +32,9 @@ namespace parquet {
 // This subclass delimits pages appearing in a serialized stream, each preceded
 // by a serialized Thrift format::PageHeader indicating the type of each page
 // and the page metadata.
-//
 class SerializedPageWriter : public PageWriter {
  public:
-  SerializedPageWriter(OutputStream* sink, Compression::type codec,
-      format::ColumnChunk* metadata, MemoryAllocator* allocator = default_allocator());
+  SerializedPageWriter(OutputStream* sink, Compression::type codec, ColumnChunkMetaDataBuilder* metadata, MemoryAllocator* allocator = default_allocator());
 
   virtual ~SerializedPageWriter() {}
 
@@ -47,14 +46,17 @@ class SerializedPageWriter : public PageWriter {
 
  private:
   OutputStream* sink_;
-  format::ColumnChunk* metadata_;
-  // MemoryAllocator* allocator_;
+  ColumnChunkMetaDataBuilder* metadata_;
+  int64_t num_values_;
+  int64_t dictionary_page_offset_;
+  int64_t data_page_offset_;
+  int64_t total_uncompressed_size_;
+  int64_t total_compressed_size_;
 
   // Compression codec to use.
   std::unique_ptr<Codec> compressor_;
   std::shared_ptr<OwnedMutableBuffer> compression_buffer_;
 
-  void AddEncoding(Encoding::type encoding);
   /**
    * Compress a buffer.
    *
@@ -67,24 +69,17 @@ class SerializedPageWriter : public PageWriter {
 // RowGroupWriter::Contents implementation for the Parquet file specification
 class RowGroupSerializer : public RowGroupWriter::Contents {
  public:
-  RowGroupSerializer(int64_t num_rows, const SchemaDescriptor* schema, OutputStream* sink,
-      format::RowGroup* metadata, const WriterProperties* properties)
+  RowGroupSerializer(int64_t num_rows, OutputStream* sink,
+      RowGroupMetaDataBuilder* metadata, const WriterProperties* properties)
       : num_rows_(num_rows),
-        schema_(schema),
         sink_(sink),
-        metadata_(metadata),
-        allocator_(properties->allocator()),
+        metadata_(std::move(metadata)),
         properties_(properties),
-        total_bytes_written_(0),
-        closed_(false),
-        current_column_index_(-1) {
-    metadata_->__set_num_rows(num_rows_);
-    metadata_->columns.resize(schema->num_columns());
+        closed_(false) {
   }
 
   int num_columns() const override;
   int64_t num_rows() const override;
-  const SchemaDescriptor* schema() const override;
 
   // TODO: PARQUET-579
   // void WriteRowGroupStatitics() override;
@@ -94,12 +89,9 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
 
  private:
   int64_t num_rows_;
-  const SchemaDescriptor* schema_;
   OutputStream* sink_;
-  format::RowGroup* metadata_;
-  MemoryAllocator* allocator_;
+  RowGroupMetaDataBuilder* metadata_;
   const WriterProperties* properties_;
-  int64_t total_bytes_written_;
   bool closed_;
 
   int64_t current_column_index_;
@@ -134,15 +126,13 @@ class FileSerializer : public ParquetFileWriter::Contents {
       const std::shared_ptr<WriterProperties>& properties);
 
   std::shared_ptr<OutputStream> sink_;
-  format::FileMetaData metadata_;
-  std::vector<format::RowGroup> row_group_metadata_;
-  MemoryAllocator* allocator_;
-  int num_row_groups_;
-  int num_rows_;
   bool is_open_;
+  const std::shared_ptr<WriterProperties> properties_;
+  int num_row_groups_;
+  int64_t num_rows_;
+  std::unique_ptr<FileMetaDataBuilder> metadata_;
   std::unique_ptr<RowGroupWriter> row_group_writer_;
-  std::shared_ptr<WriterProperties> properties_;
-
+  
   void StartFile();
   void WriteMetaData();
 };

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -77,6 +77,7 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
         sink_(sink),
         metadata_(std::move(metadata)),
         properties_(properties),
+        total_bytes_written_(0),
         closed_(false) {}
 
   int num_columns() const override;
@@ -93,6 +94,7 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
   OutputStream* sink_;
   RowGroupMetaDataBuilder* metadata_;
   const WriterProperties* properties_;
+  int64_t total_bytes_written_;
   bool closed_;
 
   int64_t current_column_index_;

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -28,9 +28,8 @@ namespace parquet {
 // RowGroupWriter public API
 
 RowGroupWriter::RowGroupWriter(
-    std::unique_ptr<Contents> contents, MemoryAllocator* allocator)
-    : contents_(std::move(contents)), allocator_(allocator) {
-  schema_ = contents_->schema();
+    std::unique_ptr<Contents> contents)
+    : contents_(std::move(contents)) {
 }
 
 void RowGroupWriter::Close() {
@@ -66,7 +65,6 @@ std::unique_ptr<ParquetFileWriter> ParquetFileWriter::Open(
 
 void ParquetFileWriter::Open(std::unique_ptr<ParquetFileWriter::Contents> contents) {
   contents_ = std::move(contents);
-  schema_ = contents_->schema();
 }
 
 void ParquetFileWriter::Close() {

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -61,6 +61,14 @@ std::unique_ptr<ParquetFileWriter> ParquetFileWriter::Open(
   return result;
 }
 
+const SchemaDescriptor* ParquetFileWriter::descr() const {
+  return contents_->schema();
+}
+
+const ColumnDescriptor* ParquetFileWriter::column_schema(int i) const {
+  return contents_->schema()->Column(i);
+}
+
 void ParquetFileWriter::Open(std::unique_ptr<ParquetFileWriter::Contents> contents) {
   contents_ = std::move(contents);
 }

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -27,10 +27,8 @@ namespace parquet {
 // ----------------------------------------------------------------------
 // RowGroupWriter public API
 
-RowGroupWriter::RowGroupWriter(
-    std::unique_ptr<Contents> contents)
-    : contents_(std::move(contents)) {
-}
+RowGroupWriter::RowGroupWriter(std::unique_ptr<Contents> contents)
+    : contents_(std::move(contents)) {}
 
 void RowGroupWriter::Close() {
   if (contents_) {

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -61,11 +61,11 @@ std::unique_ptr<ParquetFileWriter> ParquetFileWriter::Open(
   return result;
 }
 
-const SchemaDescriptor* ParquetFileWriter::descr() const {
+const SchemaDescriptor* ParquetFileWriter::schema() const {
   return contents_->schema();
 }
 
-const ColumnDescriptor* ParquetFileWriter::column_schema(int i) const {
+const ColumnDescriptor* ParquetFileWriter::descr(int i) const {
   return contents_->schema()->Column(i);
 }
 

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -46,12 +46,9 @@ class PARQUET_EXPORT RowGroupWriter {
     // virtual void WriteRowGroupStatitics();
     virtual ColumnWriter* NextColumn() = 0;
     virtual void Close() = 0;
-
-    // Return const-pointer to make it clear that this object is not to be copied
-    virtual const SchemaDescriptor* schema() const = 0;
   };
 
-  RowGroupWriter(std::unique_ptr<Contents> contents, MemoryAllocator* allocator);
+  RowGroupWriter(std::unique_ptr<Contents> contents);
 
   /**
    * Construct a ColumnWriter for the indicated row group-relative column.
@@ -75,13 +72,8 @@ class PARQUET_EXPORT RowGroupWriter {
   // virtual void WriteRowGroupStatitics();
 
  private:
-  // Owned by the parent ParquetFileWriter
-  const SchemaDescriptor* schema_;
-
   // Holds a pointer to an instance of Contents implementation
   std::unique_ptr<Contents> contents_;
-
-  MemoryAllocator* allocator_;
 };
 
 class PARQUET_EXPORT ParquetFileWriter {
@@ -101,10 +93,9 @@ class PARQUET_EXPORT ParquetFileWriter {
     virtual int num_row_groups() const = 0;
 
     virtual const std::shared_ptr<WriterProperties>& properties() const = 0;
-
-    // Return const-poitner to make it clear that this object is not to be copied
-    const SchemaDescriptor* schema() const { return &schema_; }
-    SchemaDescriptor schema_;
+   // Return const-poitner to make it clear that this object is not to be copied
+     const SchemaDescriptor* schema() const { return &schema_; }
+     SchemaDescriptor schema_;
   };
 
   ParquetFileWriter();
@@ -152,19 +143,9 @@ class PARQUET_EXPORT ParquetFileWriter {
    */
   const std::shared_ptr<WriterProperties>& properties() const;
 
-  /**
-   * Returns the file schema descriptor
-   */
-  const SchemaDescriptor* descr() { return schema_; }
-
-  const ColumnDescriptor* column_schema(int i) const { return schema_->Column(i); }
-
  private:
   // Holds a pointer to an instance of Contents implementation
   std::unique_ptr<Contents> contents_;
-
-  // The SchemaDescriptor is provided by the Contents impl
-  const SchemaDescriptor* schema_;
 };
 
 }  // namespace parquet

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -147,12 +147,12 @@ class PARQUET_EXPORT ParquetFileWriter {
   /**
     * Returns the file schema descriptor
     */
-  const SchemaDescriptor* descr() const;
+  const SchemaDescriptor* schema() const;
 
   /**
    * Returns a column descriptor in schema
    */
-  const ColumnDescriptor* column_schema(int i) const;
+  const ColumnDescriptor* descr(int i) const;
 
  private:
   // Holds a pointer to an instance of Contents implementation

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -48,7 +48,7 @@ class PARQUET_EXPORT RowGroupWriter {
     virtual void Close() = 0;
   };
 
-  RowGroupWriter(std::unique_ptr<Contents> contents);
+  explicit RowGroupWriter(std::unique_ptr<Contents> contents);
 
   /**
    * Construct a ColumnWriter for the indicated row group-relative column.
@@ -93,9 +93,9 @@ class PARQUET_EXPORT ParquetFileWriter {
     virtual int num_row_groups() const = 0;
 
     virtual const std::shared_ptr<WriterProperties>& properties() const = 0;
-   // Return const-poitner to make it clear that this object is not to be copied
-     const SchemaDescriptor* schema() const { return &schema_; }
-     SchemaDescriptor schema_;
+    // Return const-poitner to make it clear that this object is not to be copied
+    const SchemaDescriptor* schema() const { return &schema_; }
+    SchemaDescriptor schema_;
   };
 
   ParquetFileWriter();

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -93,7 +93,8 @@ class PARQUET_EXPORT ParquetFileWriter {
     virtual int num_row_groups() const = 0;
 
     virtual const std::shared_ptr<WriterProperties>& properties() const = 0;
-    // Return const-poitner to make it clear that this object is not to be copied
+
+    // Return const-pointer to make it clear that this object is not to be copied
     const SchemaDescriptor* schema() const { return &schema_; }
     SchemaDescriptor schema_;
   };
@@ -142,6 +143,16 @@ class PARQUET_EXPORT ParquetFileWriter {
    * Configuration passed to the writer, e.g. the used Parquet format version.
    */
   const std::shared_ptr<WriterProperties>& properties() const;
+
+  /**
+    * Returns the file schema descriptor
+    */
+  const SchemaDescriptor* descr() const;
+
+  /**
+   * Returns a column descriptor in schema
+   */
+  const ColumnDescriptor* column_schema(int i) const;
 
  private:
   // Holds a pointer to an instance of Contents implementation

--- a/src/parquet/schema/descriptor.cc
+++ b/src/parquet/schema/descriptor.cc
@@ -39,11 +39,11 @@ void SchemaDescriptor::Init(const NodePtr& schema) {
     throw ParquetException("Must initialize with a schema group");
   }
 
-  group_ = static_cast<const GroupNode*>(schema_.get());
+  group_node_ = static_cast<const GroupNode*>(schema_.get());
   leaves_.clear();
 
-  for (int i = 0; i < group_->field_count(); ++i) {
-    BuildTree(group_->field(i), 0, 0, group_->field(i));
+  for (int i = 0; i < group_node_->field_count(); ++i) {
+    BuildTree(group_node_->field(i), 0, 0, group_node_->field(i));
   }
 }
 

--- a/src/parquet/schema/descriptor.h
+++ b/src/parquet/schema/descriptor.h
@@ -100,18 +100,20 @@ class PARQUET_EXPORT SchemaDescriptor {
   // The number of physical columns appearing in the file
   int num_columns() const { return leaves_.size(); }
 
-  const schema::NodePtr& schema() const { return schema_; }
+  const schema::NodePtr& schema_root() const { return schema_; }
 
-  const schema::GroupNode* group() const { return group_; }
+  const schema::GroupNode* group_node() const { return group_node_; }
 
   // Returns the root (child of the schema root) node of the leaf(column) node
   const schema::NodePtr& GetColumnRoot(int i) const;
+
+  const std::string& name() const { return group_node_->name(); }
 
  private:
   friend class ColumnDescriptor;
 
   schema::NodePtr schema_;
-  const schema::GroupNode* group_;
+  const schema::GroupNode* group_node_;
 
   void BuildTree(const schema::NodePtr& node, int16_t max_def_level,
       int16_t max_rep_level, const schema::NodePtr& base);

--- a/src/parquet/schema/schema-descriptor-test.cc
+++ b/src/parquet/schema/schema-descriptor-test.cc
@@ -128,7 +128,7 @@ TEST_F(TestSchemaDescriptor, BuildTree) {
   ASSERT_EQ(bag.get(), descr_.GetColumnRoot(4).get());
   ASSERT_EQ(bag.get(), descr_.GetColumnRoot(5).get());
 
-  ASSERT_EQ(schema.get(), descr_.group());
+  ASSERT_EQ(schema.get(), descr_.group_node());
 
   // Init clears the leaves
   descr_.Init(schema);

--- a/tools/parquet-dump-schema.cc
+++ b/tools/parquet-dump-schema.cc
@@ -26,7 +26,7 @@ int main(int argc, char** argv) {
   try {
     std::unique_ptr<parquet::ParquetFileReader> reader =
         parquet::ParquetFileReader::OpenFile(filename);
-    PrintSchema(reader->metadata()->schema_descriptor()->schema().get(), std::cout);
+    PrintSchema(reader->metadata()->schema()->schema_root().get(), std::cout);
   } catch (const std::exception& e) {
     std::cerr << "Parquet error: " << e.what() << std::endl;
     return -1;


### PR DESCRIPTION
I wrote a sample file and the metadata seems to be correct.
@xhochy I fixed some missing metadata like `dictionary_page_offset`. You might want to check if this fixes the Drill problem.