### PR TITLE
PARQUET-745: TypedRowGroupStatistics fails to PlainDecode min and max in ByteArrayType

### DIFF
--- a/src/parquet/column/statistics-test.cc
+++ b/src/parquet/column/statistics-test.cc
@@ -66,7 +66,7 @@ class TestRowGroupStatistics : public PrimitiveTypedTest<TestType> {
     std::string encoded_max = statistics1.EncodeMax();
 
     TypedStats statistics2(
-        this->schema_.Column(0), encoded_min, encoded_max, this->values_.size(), 0, 0);
+        this->schema_.Column(0), encoded_min, encoded_max, this->values_.size(), 0, 0, true);
 
     ASSERT_EQ(encoded_min, statistics2.EncodeMin());
     ASSERT_EQ(encoded_max, statistics2.EncodeMax());
@@ -233,6 +233,28 @@ void TestRowGroupStatistics<ByteArrayType>::DeepFree(std::vector<ByteArray>& val
     memset(ptr, 0, ba.len);
     allocator->Free(ptr, ba.len);
   }
+}
+
+template<>
+void TestRowGroupStatistics<ByteArrayType>::TestMinMaxEncode() {
+  this->GenerateData(1000);
+  // Test that we encode min max strings correctly
+  TypedRowGroupStatistics<ByteArrayType> statistics1(this->schema_.Column(0));
+  statistics1.Update(this->values_ptr_, this->values_.size(), 0);
+  std::string encoded_min = statistics1.EncodeMin();
+  std::string encoded_max = statistics1.EncodeMax();
+
+  // encoded is same as unencoded
+  ASSERT_EQ(encoded_min, std::string((const char*)statistics1.min().ptr, statistics1.min().len));
+  ASSERT_EQ(encoded_max, std::string((const char*)statistics1.max().ptr, statistics1.max().len));
+
+  TypedRowGroupStatistics<ByteArrayType> statistics2(
+     this->schema_.Column(0), encoded_min, encoded_max, this->values_.size(), 0, 0, true);
+
+  ASSERT_EQ(encoded_min, statistics2.EncodeMin());
+  ASSERT_EQ(encoded_max, statistics2.EncodeMax());
+  ASSERT_EQ(statistics1.min(), statistics2.min());
+  ASSERT_EQ(statistics1.max(), statistics2.max());
 }
 
 using TestTypes = ::testing::Types<Int32Type, Int64Type, Int96Type, FloatType, DoubleType,

--- a/src/parquet/column/statistics-test.cc
+++ b/src/parquet/column/statistics-test.cc
@@ -66,7 +66,8 @@ class TestRowGroupStatistics : public PrimitiveTypedTest<TestType> {
     std::string encoded_max = statistics1.EncodeMax();
 
     TypedStats statistics2(
-        this->schema_.Column(0), encoded_min, encoded_max, this->values_.size(), 0, 0, true);
+        this->schema_.Column(0), encoded_min, encoded_max,
+        this->values_.size(), 0, 0, true);
 
     ASSERT_EQ(encoded_min, statistics2.EncodeMin());
     ASSERT_EQ(encoded_max, statistics2.EncodeMax());
@@ -245,8 +246,10 @@ void TestRowGroupStatistics<ByteArrayType>::TestMinMaxEncode() {
   std::string encoded_max = statistics1.EncodeMax();
 
   // encoded is same as unencoded
-  ASSERT_EQ(encoded_min, std::string((const char*)statistics1.min().ptr, statistics1.min().len));
-  ASSERT_EQ(encoded_max, std::string((const char*)statistics1.max().ptr, statistics1.max().len));
+  ASSERT_EQ(encoded_min, std::string((const char*)statistics1.min().ptr,
+      statistics1.min().len));
+  ASSERT_EQ(encoded_max, std::string((const char*)statistics1.max().ptr,
+      statistics1.max().len));
 
   TypedRowGroupStatistics<ByteArrayType> statistics2(
      this->schema_.Column(0), encoded_min, encoded_max, this->values_.size(), 0, 0, true);

--- a/src/parquet/column/statistics.cc
+++ b/src/parquet/column/statistics.cc
@@ -162,13 +162,13 @@ void TypedRowGroupStatistics<DType>::PlainDecode(const std::string& src, T* dst)
 
 template <>
 void TypedRowGroupStatistics<ByteArrayType>::PlainEncode(
-   const T& src, std::string* dst) {
+     const T& src, std::string* dst) {
   dst->assign(reinterpret_cast<const char*>(src.ptr), src.len);
 }
 
 template <>
 void TypedRowGroupStatistics<ByteArrayType>::PlainDecode(
-   const std::string& src, T* dst) {
+     const std::string& src, T* dst) {
   dst->len = src.size();
   dst->ptr = reinterpret_cast<const uint8_t*>(src.c_str());
 }

--- a/src/parquet/column/statistics.cc
+++ b/src/parquet/column/statistics.cc
@@ -64,27 +64,7 @@ TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(const ColumnDescriptor* 
 
   if (!encoded_min.empty()) { PlainDecode(encoded_min, &min_); }
   if (!encoded_max.empty()) { PlainDecode(encoded_max, &max_); }
-  has_min_max_ = !encoded_min.empty() && !encoded_max.empty();
-}
-
-template <>
-TypedRowGroupStatistics<ByteArrayType>::TypedRowGroupStatistics(
-    const ColumnDescriptor* schema,
-    const std::string& encoded_min, const std::string& encoded_max, int64_t num_values,
-    int64_t null_count, int64_t distinct_count, MemoryAllocator* allocator)
-    : allocator_(allocator), min_buffer_(0, allocator_), max_buffer_(0, allocator_) {
-  IncrementNumValues(num_values);
-  IncrementNullCount(null_count);
-  IncrementDistinctCount(distinct_count);
-
-  SetDescr(schema);
-
-  min_.len = encoded_min.size();
-  min_.ptr = reinterpret_cast<const uint8_t*>(encoded_min.c_str());
-  max_.len = encoded_max.size();
-  max_.ptr = reinterpret_cast<const uint8_t*>(encoded_max.c_str());
-
-  has_min_max_ = !encoded_min.empty() && !encoded_max.empty();
+  has_min_max_ = !encoded_min.empty() || !encoded_max.empty();
 }
 
 template <typename DType>
@@ -178,6 +158,19 @@ void TypedRowGroupStatistics<DType>::PlainDecode(const std::string& src, T* dst)
   PlainDecoder<DType> decoder(descr());
   decoder.SetData(1, reinterpret_cast<const uint8_t*>(src.c_str()), src.size());
   decoder.Decode(dst, 1);
+}
+
+template <>
+void TypedRowGroupStatistics<ByteArrayType>::PlainEncode(
+   const T& src, std::string* dst) {
+  dst->assign(reinterpret_cast<const char*>(src.ptr), src.len);
+}
+
+template <>
+void TypedRowGroupStatistics<ByteArrayType>::PlainDecode(
+   const std::string& src, T* dst) {
+  dst->len = src.size();
+  dst->ptr = reinterpret_cast<const uint8_t*>(src.c_str());
 }
 
 template class TypedRowGroupStatistics<BooleanType>;

--- a/src/parquet/column/statistics.cc
+++ b/src/parquet/column/statistics.cc
@@ -54,7 +54,7 @@ TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(const typename DType::c_
 template <typename DType>
 TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(const ColumnDescriptor* schema,
     const std::string& encoded_min, const std::string& encoded_max, int64_t num_values,
-    int64_t null_count, int64_t distinct_count, MemoryAllocator* allocator)
+    int64_t null_count, int64_t distinct_count, bool has_min_max, MemoryAllocator* allocator)
     : allocator_(allocator), min_buffer_(0, allocator_), max_buffer_(0, allocator_) {
   IncrementNumValues(num_values);
   IncrementNullCount(null_count);
@@ -64,7 +64,7 @@ TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(const ColumnDescriptor* 
 
   if (!encoded_min.empty()) { PlainDecode(encoded_min, &min_); }
   if (!encoded_max.empty()) { PlainDecode(encoded_max, &max_); }
-  has_min_max_ = !encoded_min.empty() || !encoded_max.empty();
+  has_min_max_ = has_min_max;
 }
 
 template <typename DType>

--- a/src/parquet/column/statistics.cc
+++ b/src/parquet/column/statistics.cc
@@ -68,10 +68,11 @@ TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(const ColumnDescriptor* 
 }
 
 template <>
-TypedRowGroupStatistics<ByteArrayType>::TypedRowGroupStatistics(const ColumnDescriptor* schema,
-                                                        const std::string& encoded_min, const std::string& encoded_max, int64_t num_values,
-                                                        int64_t null_count, int64_t distinct_count, MemoryAllocator* allocator)
-   : allocator_(allocator), min_buffer_(0, allocator_), max_buffer_(0, allocator_) {
+TypedRowGroupStatistics<ByteArrayType>::TypedRowGroupStatistics(
+    const ColumnDescriptor* schema,
+    const std::string& encoded_min, const std::string& encoded_max, int64_t num_values,
+    int64_t null_count, int64_t distinct_count, MemoryAllocator* allocator)
+    : allocator_(allocator), min_buffer_(0, allocator_), max_buffer_(0, allocator_) {
   IncrementNumValues(num_values);
   IncrementNullCount(null_count);
   IncrementDistinctCount(distinct_count);

--- a/src/parquet/column/statistics.cc
+++ b/src/parquet/column/statistics.cc
@@ -67,6 +67,25 @@ TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(const ColumnDescriptor* 
   has_min_max_ = !encoded_min.empty() && !encoded_max.empty();
 }
 
+template <>
+TypedRowGroupStatistics<ByteArrayType>::TypedRowGroupStatistics(const ColumnDescriptor* schema,
+                                                        const std::string& encoded_min, const std::string& encoded_max, int64_t num_values,
+                                                        int64_t null_count, int64_t distinct_count, MemoryAllocator* allocator)
+   : allocator_(allocator), min_buffer_(0, allocator_), max_buffer_(0, allocator_) {
+  IncrementNumValues(num_values);
+  IncrementNullCount(null_count);
+  IncrementDistinctCount(distinct_count);
+
+  SetDescr(schema);
+
+  min_.len = encoded_min.size();
+  min_.ptr = reinterpret_cast<const uint8_t*>(encoded_min.c_str());
+  max_.len = encoded_max.size();
+  max_.ptr = reinterpret_cast<const uint8_t*>(encoded_max.c_str());
+
+  has_min_max_ = !encoded_min.empty() && !encoded_max.empty();
+}
+
 template <typename DType>
 bool TypedRowGroupStatistics<DType>::HasMinMax() const {
   return has_min_max_;

--- a/src/parquet/column/statistics.cc
+++ b/src/parquet/column/statistics.cc
@@ -54,7 +54,8 @@ TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(const typename DType::c_
 template <typename DType>
 TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(const ColumnDescriptor* schema,
     const std::string& encoded_min, const std::string& encoded_max, int64_t num_values,
-    int64_t null_count, int64_t distinct_count, bool has_min_max, MemoryAllocator* allocator)
+    int64_t null_count, int64_t distinct_count, bool has_min_max,
+    MemoryAllocator* allocator)
     : allocator_(allocator), min_buffer_(0, allocator_), max_buffer_(0, allocator_) {
   IncrementNumValues(num_values);
   IncrementNullCount(null_count);

--- a/src/parquet/column/statistics.h
+++ b/src/parquet/column/statistics.h
@@ -197,11 +197,11 @@ inline void TypedRowGroupStatistics<ByteArrayType>::Copy(
 
 template <>
 void TypedRowGroupStatistics<ByteArrayType>::PlainEncode(
-   const T& src, std::string* dst);
+    const T& src, std::string* dst);
 
 template <>
 void TypedRowGroupStatistics<ByteArrayType>::PlainDecode(
-   const std::string& src, T* dst);
+    const std::string& src, T* dst);
 
 using BoolStatistics = TypedRowGroupStatistics<BooleanType>;
 using Int32Statistics = TypedRowGroupStatistics<Int32Type>;

--- a/src/parquet/column/statistics.h
+++ b/src/parquet/column/statistics.h
@@ -195,6 +195,14 @@ inline void TypedRowGroupStatistics<ByteArrayType>::Copy(
   *dst = ByteArray(src.len, buffer.data());
 }
 
+template <>
+void TypedRowGroupStatistics<ByteArrayType>::PlainEncode(
+   const T& src, std::string* dst);
+
+template <>
+void TypedRowGroupStatistics<ByteArrayType>::PlainDecode(
+   const std::string& src, T* dst);
+
 using BoolStatistics = TypedRowGroupStatistics<BooleanType>;
 using Int32Statistics = TypedRowGroupStatistics<Int32Type>;
 using Int64Statistics = TypedRowGroupStatistics<Int64Type>;

--- a/src/parquet/column/statistics.h
+++ b/src/parquet/column/statistics.h
@@ -142,7 +142,7 @@ class TypedRowGroupStatistics : public RowGroupStatistics {
 
   TypedRowGroupStatistics(const ColumnDescriptor* schema, const std::string& encoded_min,
       const std::string& encoded_max, int64_t num_values, int64_t null_count,
-      int64_t distinct_count, MemoryAllocator* allocator = default_allocator());
+      int64_t distinct_count, bool has_min_max, MemoryAllocator* allocator = default_allocator());
 
   bool HasMinMax() const override;
   void Reset() override;

--- a/src/parquet/column/statistics.h
+++ b/src/parquet/column/statistics.h
@@ -142,7 +142,8 @@ class TypedRowGroupStatistics : public RowGroupStatistics {
 
   TypedRowGroupStatistics(const ColumnDescriptor* schema, const std::string& encoded_min,
       const std::string& encoded_max, int64_t num_values, int64_t null_count,
-      int64_t distinct_count, bool has_min_max, MemoryAllocator* allocator = default_allocator());
+      int64_t distinct_count, bool has_min_max,
+      MemoryAllocator* allocator = default_allocator());
 
   bool HasMinMax() const override;
   void Reset() override;

--- a/src/parquet/file/metadata.cc
+++ b/src/parquet/file/metadata.cc
@@ -29,7 +29,8 @@ static std::shared_ptr<RowGroupStatistics> MakeTypedColumnStats(
     const format::ColumnMetaData& metadata, const ColumnDescriptor* descr) {
   return std::make_shared<TypedRowGroupStatistics<DType>>(descr, metadata.statistics.min,
       metadata.statistics.max, metadata.num_values - metadata.statistics.null_count,
-      metadata.statistics.null_count, metadata.statistics.distinct_count);
+      metadata.statistics.null_count, metadata.statistics.distinct_count,
+      metadata.statistics.__isset.max || metadata.statistics.__isset.min);
 }
 
 std::shared_ptr<RowGroupStatistics> MakeColumnStats(

--- a/src/parquet/file/reader-internal.cc
+++ b/src/parquet/file/reader-internal.cc
@@ -175,14 +175,6 @@ std::unique_ptr<PageReader> SerializedRowGroup::GetColumnPageReader(int i) {
       std::move(stream), col->compression(), properties_.allocator()));
 }
 
-template <typename DType>
-static std::shared_ptr<RowGroupStatistics> MakeColumnStats(
-    const format::ColumnMetaData& metadata, const ColumnDescriptor* descr) {
-  return std::make_shared<TypedRowGroupStatistics<DType>>(descr, metadata.statistics.min,
-      metadata.statistics.max, metadata.num_values, metadata.statistics.null_count,
-      metadata.statistics.distinct_count);
-}
-
 // ----------------------------------------------------------------------
 // SerializedFile: Parquet on-disk layout
 


### PR DESCRIPTION
I'm not sure how this code is supposed to work, this seems to solve the issue.

The code was added in 176b08c305919551ecfd5fc2f741f7bff4deefdd by @lomereiter I think.
