### PR TITLE
PARQUET-809: Add SchemaDescriptor::Equals method

### DIFF
--- a/src/parquet/arrow/schema.cc
+++ b/src/parquet/arrow/schema.cc
@@ -364,12 +364,6 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
       type = ParquetType::INT64;
       logical_type = LogicalType::TIMESTAMP_MILLIS;
     } break;
-    case ArrowType::TIMESTAMP_DOUBLE:
-      type = ParquetType::INT64;
-      // This is specified as seconds since the UNIX epoch
-      // TODO: Converted type in Parquet?
-      // logical_type = LogicalType::TIMESTAMP_MILLIS;
-      break;
     case ArrowType::TIME:
       type = ParquetType::INT64;
       logical_type = LogicalType::TIME_MILLIS;

--- a/src/parquet/schema/descriptor.cc
+++ b/src/parquet/schema/descriptor.cc
@@ -47,6 +47,20 @@ void SchemaDescriptor::Init(const NodePtr& schema) {
   }
 }
 
+bool SchemaDescriptor::Equals(const SchemaDescriptor& other) const {
+  if (this->num_columns() != other.num_columns()) {
+    return false;
+  }
+
+  for (int i = 0; i < this->num_columns(); ++i) {
+    if (!this->Column(i)->Equals(*other.Column(i))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 void SchemaDescriptor::BuildTree(const NodePtr& node, int16_t max_def_level,
     int16_t max_rep_level, const NodePtr& base) {
   if (node->is_optional()) {
@@ -80,6 +94,12 @@ ColumnDescriptor::ColumnDescriptor(const schema::NodePtr& node,
       schema_descr_(schema_descr) {
   if (!node_->is_primitive()) { throw ParquetException("Must be a primitive type"); }
   primitive_node_ = static_cast<const PrimitiveNode*>(node_.get());
+}
+
+bool ColumnDescriptor::Equals(const ColumnDescriptor& other) const {
+  return primitive_node_->Equals(other.primitive_node_) &&
+    max_repetition_level() == other.max_repetition_level() &&
+    max_definition_level() == other.max_definition_level();
 }
 
 const ColumnDescriptor* SchemaDescriptor::Column(int i) const {

--- a/src/parquet/schema/descriptor.h
+++ b/src/parquet/schema/descriptor.h
@@ -42,6 +42,8 @@ class PARQUET_EXPORT ColumnDescriptor {
   ColumnDescriptor(const schema::NodePtr& node, int16_t max_definition_level,
       int16_t max_repetition_level, const SchemaDescriptor* schema_descr = nullptr);
 
+  bool Equals(const ColumnDescriptor& other) const;
+
   int16_t max_definition_level() const { return max_definition_level_; }
 
   int16_t max_repetition_level() const { return max_repetition_level_; }
@@ -96,6 +98,8 @@ class PARQUET_EXPORT SchemaDescriptor {
   void Init(const schema::NodePtr& schema);
 
   const ColumnDescriptor* Column(int i) const;
+
+  bool Equals(const SchemaDescriptor& other) const;
 
   // The number of physical columns appearing in the file
   int num_columns() const { return leaves_.size(); }


### PR DESCRIPTION
To make it simpler to compare file metadata