### PR TITLE
PARQUET-778:  Standardize the schema output to match the parquet-mr format

### DIFF
--- a/src/parquet/schema/printer.cc
+++ b/src/parquet/schema/printer.cc
@@ -83,7 +83,7 @@ static void PrintType(const PrimitiveNode* node, std::ostream& stream) {
       stream << "double";
       break;
     case Type::BYTE_ARRAY:
-      stream << "byte_array";
+      stream << "binary";
       break;
     case Type::FIXED_LEN_BYTE_ARRAY:
       stream << "fixed_len_byte_array(" << node->type_length() << ")";
@@ -93,16 +93,104 @@ static void PrintType(const PrimitiveNode* node, std::ostream& stream) {
   }
 }
 
+static void PrintLogicalType(LogicalType::type lt, std::ostream& stream) {
+  switch (lt) {
+    case LogicalType::UTF8:
+      stream << " (UTF8)";
+      break;
+    case LogicalType::MAP:
+      stream << " (MAP)";
+      break;
+    case LogicalType::MAP_KEY_VALUE:
+      stream << " (MAP_KEY_VALUE)";
+      break;
+    case LogicalType::LIST:
+      stream << " (LIST)";
+      break;
+    case LogicalType::ENUM:
+      stream << " (ENUM)";
+      break;
+    case LogicalType::DATE:
+      stream << " (DATE)";
+      break;
+    case LogicalType::TIME_MILLIS:
+      stream << " (TIME_MILLIS)";
+      break;
+    case LogicalType::TIME_MICROS:
+      stream << " (TIME_MICROS)";
+      break;
+    case LogicalType::TIMESTAMP_MILLIS:
+      stream << " (TIMESTAMP_MILLIS)";
+      break;
+    case LogicalType::TIMESTAMP_MICROS:
+      stream << " (TIMESTAMP_MICROS)";
+      break;
+    case LogicalType::UINT_8:
+      stream << " (UINT_8)";
+      break;
+    case LogicalType::UINT_16:
+      stream << " (UINT_16)";
+      break;
+    case LogicalType::UINT_32:
+      stream << " (UINT_32)";
+      break;
+    case LogicalType::UINT_64:
+      stream << " (UINT_64)";
+      break;
+    case LogicalType::INT_8:
+      stream << " (INT_8)";
+      break;
+    case LogicalType::INT_16:
+      stream << " (INT_16)";
+      break;
+    case LogicalType::INT_32:
+      stream << " (INT_32)";
+      break;
+    case LogicalType::INT_64:
+      stream << " (INT_64)";
+      break;
+    case LogicalType::JSON:
+      stream << " (JSON)";
+      break;
+    case LogicalType::BSON:
+      stream << " (BSON)";
+      break;
+    case LogicalType::INTERVAL:
+      stream << " (INTERVAL)";
+      break;
+  default:
+      break;
+  }
+}
+
+static void PrintLogicalType(const PrimitiveNode* node, std::ostream& stream) {
+  auto lt = node->logical_type();
+  if (lt == LogicalType::DECIMAL) {
+    stream << " (DECIMAL(" <<  node->decimal_metadata().precision << "," <<
+      node->decimal_metadata().scale << "))";
+  } else {
+    PrintLogicalType(lt, stream);
+  }
+}
+
 void SchemaPrinter::Visit(const PrimitiveNode* node) {
   PrintRepLevel(node->repetition(), stream_);
   stream_ << " ";
   PrintType(node, stream_);
-  stream_ << " " << node->name() << std::endl;
+  stream_ << " " << node->name();
+  PrintLogicalType(node, stream_);
+  stream_ << ";" << std::endl;
 }
 
 void SchemaPrinter::Visit(const GroupNode* node) {
-  PrintRepLevel(node->repetition(), stream_);
-  stream_ << " group " << node->name() << " {" << std::endl;
+  if (!node->parent()) {
+    stream_ << "message " << node->name() << " {" << std::endl;
+  } else {
+    PrintRepLevel(node->repetition(), stream_);
+    stream_ << " group " << node->name();
+    PrintLogicalType(node->logical_type(), stream_);
+    stream_  << " {" << std::endl;
+  }
 
   indent_ += indent_width_;
   for (int i = 0; i < node->field_count(); ++i) {

--- a/src/parquet/schema/printer.cc
+++ b/src/parquet/schema/printer.cc
@@ -93,83 +93,14 @@ static void PrintType(const PrimitiveNode* node, std::ostream& stream) {
   }
 }
 
-static void PrintLogicalType(LogicalType::type lt, std::ostream& stream) {
-  switch (lt) {
-    case LogicalType::UTF8:
-      stream << " (UTF8)";
-      break;
-    case LogicalType::MAP:
-      stream << " (MAP)";
-      break;
-    case LogicalType::MAP_KEY_VALUE:
-      stream << " (MAP_KEY_VALUE)";
-      break;
-    case LogicalType::LIST:
-      stream << " (LIST)";
-      break;
-    case LogicalType::ENUM:
-      stream << " (ENUM)";
-      break;
-    case LogicalType::DATE:
-      stream << " (DATE)";
-      break;
-    case LogicalType::TIME_MILLIS:
-      stream << " (TIME_MILLIS)";
-      break;
-    case LogicalType::TIME_MICROS:
-      stream << " (TIME_MICROS)";
-      break;
-    case LogicalType::TIMESTAMP_MILLIS:
-      stream << " (TIMESTAMP_MILLIS)";
-      break;
-    case LogicalType::TIMESTAMP_MICROS:
-      stream << " (TIMESTAMP_MICROS)";
-      break;
-    case LogicalType::UINT_8:
-      stream << " (UINT_8)";
-      break;
-    case LogicalType::UINT_16:
-      stream << " (UINT_16)";
-      break;
-    case LogicalType::UINT_32:
-      stream << " (UINT_32)";
-      break;
-    case LogicalType::UINT_64:
-      stream << " (UINT_64)";
-      break;
-    case LogicalType::INT_8:
-      stream << " (INT_8)";
-      break;
-    case LogicalType::INT_16:
-      stream << " (INT_16)";
-      break;
-    case LogicalType::INT_32:
-      stream << " (INT_32)";
-      break;
-    case LogicalType::INT_64:
-      stream << " (INT_64)";
-      break;
-    case LogicalType::JSON:
-      stream << " (JSON)";
-      break;
-    case LogicalType::BSON:
-      stream << " (BSON)";
-      break;
-    case LogicalType::INTERVAL:
-      stream << " (INTERVAL)";
-      break;
-  default:
-      break;
-  }
-}
-
 static void PrintLogicalType(const PrimitiveNode* node, std::ostream& stream) {
   auto lt = node->logical_type();
   if (lt == LogicalType::DECIMAL) {
-    stream << " (DECIMAL(" <<  node->decimal_metadata().precision << "," <<
+    stream << " (" <<  LogicalTypeToString(lt) << "(" <<
+      node->decimal_metadata().precision << "," <<
       node->decimal_metadata().scale << "))";
-  } else {
-    PrintLogicalType(lt, stream);
+  } else if (lt != LogicalType::NONE) {
+    stream << " (" << LogicalTypeToString(lt) << ")";
   }
 }
 
@@ -188,7 +119,10 @@ void SchemaPrinter::Visit(const GroupNode* node) {
   } else {
     PrintRepLevel(node->repetition(), stream_);
     stream_ << " group " << node->name();
-    PrintLogicalType(node->logical_type(), stream_);
+    auto lt = node->logical_type();
+    if (lt != LogicalType::NONE) {
+      stream_ << " (" << LogicalTypeToString(lt) << ")";
+    }
     stream_  << " {" << std::endl;
   }
 

--- a/src/parquet/schema/schema-printer-test.cc
+++ b/src/parquet/schema/schema-printer-test.cc
@@ -51,6 +51,9 @@ TEST(TestSchemaPrinter, Examples) {
   NodePtr bag(GroupNode::Make("bag", Repetition::OPTIONAL, {list}));
   fields.push_back(bag);
 
+  fields.push_back(PrimitiveNode::Make("c", Repetition::REQUIRED, Type::INT32,
+                                       LogicalType::DECIMAL, -1, 3, 2));
+
   NodePtr schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
 
   std::string result = Print(schema);
@@ -62,6 +65,7 @@ TEST(TestSchemaPrinter, Examples) {
       required boolean item2;
     }
   }
+  required int32 c (DECIMAL(3,2));
 }
 )";
   ASSERT_EQ(expected, result);

--- a/src/parquet/schema/schema-printer-test.cc
+++ b/src/parquet/schema/schema-printer-test.cc
@@ -54,12 +54,12 @@ TEST(TestSchemaPrinter, Examples) {
   NodePtr schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
 
   std::string result = Print(schema);
-  std::string expected = R"(repeated group schema {
-  required int32 a
+  std::string expected = R"(message schema {
+  required int32 a;
   optional group bag {
-    repeated group b {
-      optional int64 item1
-      required boolean item2
+    repeated group b (LIST) {
+      optional int64 item1;
+      required boolean item2;
     }
   }
 }


### PR DESCRIPTION
- root node name is preceded by 'message'
- byte_array type is named 'binary'
- column entries end with a semicolon
- add logical type output