### PR TITLE
PARQUET-720: Mark ScanAllValues as inline to prevent link error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,6 +493,7 @@ set(LIBPARQUET_SRCS
   src/parquet/column/reader.cc
   src/parquet/column/writer.cc
   src/parquet/column/scanner.cc
+  src/parquet/column/scan-all.cc
 
   src/parquet/compression/codec.cc
   src/parquet/compression/snappy-codec.cc

--- a/src/parquet/column/scan-all.cc
+++ b/src/parquet/column/scan-all.cc
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/column/scan-all.h"
+
+namespace parquet {
+
+int64_t ScanAllValues(int32_t batch_size, int16_t* def_levels, int16_t* rep_levels,
+                      uint8_t* values, int64_t* values_buffered, parquet::ColumnReader* reader) {
+  switch (reader->type()) {
+  case parquet::Type::BOOLEAN:
+    return ScanAll<parquet::BoolReader>(
+       batch_size, def_levels, rep_levels, values, values_buffered, reader);
+  case parquet::Type::INT32:
+    return ScanAll<parquet::Int32Reader>(
+       batch_size, def_levels, rep_levels, values, values_buffered, reader);
+  case parquet::Type::INT64:
+    return ScanAll<parquet::Int64Reader>(
+       batch_size, def_levels, rep_levels, values, values_buffered, reader);
+  case parquet::Type::INT96:
+    return ScanAll<parquet::Int96Reader>(
+       batch_size, def_levels, rep_levels, values, values_buffered, reader);
+  case parquet::Type::FLOAT:
+    return ScanAll<parquet::FloatReader>(
+       batch_size, def_levels, rep_levels, values, values_buffered, reader);
+  case parquet::Type::DOUBLE:
+    return ScanAll<parquet::DoubleReader>(
+       batch_size, def_levels, rep_levels, values, values_buffered, reader);
+  case parquet::Type::BYTE_ARRAY:
+    return ScanAll<parquet::ByteArrayReader>(
+       batch_size, def_levels, rep_levels, values, values_buffered, reader);
+  case parquet::Type::FIXED_LEN_BYTE_ARRAY:
+    return ScanAll<parquet::FixedLenByteArrayReader>(
+       batch_size, def_levels, rep_levels, values, values_buffered, reader);
+  default:
+    parquet::ParquetException::NYI("type reader not implemented");
+  }
+  // Unreachable code, but supress compiler warning
+  return 0;
+}
+
+}  // namespace parquet

--- a/src/parquet/column/scan-all.h
+++ b/src/parquet/column/scan-all.h
@@ -30,38 +30,7 @@ int64_t ScanAll(int32_t batch_size, int16_t* def_levels, int16_t* rep_levels,
       batch_size, def_levels, rep_levels, vals, values_buffered);
 }
 
-inline int64_t ScanAllValues(int32_t batch_size, int16_t* def_levels, int16_t* rep_levels,
-    uint8_t* values, int64_t* values_buffered, parquet::ColumnReader* reader) {
-  switch (reader->type()) {
-    case parquet::Type::BOOLEAN:
-      return ScanAll<parquet::BoolReader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
-    case parquet::Type::INT32:
-      return ScanAll<parquet::Int32Reader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
-    case parquet::Type::INT64:
-      return ScanAll<parquet::Int64Reader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
-    case parquet::Type::INT96:
-      return ScanAll<parquet::Int96Reader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
-    case parquet::Type::FLOAT:
-      return ScanAll<parquet::FloatReader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
-    case parquet::Type::DOUBLE:
-      return ScanAll<parquet::DoubleReader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
-    case parquet::Type::BYTE_ARRAY:
-      return ScanAll<parquet::ByteArrayReader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
-    case parquet::Type::FIXED_LEN_BYTE_ARRAY:
-      return ScanAll<parquet::FixedLenByteArrayReader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
-    default:
-      parquet::ParquetException::NYI("type reader not implemented");
-  }
-  // Unreachable code, but supress compiler warning
-  return 0;
-}
+int64_t ScanAllValues(int32_t batch_size, int16_t* def_levels, int16_t* rep_levels,
+                      uint8_t* values, int64_t* values_buffered, parquet::ColumnReader* reader);
 
 #endif  // PARQUET_SCAN_ALL_H

--- a/src/parquet/column/scan-all.h
+++ b/src/parquet/column/scan-all.h
@@ -30,7 +30,7 @@ int64_t ScanAll(int32_t batch_size, int16_t* def_levels, int16_t* rep_levels,
       batch_size, def_levels, rep_levels, vals, values_buffered);
 }
 
-int64_t ScanAllValues(int32_t batch_size, int16_t* def_levels, int16_t* rep_levels,
+inline int64_t ScanAllValues(int32_t batch_size, int16_t* def_levels, int16_t* rep_levels,
     uint8_t* values, int64_t* values_buffered, parquet::ColumnReader* reader) {
   switch (reader->type()) {
     case parquet::Type::BOOLEAN:


### PR DESCRIPTION
When reader.h is included in multiple cpp files, it causes a linker error
because ScanAllValues is defined in multiple TUs

An alternative solution would be to move ScanAllValues to a separate cpp file.

Should I open a JIRA for this?