### PR TITLE
PARQUET-789: Catch/translate ParquetExceptions in parquet::arrow::FileReader

### DIFF
--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -201,11 +201,19 @@ Status FileReader::GetFlatColumn(int i, std::unique_ptr<FlatColumnReader>* out) 
 }
 
 Status FileReader::ReadFlatColumn(int i, std::shared_ptr<Array>* out) {
-  return impl_->ReadFlatColumn(i, out);
+  try {
+    return impl_->ReadFlatColumn(i, out);
+  } catch (const ::parquet::ParquetException& e) {
+    return ::arrow::Status::IOError(e.what());
+  }
 }
 
 Status FileReader::ReadFlatTable(std::shared_ptr<Table>* out) {
-  return impl_->ReadFlatTable(out);
+  try {
+    return impl_->ReadFlatTable(out);
+  } catch (const ::parquet::ParquetException& e) {
+    return ::arrow::Status::IOError(e.what());
+  }
 }
 
 const ParquetFileReader* FileReader::parquet_reader() const {

--- a/src/parquet/arrow/utils.h
+++ b/src/parquet/arrow/utils.h
@@ -26,11 +26,11 @@
 namespace parquet {
 namespace arrow {
 
-#define PARQUET_CATCH_NOT_OK(s)                    \
-  try {                                            \
-    (s);                                           \
-  } catch (const ::parquet::ParquetException& e) { \
-    return ::arrow::Status::Invalid(e.what());     \
+#define PARQUET_CATCH_NOT_OK(s)                     \
+  try {                                             \
+    (s);                                            \
+  } catch (const ::parquet::ParquetException& e) {  \
+    return ::arrow::Status::IOError(e.what());      \
   }
 
 #define PARQUET_IGNORE_NOT_OK(s) \


### PR DESCRIPTION
I ran into this issue when debugging ARROW-406. I also changed the translated status type to `IOError` if that makes sense. 