### PR TITLE
PARQUET-799: Fix bug in MemoryMapSource::CloseFile

### DIFF
--- a/src/parquet/file/reader.h
+++ b/src/parquet/file/reader.h
@@ -79,7 +79,8 @@ class PARQUET_EXPORT ParquetFileReader {
   ParquetFileReader();
   ~ParquetFileReader();
 
-  // API Convenience to open a serialized Parquet file on disk
+  // API Convenience to open a serialized Parquet file on disk, using SAMPLE
+  // implementations of RandomAccessSource
   static std::unique_ptr<ParquetFileReader> OpenFile(const std::string& path,
       bool memory_map = true, ReaderProperties props = default_reader_properties());
 

--- a/src/parquet/file/reader.h
+++ b/src/parquet/file/reader.h
@@ -79,8 +79,9 @@ class PARQUET_EXPORT ParquetFileReader {
   ParquetFileReader();
   ~ParquetFileReader();
 
-  // API Convenience to open a serialized Parquet file on disk, using SAMPLE
-  // implementations of RandomAccessSource
+  // API Convenience to open a serialized Parquet file on disk, using built-in IO
+  // interface implementations that were created for testing, and may not be robust for
+  // all use cases.
   static std::unique_ptr<ParquetFileReader> OpenFile(const std::string& path,
       bool memory_map = true, ReaderProperties props = default_reader_properties());
 

--- a/src/parquet/util/input.cc
+++ b/src/parquet/util/input.cc
@@ -134,7 +134,10 @@ void MemoryMapSource::Close() {
 }
 
 void MemoryMapSource::CloseFile() {
-  if (data_ != nullptr) { munmap(data_, size_); }
+  if (data_ != nullptr) {
+    munmap(data_, size_);
+    data_ = nullptr;
+  }
 
   LocalFileSource::CloseFile();
 }

--- a/src/parquet/util/input.h
+++ b/src/parquet/util/input.h
@@ -56,7 +56,8 @@ class PARQUET_EXPORT RandomAccessSource {
 };
 
 // ----------------------------------------------------------------------
-// SAMPLE implementations of RandomAccessSource, for reading files from local disk
+// Implementations of RandomAccessSource used for testing and internal CLI tools.
+// May not be sufficiently robust for general production use.
 
 class PARQUET_EXPORT LocalFileSource : public RandomAccessSource {
  public:

--- a/src/parquet/util/input.h
+++ b/src/parquet/util/input.h
@@ -55,6 +55,9 @@ class PARQUET_EXPORT RandomAccessSource {
   int64_t size_;
 };
 
+// ----------------------------------------------------------------------
+// SAMPLE implementations of RandomAccessSource, for reading files from local disk
+
 class PARQUET_EXPORT LocalFileSource : public RandomAccessSource {
  public:
   explicit LocalFileSource(MemoryAllocator* allocator = default_allocator())


### PR DESCRIPTION
The key change here is to ensure that munmap is called at most once for
a given memory-mapped file.

Previously, MemoryMapSource::CloseFile was calling munmap on every
invocation (provided that a file had ever been successfully mapped into
memory for that instance). This is problematic in a multi-threaded
environment, even if each MemoryMapSource instance is being used in only
one thread, as illustrated by the following hypothetical sequence of
operations:

thread 1 @ time 1: munmap(0xf000, 4096)
thread 2 @ time 2: void *addr = mmap(NULL, 4096, ...) // addr <- 0xf000
thread 1 @ time 3: munmap(0xf000, 4096)

After time 3, the mapping for the memory segment beginning at 0xf000 has
been invalidated, so the next attempt by thread 2 to access memory
within that segment will likely cause a segfault (unless yet another
thread has mmap'd that segment in the meantime, in which case the
results could be even more interesting, but certainly no better).

Also, I'm adding/modifying a couple comments in header files to mark
"sample" implementations accordingly. This is intended to give API
consumers a heads up as to the intent and level of maturity of those
sections of the codebase.