### PR TITLE
PARQUET-739: Don't use a static buffer for data accessed by multiple threads

### DIFF
--- a/src/parquet/util/rle-encoding.h
+++ b/src/parquet/util/rle-encoding.h
@@ -320,7 +320,7 @@ inline int RleDecoder::GetBatchWithDict(
           std::min(batch_size - values_read, static_cast<int>(literal_count_));
 
       const int buffer_size = 1024;
-      static int indices[buffer_size];
+      int indices[buffer_size];
       literal_batch = std::min(literal_batch, buffer_size);
       int actual_read = bit_reader_.GetBatch(bit_width_, &indices[0], literal_batch);
       DCHECK_EQ(actual_read, literal_batch);


### PR DESCRIPTION
This buffer is used in multiple threads, so it cannot be static. It's small enough to just have it on the stack. I could add a vector to the RleDecoder class as well if you prefer