### PR TITLE
PARQUET-775: Make TrackingAllocator thread-safe

### DIFF
--- a/src/parquet/util/mem-allocator.h
+++ b/src/parquet/util/mem-allocator.h
@@ -19,6 +19,7 @@
 #define PARQUET_UTIL_MEMORY_POOL_H
 
 #include <cstdint>
+#include <mutex>
 
 #include "parquet/util/visibility.h"
 
@@ -48,6 +49,7 @@ class PARQUET_EXPORT TrackingAllocator : public MemoryAllocator {
   int64_t MaxMemory() { return max_memory_; }
 
  private:
+  std::mutex stats_mutex_;
   int64_t total_memory_;
   int64_t max_memory_;
 };


### PR DESCRIPTION
Mutex is only locked around the statistics as the other parts are
thread-safe and should run in parallel if needed/possible.