### PR TITLE
PARQUET-828: Do not implicitly cast ParquetVersion enum to int

### DIFF
--- a/src/parquet/file/file-metadata-test.cc
+++ b/src/parquet/file/file-metadata-test.cc
@@ -31,7 +31,10 @@ TEST(Metadata, TestBuildAccess) {
   parquet::schema::NodePtr root;
   parquet::SchemaDescriptor schema;
 
-  std::shared_ptr<WriterProperties> props = WriterProperties::Builder().build();
+  WriterProperties::Builder prop_builder;
+
+  std::shared_ptr<WriterProperties> props =
+      prop_builder.version(ParquetVersion::PARQUET_2_0)->build();
 
   fields.push_back(parquet::schema::Int32("int_col", Repetition::REQUIRED));
   fields.push_back(parquet::schema::Float("float_col", Repetition::REQUIRED));
@@ -84,7 +87,7 @@ TEST(Metadata, TestBuildAccess) {
   ASSERT_EQ(nrows, f_accessor->num_rows());
   ASSERT_LE(0, f_accessor->size());
   ASSERT_EQ(2, f_accessor->num_row_groups());
-  ASSERT_EQ(DEFAULT_WRITER_VERSION, f_accessor->version());
+  ASSERT_EQ(ParquetVersion::PARQUET_2_0, f_accessor->version());
   ASSERT_EQ(DEFAULT_CREATED_BY, f_accessor->created_by());
   ASSERT_EQ(3, f_accessor->num_schema_elements());
 
@@ -110,8 +113,8 @@ TEST(Metadata, TestBuildAccess) {
   ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column2->compression());
   ASSERT_EQ(nrows / 2, rg1_column1->num_values());
   ASSERT_EQ(nrows / 2, rg1_column2->num_values());
-  ASSERT_EQ(2, rg1_column1->encodings().size());
-  ASSERT_EQ(2, rg1_column2->encodings().size());
+  ASSERT_EQ(3, rg1_column1->encodings().size());
+  ASSERT_EQ(3, rg1_column2->encodings().size());
   ASSERT_EQ(512, rg1_column1->total_compressed_size());
   ASSERT_EQ(512, rg1_column2->total_compressed_size());
   ASSERT_EQ(600, rg1_column1->total_uncompressed_size());
@@ -142,8 +145,8 @@ TEST(Metadata, TestBuildAccess) {
   ASSERT_EQ(nrows / 2, rg2_column2->num_values());
   ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column1->compression());
   ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column2->compression());
-  ASSERT_EQ(2, rg2_column1->encodings().size());
-  ASSERT_EQ(2, rg2_column2->encodings().size());
+  ASSERT_EQ(3, rg2_column1->encodings().size());
+  ASSERT_EQ(3, rg2_column2->encodings().size());
   ASSERT_EQ(512, rg2_column1->total_compressed_size());
   ASSERT_EQ(512, rg2_column2->total_compressed_size());
   ASSERT_EQ(600, rg2_column1->total_uncompressed_size());

--- a/src/parquet/file/metadata.h
+++ b/src/parquet/file/metadata.h
@@ -130,7 +130,7 @@ class PARQUET_EXPORT FileMetaData {
   int num_columns() const;
   int64_t num_rows() const;
   int num_row_groups() const;
-  int32_t version() const;
+  ParquetVersion::type version() const;
   const std::string& created_by() const;
   int num_schema_elements() const;
   std::unique_ptr<RowGroupMetaData> RowGroup(int i) const;


### PR DESCRIPTION
See https://github.com/apache/parquet-mr/blob/df9d8e415436292ae33e1ca0b8da256640de9710/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java#L86, this number should be 1 for Parquet 1.0 files, I believe. 