### PR TITLE
PARQUET-797: Updates for ARROW-418 header API changes

### DIFF
--- a/src/parquet/arrow/arrow-io-test.cc
+++ b/src/parquet/arrow/arrow-io-test.cc
@@ -22,10 +22,9 @@
 
 #include "gtest/gtest.h"
 
+#include "arrow/api.h"
 #include "arrow/io/memory.h"
 #include "arrow/test-util.h"
-#include "arrow/util/memory-pool.h"
-#include "arrow/util/status.h"
 
 #include "parquet/api/io.h"
 #include "parquet/arrow/io.h"

--- a/src/parquet/arrow/arrow-reader-writer-benchmark.cc
+++ b/src/parquet/arrow/arrow-reader-writer-benchmark.cc
@@ -25,10 +25,7 @@
 #include "parquet/file/writer-internal.h"
 #include "parquet/util/input.h"
 
-#include "arrow/column.h"
-#include "arrow/schema.h"
-#include "arrow/table.h"
-#include "arrow/types/primitive.h"
+#include "arrow/api.h"
 
 using arrow::NumericBuilder;
 

--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -24,13 +24,9 @@
 #include "parquet/arrow/test-util.h"
 #include "parquet/arrow/writer.h"
 
+#include "arrow/api.h"
 #include "arrow/io/memory.h"
 #include "arrow/test-util.h"
-#include "arrow/types/construct.h"
-#include "arrow/types/primitive.h"
-#include "arrow/types/string.h"
-#include "arrow/util/memory-pool.h"
-#include "arrow/util/status.h"
 
 using arrow::Array;
 using arrow::ChunkedArray;

--- a/src/parquet/arrow/arrow-schema-test.cc
+++ b/src/parquet/arrow/arrow-schema-test.cc
@@ -22,11 +22,8 @@
 
 #include "parquet/arrow/schema.h"
 
+#include "arrow/api.h"
 #include "arrow/test-util.h"
-#include "arrow/type.h"
-#include "arrow/types/datetime.h"
-#include "arrow/types/decimal.h"
-#include "arrow/util/status.h"
 
 using arrow::Field;
 

--- a/src/parquet/arrow/io.cc
+++ b/src/parquet/arrow/io.cc
@@ -23,7 +23,7 @@
 #include "parquet/api/io.h"
 #include "parquet/arrow/utils.h"
 
-#include "arrow/util/status.h"
+#include "arrow/status.h"
 
 using arrow::Status;
 using arrow::MemoryPool;

--- a/src/parquet/arrow/io.h
+++ b/src/parquet/arrow/io.h
@@ -26,7 +26,7 @@
 #include "parquet/api/io.h"
 
 #include "arrow/io/interfaces.h"
-#include "arrow/util/memory-pool.h"
+#include "arrow/memory_pool.h"
 
 namespace parquet {
 

--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -26,13 +26,8 @@
 #include "parquet/arrow/schema.h"
 #include "parquet/arrow/utils.h"
 
-#include "arrow/column.h"
-#include "arrow/schema.h"
-#include "arrow/table.h"
-#include "arrow/types/primitive.h"
-#include "arrow/types/string.h"
+#include "arrow/api.h"
 #include "arrow/util/bit-util.h"
-#include "arrow/util/status.h"
 
 using arrow::Array;
 using arrow::Column;

--- a/src/parquet/arrow/schema.cc
+++ b/src/parquet/arrow/schema.cc
@@ -23,9 +23,7 @@
 #include "parquet/api/schema.h"
 #include "parquet/arrow/utils.h"
 
-#include "arrow/types/decimal.h"
-#include "arrow/types/string.h"
-#include "arrow/util/status.h"
+#include "arrow/api.h"
 
 using arrow::Field;
 using arrow::Status;

--- a/src/parquet/arrow/test-util.h
+++ b/src/parquet/arrow/test-util.h
@@ -18,9 +18,8 @@
 #include <string>
 #include <vector>
 
+#include "arrow/api.h"
 #include "arrow/test-util.h"
-#include "arrow/types/primitive.h"
-#include "arrow/types/string.h"
 
 namespace parquet {
 namespace arrow {

--- a/src/parquet/arrow/utils.h
+++ b/src/parquet/arrow/utils.h
@@ -20,7 +20,7 @@
 
 #include <sstream>
 
-#include "arrow/util/status.h"
+#include "arrow/status.h"
 #include "parquet/exception.h"
 
 namespace parquet {

--- a/src/parquet/arrow/writer.cc
+++ b/src/parquet/arrow/writer.cc
@@ -20,17 +20,13 @@
 #include <algorithm>
 #include <vector>
 
+#include "parquet/util/logging.h"
+
 #include "parquet/arrow/io.h"
 #include "parquet/arrow/schema.h"
 #include "parquet/arrow/utils.h"
 
-#include "arrow/array.h"
-#include "arrow/column.h"
-#include "arrow/table.h"
-#include "arrow/types/construct.h"
-#include "arrow/types/primitive.h"
-#include "arrow/types/string.h"
-#include "arrow/util/status.h"
+#include "arrow/api.h"
 
 using arrow::MemoryPool;
 using arrow::PoolBuffer;

--- a/thirdparty/versions.sh
+++ b/thirdparty/versions.sh
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ARROW_VERSION="86f56a6073c3254487ede3aff1dc9d117d24adaf"
+ARROW_VERSION="2c10d7ccec3c07fb061e1988be16aecaf9916af4"
 ARROW_URL="https://github.com/apache/arrow/archive/${ARROW_VERSION}.tar.gz"
 ARROW_BASEDIR="arrow-${ARROW_VERSION}"
 


### PR DESCRIPTION
I also changed this code to use `arrow/api.h` in some places to be less sensitive to some kinds of header changes. 