### PR TITLE
PARQUET-811: Use Brotli static libraries if they are available

### DIFF
--- a/cmake_modules/FindBrotli.cmake
+++ b/cmake_modules/FindBrotli.cmake
@@ -43,13 +43,13 @@ if ( _brotli_roots )
     find_path( BROTLI_INCLUDE_DIR NAMES brotli/decode.h
         PATHS ${_brotli_roots} NO_DEFAULT_PATH
         PATH_SUFFIXES "include" )
-    find_library( BROTLI_LIBRARY_ENC NAMES brotlienc
+    find_library( BROTLI_LIBRARY_ENC NAMES libbrotlienc.a brotlienc
         PATHS ${_brotli_roots} NO_DEFAULT_PATH
         PATH_SUFFIXES "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib" )
-    find_library( BROTLI_LIBRARY_DEC NAMES brotlidec
+    find_library( BROTLI_LIBRARY_DEC NAMES libbrotlidec.a brotlidec
         PATHS ${_brotli_roots} NO_DEFAULT_PATH
         PATH_SUFFIXES "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib" )
-    find_library( BROTLI_LIBRARY_COMMON NAMES brotlicommon
+    find_library( BROTLI_LIBRARY_COMMON NAMES libbrotlicommon.a brotlicommon
         PATHS ${_brotli_roots} NO_DEFAULT_PATH
         PATH_SUFFIXES "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib" )
 else ()

--- a/thirdparty/build_thirdparty.sh
+++ b/thirdparty/build_thirdparty.sh
@@ -148,7 +148,13 @@ fi
 # build brotli
 if [ -n "$F_ALL" -o -n "$F_BROTLI" ]; then
     cd $TP_DIR/$BROTLI_BASEDIR
-    cmake -DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_SHARED_LIBS=OFF .
+    cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
+          -DCMAKE_INSTALL_LIBDIR="lib" \
+          -DBUILD_SHARED_LIBS=OFF .
+    make -j$PARALLEL install
+    cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
+          -DCMAKE_INSTALL_LIBDIR="lib" \
+          -DBUILD_SHARED_LIBS=on .
     make -j$PARALLEL install
     # :
 fi


### PR DESCRIPTION
If a user has both shared and static libraries in their `$BROTLI_HOME`, the shared libraries were being chosen. 