### PR TITLE
PARQUET-807: Allow user to retain ownership of parquet::FileMetaData. 

### DIFF
--- a/examples/reader-writer.cc
+++ b/examples/reader-writer.cc
@@ -226,7 +226,7 @@ int main(int argc, char** argv) {
     std::unique_ptr<parquet::ParquetFileReader> parquet_reader =
         parquet::ParquetFileReader::OpenFile(PARQUET_FILENAME, false);
     // Get the File MetaData
-    const parquet::FileMetaData* file_metadata = parquet_reader->metadata();
+    std::shared_ptr<parquet::FileMetaData> file_metadata = parquet_reader->metadata();
 
     // Get the number of RowGroups
     int num_row_groups = file_metadata->num_row_groups();

--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -360,6 +360,7 @@ TYPED_TEST(TestParquetIO, SingleColumnTableRequiredChunkedWriteArrowIO) {
     ASSERT_OK_NO_THROW(WriteFlatTable(table.get(), default_memory_pool(), arrow_sink_,
         512, default_writer_properties()));
 
+    // XXX: Remove this after ARROW-455 completed
     ASSERT_OK(arrow_sink_->Close());
   }
 

--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -353,9 +353,15 @@ TYPED_TEST(TestParquetIO, SingleColumnTableRequiredChunkedWriteArrowIO) {
   std::shared_ptr<Table> table = MakeSimpleTable(values, false);
   this->sink_ = std::make_shared<InMemoryOutputStream>();
   auto buffer = std::make_shared<::arrow::PoolBuffer>();
-  auto arrow_sink_ = std::make_shared<::arrow::io::BufferOutputStream>(buffer);
-  ASSERT_OK_NO_THROW(WriteFlatTable(
-      table.get(), default_memory_pool(), arrow_sink_, 512, default_writer_properties()));
+
+  {
+    // BufferOutputStream closed on gc
+    auto arrow_sink_ = std::make_shared<::arrow::io::BufferOutputStream>(buffer);
+    ASSERT_OK_NO_THROW(WriteFlatTable(table.get(), default_memory_pool(), arrow_sink_,
+        512, default_writer_properties()));
+
+    ASSERT_OK(arrow_sink_->Close());
+  }
 
   auto pbuffer = std::make_shared<Buffer>(buffer->data(), buffer->size());
 

--- a/src/parquet/arrow/schema.cc
+++ b/src/parquet/arrow/schema.cc
@@ -364,12 +364,6 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
       type = ParquetType::INT64;
       logical_type = LogicalType::TIMESTAMP_MILLIS;
     } break;
-    case ArrowType::TIMESTAMP_DOUBLE:
-      type = ParquetType::INT64;
-      // This is specified as seconds since the UNIX epoch
-      // TODO: Converted type in Parquet?
-      // logical_type = LogicalType::TIMESTAMP_MILLIS;
-      break;
     case ArrowType::TIME:
       type = ParquetType::INT64;
       logical_type = LogicalType::TIME_MILLIS;

--- a/src/parquet/file/metadata.cc
+++ b/src/parquet/file/metadata.cc
@@ -325,6 +325,7 @@ class FileMetaData::FileMetaDataImpl {
 
 std::shared_ptr<FileMetaData> FileMetaData::Make(
     const uint8_t* metadata, uint32_t* metadata_len) {
+  // This FileMetaData ctor is private, not compatible with std::make_shared
   return std::shared_ptr<FileMetaData>(new FileMetaData(metadata, metadata_len));
 }
 

--- a/src/parquet/file/metadata.cc
+++ b/src/parquet/file/metadata.cc
@@ -323,9 +323,9 @@ class FileMetaData::FileMetaDataImpl {
   FileMetaData::Version writer_version_;
 };
 
-std::unique_ptr<FileMetaData> FileMetaData::Make(
+std::shared_ptr<FileMetaData> FileMetaData::Make(
     const uint8_t* metadata, uint32_t* metadata_len) {
-  return std::unique_ptr<FileMetaData>(new FileMetaData(metadata, metadata_len));
+  return std::shared_ptr<FileMetaData>(new FileMetaData(metadata, metadata_len));
 }
 
 FileMetaData::FileMetaData(const uint8_t* metadata, uint32_t* metadata_len)

--- a/src/parquet/file/metadata.h
+++ b/src/parquet/file/metadata.h
@@ -120,7 +120,7 @@ class PARQUET_EXPORT FileMetaData {
   };
 
   // API convenience to get a MetaData accessor
-  static std::unique_ptr<FileMetaData> Make(
+  static std::shared_ptr<FileMetaData> Make(
       const uint8_t* serialized_metadata, uint32_t* metadata_len);
 
   ~FileMetaData();

--- a/src/parquet/file/reader-internal.cc
+++ b/src/parquet/file/reader-internal.cc
@@ -233,8 +233,8 @@ std::shared_ptr<RowGroupReader> SerializedFile::GetRowGroup(int i) {
   return std::make_shared<RowGroupReader>(std::move(contents));
 }
 
-const FileMetaData* SerializedFile::metadata() const {
-  return file_metadata_.get();
+std::shared_ptr<FileMetaData> SerializedFile::metadata() const {
+  return file_metadata_;
 }
 
 SerializedFile::SerializedFile(std::unique_ptr<RandomAccessSource> source,

--- a/src/parquet/file/reader-internal.cc
+++ b/src/parquet/file/reader-internal.cc
@@ -206,15 +206,20 @@ static constexpr uint32_t FOOTER_SIZE = 8;
 static constexpr uint8_t PARQUET_MAGIC[4] = {'P', 'A', 'R', '1'};
 
 std::unique_ptr<ParquetFileReader::Contents> SerializedFile::Open(
-    std::unique_ptr<RandomAccessSource> source, const ReaderProperties& props) {
+    std::unique_ptr<RandomAccessSource> source, const ReaderProperties& props,
+    const std::shared_ptr<FileMetaData>& metadata) {
   std::unique_ptr<ParquetFileReader::Contents> result(
       new SerializedFile(std::move(source), props));
 
   // Access private methods here, but otherwise unavailable
   SerializedFile* file = static_cast<SerializedFile*>(result.get());
 
-  // Validates magic bytes, parses metadata, and initializes the SchemaDescriptor
-  file->ParseMetaData();
+  if (metadata == nullptr) {
+    // Validates magic bytes, parses metadata, and initializes the SchemaDescriptor
+    file->ParseMetaData();
+  } else {
+    file->file_metadata_ = metadata;
+  }
 
   return result;
 }

--- a/src/parquet/file/reader-internal.h
+++ b/src/parquet/file/reader-internal.h
@@ -105,9 +105,9 @@ class SerializedFile : public ParquetFileReader::Contents {
   static std::unique_ptr<ParquetFileReader::Contents> Open(
       std::unique_ptr<RandomAccessSource> source,
       const ReaderProperties& props = default_reader_properties());
-  virtual void Close();
-  virtual std::shared_ptr<RowGroupReader> GetRowGroup(int i);
-  virtual const FileMetaData* metadata() const;
+  void Close() override;
+  std::shared_ptr<RowGroupReader> GetRowGroup(int i) override;
+  std::shared_ptr<FileMetaData> metadata() const override;
   virtual ~SerializedFile();
 
  private:
@@ -116,7 +116,7 @@ class SerializedFile : public ParquetFileReader::Contents {
       std::unique_ptr<RandomAccessSource> source, const ReaderProperties& props);
 
   std::unique_ptr<RandomAccessSource> source_;
-  std::unique_ptr<FileMetaData> file_metadata_;
+  std::shared_ptr<FileMetaData> file_metadata_;
   ReaderProperties properties_;
 
   void ParseMetaData();

--- a/src/parquet/file/reader-internal.h
+++ b/src/parquet/file/reader-internal.h
@@ -99,12 +99,15 @@ class SerializedRowGroup : public RowGroupReader::Contents {
 class SerializedFile : public ParquetFileReader::Contents {
  public:
   // Open the valid and validate the header, footer, and parse the Thrift metadata
-  //
-  // This class does _not_ take ownership of the data source. You must manage its
-  // lifetime separately
   static std::unique_ptr<ParquetFileReader::Contents> Open(
       std::unique_ptr<RandomAccessSource> source,
       const ReaderProperties& props = default_reader_properties());
+
+  // Open the file given externally-provided metadata
+  static std::unique_ptr<ParquetFileReader::Contents> Open(
+      std::unique_ptr<RandomAccessSource> source,
+      const ReaderProperties& props = default_reader_properties());
+
   void Close() override;
   std::shared_ptr<RowGroupReader> GetRowGroup(int i) override;
   std::shared_ptr<FileMetaData> metadata() const override;

--- a/src/parquet/file/reader-internal.h
+++ b/src/parquet/file/reader-internal.h
@@ -98,15 +98,12 @@ class SerializedRowGroup : public RowGroupReader::Contents {
 
 class SerializedFile : public ParquetFileReader::Contents {
  public:
-  // Open the valid and validate the header, footer, and parse the Thrift metadata
+  // Open the file. If no metadata is passed, it is parsed from the footer of
+  // the file
   static std::unique_ptr<ParquetFileReader::Contents> Open(
       std::unique_ptr<RandomAccessSource> source,
-      const ReaderProperties& props = default_reader_properties());
-
-  // Open the file given externally-provided metadata
-  static std::unique_ptr<ParquetFileReader::Contents> Open(
-      std::unique_ptr<RandomAccessSource> source,
-      const ReaderProperties& props = default_reader_properties());
+      const ReaderProperties& props = default_reader_properties(),
+      const std::shared_ptr<FileMetaData>& metadata = nullptr);
 
   void Close() override;
   std::shared_ptr<RowGroupReader> GetRowGroup(int i) override;

--- a/src/parquet/file/reader.cc
+++ b/src/parquet/file/reader.cc
@@ -72,21 +72,23 @@ ParquetFileReader::~ParquetFileReader() {
 
 std::unique_ptr<ParquetFileReader> ParquetFileReader::Open(
     const std::shared_ptr<::arrow::io::ReadableFileInterface>& source,
-    const ReaderProperties& props) {
+    const ReaderProperties& props, const std::shared_ptr<FileMetaData>& metadata) {
   std::unique_ptr<RandomAccessSource> io_wrapper(new ArrowInputFile(source));
-  return Open(std::move(io_wrapper), props);
+  return Open(std::move(io_wrapper), props, metadata);
 }
 
 std::unique_ptr<ParquetFileReader> ParquetFileReader::Open(
-    std::unique_ptr<RandomAccessSource> source, const ReaderProperties& props) {
-  auto contents = SerializedFile::Open(std::move(source), props);
+    std::unique_ptr<RandomAccessSource> source, const ReaderProperties& props,
+    const std::shared_ptr<FileMetaData>& metadata) {
+  auto contents = SerializedFile::Open(std::move(source), props, metadata);
   std::unique_ptr<ParquetFileReader> result(new ParquetFileReader());
   result->Open(std::move(contents));
   return result;
 }
 
-std::unique_ptr<ParquetFileReader> ParquetFileReader::OpenFile(
-    const std::string& path, bool memory_map, const ReaderProperties& props) {
+std::unique_ptr<ParquetFileReader> ParquetFileReader::OpenFile(const std::string& path,
+    bool memory_map, const ReaderProperties& props,
+    const std::shared_ptr<FileMetaData>& metadata) {
   std::shared_ptr<::arrow::io::ReadableFileInterface> source;
   if (memory_map) {
     std::shared_ptr<::arrow::io::ReadableFile> handle;
@@ -100,7 +102,7 @@ std::unique_ptr<ParquetFileReader> ParquetFileReader::OpenFile(
     source = handle;
   }
 
-  return Open(source, props);
+  return Open(source, props, metadata);
 }
 
 void ParquetFileReader::Open(std::unique_ptr<ParquetFileReader::Contents> contents) {

--- a/src/parquet/file/reader.cc
+++ b/src/parquet/file/reader.cc
@@ -111,7 +111,7 @@ void ParquetFileReader::Close() {
   if (contents_) { contents_->Close(); }
 }
 
-const FileMetaData* ParquetFileReader::metadata() const {
+std::shared_ptr<FileMetaData> ParquetFileReader::metadata() const {
   return contents_->metadata();
 }
 
@@ -130,7 +130,7 @@ std::shared_ptr<RowGroupReader> ParquetFileReader::RowGroup(int i) {
 
 void ParquetFileReader::DebugPrint(
     std::ostream& stream, std::list<int> selected_columns, bool print_values) {
-  const FileMetaData* file_metadata = metadata();
+  const FileMetaData* file_metadata = metadata().get();
 
   stream << "File statistics:\n";
   stream << "Version: " << file_metadata->version() << "\n";

--- a/src/parquet/file/reader.cc
+++ b/src/parquet/file/reader.cc
@@ -236,4 +236,12 @@ void ParquetFileReader::DebugPrint(
   }
 }
 
+// ----------------------------------------------------------------------
+// File metadata helpers
+
+std::shared_ptr<FileMetaData> ReadMetaData(
+    const std::shared_ptr<::arrow::io::ReadableFileInterface>& source) {
+  return ParquetFileReader::Open(source)->metadata();
+}
+
 }  // namespace parquet

--- a/src/parquet/file/reader.h
+++ b/src/parquet/file/reader.h
@@ -117,6 +117,10 @@ class PARQUET_EXPORT ParquetFileReader {
   std::unique_ptr<Contents> contents_;
 };
 
+// Read only Parquet file metadata
+std::shared_ptr<FileMetaData> PARQUET_EXPORT ReadMetaData(
+    const std::shared_ptr<::arrow::io::ReadableFileInterface>& source);
+
 }  // namespace parquet
 
 #endif  // PARQUET_FILE_READER_H

--- a/src/parquet/file/reader.h
+++ b/src/parquet/file/reader.h
@@ -86,18 +86,21 @@ class PARQUET_EXPORT ParquetFileReader {
   // subclass of RandomAccessSource that wraps the shared resource
   static std::unique_ptr<ParquetFileReader> Open(
       std::unique_ptr<RandomAccessSource> source,
+      const std::shared<FileMetaData> metadata = nullptr,
       const ReaderProperties& props = default_reader_properties());
 
   // Create a file reader instance from an Arrow file object. Thread-safety is
   // the responsibility of the file implementation
   static std::unique_ptr<ParquetFileReader> Open(
       const std::shared_ptr<::arrow::io::ReadableFileInterface>& source,
+      const std::shared<FileMetaData> metadata = nullptr,
       const ReaderProperties& props = default_reader_properties());
 
   // API Convenience to open a serialized Parquet file on disk, using Arrow IO
   // interfaces.
   static std::unique_ptr<ParquetFileReader> OpenFile(const std::string& path,
       bool memory_map = true,
+      const std::shared<FileMetaData> metadata = nullptr,
       const ReaderProperties& props = default_reader_properties());
 
   void Open(std::unique_ptr<Contents> contents);

--- a/src/parquet/file/reader.h
+++ b/src/parquet/file/reader.h
@@ -86,22 +86,21 @@ class PARQUET_EXPORT ParquetFileReader {
   // subclass of RandomAccessSource that wraps the shared resource
   static std::unique_ptr<ParquetFileReader> Open(
       std::unique_ptr<RandomAccessSource> source,
-      const std::shared<FileMetaData> metadata = nullptr,
-      const ReaderProperties& props = default_reader_properties());
+      const ReaderProperties& props = default_reader_properties(),
+      const std::shared_ptr<FileMetaData>& metadata = nullptr);
 
   // Create a file reader instance from an Arrow file object. Thread-safety is
   // the responsibility of the file implementation
   static std::unique_ptr<ParquetFileReader> Open(
       const std::shared_ptr<::arrow::io::ReadableFileInterface>& source,
-      const std::shared<FileMetaData> metadata = nullptr,
-      const ReaderProperties& props = default_reader_properties());
+      const ReaderProperties& props = default_reader_properties(),
+      const std::shared_ptr<FileMetaData>& metadata = nullptr);
 
   // API Convenience to open a serialized Parquet file on disk, using Arrow IO
   // interfaces.
   static std::unique_ptr<ParquetFileReader> OpenFile(const std::string& path,
-      bool memory_map = true,
-      const std::shared<FileMetaData> metadata = nullptr,
-      const ReaderProperties& props = default_reader_properties());
+      bool memory_map = true, const ReaderProperties& props = default_reader_properties(),
+      const std::shared_ptr<FileMetaData>& metadata = nullptr);
 
   void Open(std::unique_ptr<Contents> contents);
   void Close();

--- a/src/parquet/file/reader.h
+++ b/src/parquet/file/reader.h
@@ -73,7 +73,7 @@ class PARQUET_EXPORT ParquetFileReader {
     // Perform any cleanup associated with the file contents
     virtual void Close() = 0;
     virtual std::shared_ptr<RowGroupReader> GetRowGroup(int i) = 0;
-    virtual const FileMetaData* metadata() const = 0;
+    virtual std::shared_ptr<FileMetaData> metadata() const = 0;
   };
 
   ParquetFileReader();
@@ -94,9 +94,8 @@ class PARQUET_EXPORT ParquetFileReader {
       const std::shared_ptr<::arrow::io::ReadableFileInterface>& source,
       const ReaderProperties& props = default_reader_properties());
 
-  // API Convenience to open a serialized Parquet file on disk, using built-in IO
-  // interface implementations that were created for testing, and may not be robust for
-  // all use cases.
+  // API Convenience to open a serialized Parquet file on disk, using Arrow IO
+  // interfaces.
   static std::unique_ptr<ParquetFileReader> OpenFile(const std::string& path,
       bool memory_map = true,
       const ReaderProperties& props = default_reader_properties());
@@ -107,8 +106,8 @@ class PARQUET_EXPORT ParquetFileReader {
   // The RowGroupReader is owned by the FileReader
   std::shared_ptr<RowGroupReader> RowGroup(int i);
 
-  // Returns the file metadata
-  const FileMetaData* metadata() const;
+  // Returns the file metadata. Only one instance is ever created
+  std::shared_ptr<FileMetaData> metadata() const;
 
   void DebugPrint(
       std::ostream& stream, std::list<int> selected_columns, bool print_values = true);

--- a/src/parquet/reader-test.cc
+++ b/src/parquet/reader-test.cc
@@ -182,15 +182,57 @@ class TestLocalFile : public ::testing::Test {
   std::shared_ptr<::arrow::io::ReadableFile> handle;
 };
 
+class HelperFileClosed : public ArrowInputFile {
+ public:
+  explicit HelperFileClosed(
+      const std::shared_ptr<::arrow::io::ReadableFileInterface>& file, bool* close_called)
+      : ArrowInputFile(file), close_called_(close_called) {}
+
+  void Close() override { *close_called_ = true; }
+
+ private:
+  bool* close_called_;
+};
+
 TEST_F(TestLocalFile, FileClosedOnDestruction) {
+  bool close_called = false;
   {
     auto contents = SerializedFile::Open(
-        std::unique_ptr<RandomAccessSource>(new ArrowInputFile(handle)));
+        std::unique_ptr<RandomAccessSource>(new HelperFileClosed(handle, &close_called)));
     std::unique_ptr<ParquetFileReader> result(new ParquetFileReader());
     result->Open(std::move(contents));
   }
-  ASSERT_EQ(-1, fcntl(fileno, F_GETFD));
-  ASSERT_EQ(EBADF, errno);
+  ASSERT_TRUE(close_called);
+}
+
+TEST_F(TestLocalFile, OpenWithMetadata) {
+  // PARQUET-808
+  std::stringstream ss;
+  std::shared_ptr<FileMetaData> metadata;
+
+  // empty list means print all
+  std::list<int> columns;
+
+  {
+    auto reader = ParquetFileReader::Open(handle);
+    metadata = reader->metadata();
+    reader->DebugPrint(ss, columns, true);
+  }
+
+  auto reader = ParquetFileReader::Open(handle, default_reader_properties(), metadata);
+
+  // Compare pointers
+  ASSERT_EQ(metadata.get(), reader->metadata().get());
+
+  columns.clear();
+  reader->DebugPrint(ss, columns, true);
+
+  // Make sure OpenFile passes on the external metadata, too
+  auto reader2 = ParquetFileReader::OpenFile(
+      alltypes_plain(), false, default_reader_properties(), metadata);
+
+  // Compare pointers
+  ASSERT_EQ(metadata.get(), reader2->metadata().get());
 }
 
 TEST(TestFileReaderAdHoc, NationDictTruncatedDataPage) {

--- a/src/parquet/reader-test.cc
+++ b/src/parquet/reader-test.cc
@@ -208,23 +208,14 @@ TEST_F(TestLocalFile, FileClosedOnDestruction) {
 TEST_F(TestLocalFile, OpenWithMetadata) {
   // PARQUET-808
   std::stringstream ss;
-  std::shared_ptr<FileMetaData> metadata;
-
-  // empty list means print all
-  std::list<int> columns;
-
-  {
-    auto reader = ParquetFileReader::Open(handle);
-    metadata = reader->metadata();
-    reader->DebugPrint(ss, columns, true);
-  }
+  std::shared_ptr<FileMetaData> metadata = ReadMetaData(handle);
 
   auto reader = ParquetFileReader::Open(handle, default_reader_properties(), metadata);
 
   // Compare pointers
   ASSERT_EQ(metadata.get(), reader->metadata().get());
 
-  columns.clear();
+  std::list<int> columns;
   reader->DebugPrint(ss, columns, true);
 
   // Make sure OpenFile passes on the external metadata, too

--- a/src/parquet/util/memory.cc
+++ b/src/parquet/util/memory.cc
@@ -347,9 +347,9 @@ bool ChunkedAllocator::CheckIntegrity(bool current_chunk_empty) {
 // ----------------------------------------------------------------------
 // Arrow IO wrappers
 
-// Close the output stream
 void ArrowFileMethods::Close() {
-  PARQUET_THROW_NOT_OK(file_interface()->Close());
+  // Closing the file is the responsibility of the owner of the handle
+  return;
 }
 
 // Return the current position in the output stream relative to the start

--- a/src/parquet/util/memory.h
+++ b/src/parquet/util/memory.h
@@ -286,7 +286,9 @@ class PARQUET_EXPORT OutputStream : virtual public FileInterface {
 
 class PARQUET_EXPORT ArrowFileMethods : virtual public FileInterface {
  public:
+  // No-op. Closing the file is the responsibility of the owner of the handle
   void Close() override;
+
   int64_t Tell() override;
 
  protected:


### PR DESCRIPTION
Also implements PARQUET-808: opening file with existing metadata object. 

This allows a user to create a reader only for the purposes of obtaining the metadata. 

Do you all think it's worth having a convenience method for reading the metadata out of a file? 