### PR TITLE
PARQUET-718: Fix I/O of non-dictionary encoded pages

### DIFF
--- a/src/parquet/column/test-specialization.h
+++ b/src/parquet/column/test-specialization.h
@@ -22,6 +22,7 @@
 #ifndef PARQUET_COLUMN_TEST_SPECIALIZATION_H
 #define PARQUET_COLUMN_TEST_SPECIALIZATION_H
 
+#include <algorithm>
 #include <limits>
 #include <vector>
 

--- a/src/parquet/column/test-specialization.h
+++ b/src/parquet/column/test-specialization.h
@@ -59,6 +59,102 @@ void InitValues<Int96>(int num_values, vector<Int96>& values, vector<uint8_t>& b
       std::numeric_limits<int32_t>::max(), values.data());
 }
 
+// This class lives here because of its dependency on the InitValues specializations.
+template <typename TestType>
+class PrimitiveTypedTest : public ::testing::Test {
+ public:
+  typedef typename TestType::c_type T;
+
+  void SetUpSchemaRequired() {
+    primitive_node_ = schema::PrimitiveNode::Make("column", Repetition::REQUIRED,
+        TestType::type_num, LogicalType::NONE, FLBA_LENGTH);
+    descr_ = std::make_shared<ColumnDescriptor>(primitive_node_, 0, 0);
+    node_ = schema::GroupNode::Make(
+        "schema", Repetition::REQUIRED, std::vector<schema::NodePtr>({primitive_node_}));
+    schema_.Init(node_);
+  }
+
+  void SetUpSchemaOptional() {
+    primitive_node_ = schema::PrimitiveNode::Make("column", Repetition::OPTIONAL,
+        TestType::type_num, LogicalType::NONE, FLBA_LENGTH);
+    descr_ = std::make_shared<ColumnDescriptor>(primitive_node_, 1, 0);
+    node_ = schema::GroupNode::Make(
+        "schema", Repetition::REQUIRED, std::vector<schema::NodePtr>({primitive_node_}));
+    schema_.Init(node_);
+  }
+
+  void SetUpSchemaRepeated() {
+    primitive_node_ = schema::PrimitiveNode::Make("column", Repetition::REPEATED,
+        TestType::type_num, LogicalType::NONE, FLBA_LENGTH);
+    descr_ = std::make_shared<ColumnDescriptor>(primitive_node_, 1, 1);
+    node_ = schema::GroupNode::Make(
+        "schema", Repetition::REQUIRED, std::vector<schema::NodePtr>({primitive_node_}));
+    schema_.Init(node_);
+  }
+
+  void GenerateData(int64_t num_values);
+  void SetupValuesOut(int64_t num_values);
+  void SyncValuesOut();
+  void SetUp() { SetUpSchemaRequired(); }
+
+ protected:
+  schema::NodePtr primitive_node_;
+  schema::NodePtr node_;
+  SchemaDescriptor schema_;
+  std::shared_ptr<ColumnDescriptor> descr_;
+
+  // Input buffers
+  std::vector<T> values_;
+  std::vector<uint8_t> buffer_;
+  // Pointer to the values, needed as we cannot use vector<bool>::data()
+  T* values_ptr_;
+  std::vector<uint8_t> bool_buffer_;
+
+  // Output buffers
+  std::vector<T> values_out_;
+  std::vector<uint8_t> bool_buffer_out_;
+  T* values_out_ptr_;
+};
+
+template <typename TestType>
+void PrimitiveTypedTest<TestType>::SyncValuesOut() {}
+
+template <>
+void PrimitiveTypedTest<BooleanType>::SyncValuesOut() {
+  std::copy(bool_buffer_out_.begin(), bool_buffer_out_.end(), values_out_.begin());
+}
+
+template <typename TestType>
+void PrimitiveTypedTest<TestType>::SetupValuesOut(int64_t num_values) {
+  values_out_.resize(num_values);
+  values_out_ptr_ = values_out_.data();
+}
+
+template <>
+void PrimitiveTypedTest<BooleanType>::SetupValuesOut(int64_t num_values) {
+  values_out_.resize(num_values);
+  bool_buffer_out_.resize(num_values);
+  // Write once to all values so we can copy it without getting Valgrind errors
+  // about uninitialised values.
+  std::fill(bool_buffer_out_.begin(), bool_buffer_out_.end(), true);
+  values_out_ptr_ = reinterpret_cast<bool*>(bool_buffer_out_.data());
+}
+
+template <typename TestType>
+void PrimitiveTypedTest<TestType>::GenerateData(int64_t num_values) {
+  values_.resize(num_values);
+  InitValues<T>(num_values, values_, buffer_);
+  values_ptr_ = values_.data();
+}
+
+template <>
+void PrimitiveTypedTest<BooleanType>::GenerateData(int64_t num_values) {
+  values_.resize(num_values);
+  InitValues<T>(num_values, values_, buffer_);
+  bool_buffer_.resize(num_values);
+  std::copy(values_.begin(), values_.end(), bool_buffer_.begin());
+  values_ptr_ = reinterpret_cast<bool*>(bool_buffer_.data());
+}
 }  // namespace test
 
 }  // namespace parquet

--- a/src/parquet/file/metadata.cc
+++ b/src/parquet/file/metadata.cc
@@ -355,13 +355,13 @@ class ColumnChunkMetaDataBuilder::ColumnChunkMetaDataBuilderImpl {
       int64_t index_page_offset, int64_t data_page_offset, int64_t compressed_size,
       int64_t uncompressed_size, bool has_dictionary, bool dictionary_fallback) {
     if (dictionary_page_offset > 0) {
+      column_chunk_->meta_data.__set_dictionary_page_offset(dictionary_page_offset);
       column_chunk_->__set_file_offset(dictionary_page_offset + compressed_size);
     } else {
       column_chunk_->__set_file_offset(data_page_offset + compressed_size);
     }
     column_chunk_->__isset.meta_data = true;
     column_chunk_->meta_data.__set_num_values(num_values);
-    column_chunk_->meta_data.__set_dictionary_page_offset(dictionary_page_offset);
     column_chunk_->meta_data.__set_index_page_offset(index_page_offset);
     column_chunk_->meta_data.__set_data_page_offset(data_page_offset);
     column_chunk_->meta_data.__set_total_uncompressed_size(uncompressed_size);


### PR DESCRIPTION
We have set dictionary_page_offset if though we did not have a dictionary page present, this caused too much data to be loaded into the SerializedPageReader.