### PR TITLE
PARQUET-820: Decoders should directly emit arrays with spacing for null entries

### DIFF
--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -205,9 +205,9 @@ class TestParquetIO : public ::testing::Test {
 
   void ReaderFromSink(std::unique_ptr<FileReader>* out) {
     std::shared_ptr<Buffer> buffer = sink_->GetBuffer();
-    ASSERT_OK_NO_THROW(OpenFile(std::make_shared<BufferReader>(buffer),
-            ::arrow::default_memory_pool(), ::parquet::default_reader_properties(),
-            nullptr, out));
+    ASSERT_OK_NO_THROW(
+        OpenFile(std::make_shared<BufferReader>(buffer), ::arrow::default_memory_pool(),
+            ::parquet::default_reader_properties(), nullptr, out));
   }
 
   void ReadSingleColumnFile(
@@ -567,8 +567,8 @@ class TestPrimitiveParquetIO : public TestParquetIO<TestType> {
  public:
   typedef typename c_type_trait<TestType>::ArrowCType T;
 
-  void MakeTestFile(std::vector<T>& values, int num_chunks,
-      std::unique_ptr<FileReader>* reader) {
+  void MakeTestFile(
+      std::vector<T>& values, int num_chunks, std::unique_ptr<FileReader>* reader) {
     std::shared_ptr<GroupNode> schema = this->MakeSchema(Repetition::REQUIRED);
     std::unique_ptr<ParquetFileWriter> file_writer = this->MakeWriter(schema);
     size_t chunk_size = values.size() / num_chunks;

--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -268,8 +268,7 @@ class TestParquetIO : public ::testing::Test {
 typedef ::testing::Types<::arrow::BooleanType, ::arrow::UInt8Type, ::arrow::Int8Type,
     ::arrow::UInt16Type, ::arrow::Int16Type, ::arrow::Int32Type, ::arrow::UInt64Type,
     ::arrow::Int64Type, ::arrow::TimestampType, ::arrow::FloatType, ::arrow::DoubleType,
-    ::arrow::StringType, ::arrow::BinaryType>
-    TestTypes;
+    ::arrow::StringType, ::arrow::BinaryType> TestTypes;
 
 TYPED_TEST_CASE(TestParquetIO, TestTypes);
 
@@ -621,8 +620,8 @@ class TestPrimitiveParquetIO : public TestParquetIO<TestType> {
 
 typedef ::testing::Types<::arrow::BooleanType, ::arrow::UInt8Type, ::arrow::Int8Type,
     ::arrow::UInt16Type, ::arrow::Int16Type, ::arrow::UInt32Type, ::arrow::Int32Type,
-    ::arrow::UInt64Type, ::arrow::Int64Type, ::arrow::FloatType, ::arrow::DoubleType>
-    PrimitiveTestTypes;
+    ::arrow::UInt64Type, ::arrow::Int64Type, ::arrow::FloatType,
+    ::arrow::DoubleType> PrimitiveTestTypes;
 
 TYPED_TEST_CASE(TestPrimitiveParquetIO, PrimitiveTestTypes);
 

--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -54,17 +54,7 @@ static inline int64_t impala_timestamp_to_nanoseconds(const Int96& impala_timest
 }
 
 template <typename ArrowType>
-struct ArrowTypeTraits {
-  typedef ::arrow::NumericArray<ArrowType> array_type;
-};
-
-template <>
-struct ArrowTypeTraits<::arrow::BooleanType> {
-  typedef ::arrow::BooleanArray array_type;
-};
-
-template <typename ArrowType>
-using ArrayType = typename ArrowTypeTraits<ArrowType>::array_type;
+using ArrayType = typename ::arrow::TypeTraits<ArrowType>::ArrayType;
 
 class FileReader::Impl {
  public:

--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -412,10 +412,8 @@ Status FlatColumnReader::Impl::TypedReadBatch(
     int16_t* def_levels = reinterpret_cast<int16_t*>(def_levels_buffer_.mutable_data());
     auto values = reinterpret_cast<ParquetCType*>(values_buffer_.mutable_data());
     if (descr_->max_definition_level() == 0) {
-      // TODO: No need for spaced here.
-      int null_count;
-      PARQUET_CATCH_NOT_OK(levels_read = reader->ReadBatchSpaced(
-                               values_to_read, def_levels, nullptr, values, &null_count));
+      int64_t values_read;
+      PARQUET_CATCH_NOT_OK(levels_read = reader->ReadBatch(values_to_read, nullptr, nullptr, values, &values_read));
       ReadNonNullableBatch<ArrowType, ParquetType>(values, levels_read);
     } else {
       // As per the defintion and checks for flat columns:
@@ -486,11 +484,8 @@ Status FlatColumnReader::Impl::TypedReadBatch<::arrow::BooleanType, BooleanType>
     int16_t* def_levels = reinterpret_cast<int16_t*>(def_levels_buffer_.mutable_data());
     auto values = reinterpret_cast<bool*>(values_buffer_.mutable_data());
     if (descr_->max_definition_level() == 0) {
-      // TODO: No need for spaced here.
-      // Remove null_count
-      int null_count;
-      PARQUET_CATCH_NOT_OK(levels_read = reader->ReadBatchSpaced(
-                               values_to_read, def_levels, nullptr, values, &null_count));
+      int64_t values_read;
+      PARQUET_CATCH_NOT_OK(levels_read = reader->ReadBatch(values_to_read, nullptr, nullptr, values, &values_read));
       ReadNonNullableBatch<::arrow::BooleanType, BooleanType>(values, levels_read);
     } else {
       // As per the defintion and checks for flat columns:

--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -457,7 +457,7 @@ Status FlatColumnReader::Impl::TypedReadBatch(
   RETURN_NOT_OK(InitDataBuffer<ArrowType>(batch_size));
   valid_bits_idx_ = 0;
   if (descr_->max_definition_level() > 0) {
-    int valid_bits_size = ::arrow::BitUtil::CeilByte(batch_size) / 8;
+    int valid_bits_size = ::arrow::BitUtil::CeilByte(batch_size + 1) / 8;
     valid_bits_buffer_ = std::make_shared<PoolBuffer>(pool_);
     RETURN_NOT_OK(valid_bits_buffer_->Resize(valid_bits_size, false));
     valid_bits_ptr_ = valid_bits_buffer_->mutable_data();
@@ -527,7 +527,7 @@ Status FlatColumnReader::Impl::TypedReadBatch<::arrow::BooleanType, BooleanType>
   valid_bits_idx_ = 0;
   if (descr_->max_definition_level() > 0) {
     valid_bits_buffer_ = std::make_shared<PoolBuffer>(pool_);
-    int valid_bits_size = ::arrow::BitUtil::CeilByte(batch_size) / 8;
+    int valid_bits_size = ::arrow::BitUtil::CeilByte(batch_size + 1) / 8;
     RETURN_NOT_OK(valid_bits_buffer_->Resize(valid_bits_size, false));
     valid_bits_ptr_ = valid_bits_buffer_->mutable_data();
     memset(valid_bits_ptr_, 0, valid_bits_size);

--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -326,13 +326,10 @@ Status FlatColumnReader::Impl::ReadNullableFlatBatch(
                                values, &null_count, valid_bits_ptr_, valid_bits_idx_));
 
   auto data_ptr = reinterpret_cast<ArrowCType*>(data_buffer_ptr_);
-  int byte_offset = valid_bits_idx_ / 8;
-  int bit_offset = valid_bits_idx_ % 8;
-  uint8_t bitset = valid_bits_ptr_[byte_offset];
+  INIT_BITSET(valid_bits_ptr_, valid_bits_idx_);
 
   for (int64_t i = 0; i < *levels_read; i++) {
     if (bitset & (1 << bit_offset)) { data_ptr[valid_bits_idx_ + i] = values[i]; }
-
     READ_NEXT_BITSET(valid_bits_ptr_);
   }
   null_count_ += null_count;
@@ -375,14 +372,11 @@ Status FlatColumnReader::Impl::ReadNullableFlatBatch<::arrow::TimestampType, Int
                                values, &null_count, valid_bits_ptr_, valid_bits_idx_));
 
   auto data_ptr = reinterpret_cast<int64_t*>(data_buffer_ptr_);
-  int byte_offset = valid_bits_idx_ / 8;
-  int bit_offset = valid_bits_idx_ % 8;
-  uint8_t bitset = valid_bits_ptr_[byte_offset];
+  INIT_BITSET(valid_bits_ptr_, valid_bits_idx_);
   for (int64_t i = 0; i < *levels_read; i++) {
     if (bitset & (1 << bit_offset)) {
       data_ptr[valid_bits_idx_ + i] = impala_timestamp_to_nanoseconds(values[i]);
     }
-
     READ_NEXT_BITSET(valid_bits_ptr_);
   }
   null_count_ += null_count;
@@ -402,14 +396,11 @@ Status FlatColumnReader::Impl::ReadNullableFlatBatch<::arrow::BooleanType, Boole
                            reader->ReadBatchSpaced(values_to_read, def_levels, nullptr,
                                values, &null_count, valid_bits_ptr_, valid_bits_idx_));
 
-  int byte_offset = valid_bits_idx_ / 8;
-  int bit_offset = valid_bits_idx_ % 8;
-  uint8_t bitset = valid_bits_ptr_[byte_offset];
+  INIT_BITSET(valid_bits_ptr_, valid_bits_idx_);
   for (int64_t i = 0; i < *levels_read; i++) {
     if (bitset & (1 << bit_offset)) {
       if (values[i]) { ::arrow::BitUtil::SetBit(data_buffer_ptr_, valid_bits_idx_ + i); }
     }
-
     READ_NEXT_BITSET(valid_bits_ptr_);
   }
   valid_bits_idx_ += *levels_read;

--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "parquet/arrow/schema.h"
+#include "parquet/util/bit-util.h"
 
 #include "arrow/api.h"
 #include "arrow/type_traits.h"
@@ -292,12 +293,7 @@ Status FlatColumnReader::Impl::ReadNullableFlatBatch(
   for (int64_t i = 0; i < *levels_read; i++) {
     if (bitset & (1 << bit_offset)) { data_ptr[valid_bits_idx_ + i] = values[i]; }
 
-    bit_offset++;
-    if (bit_offset == 8) {
-      bit_offset = 0;
-      byte_offset++;
-      bitset = valid_bits_ptr_[byte_offset];
-    }
+    READ_NEXT_BITSET(valid_bits_ptr_);
   }
   null_count_ += null_count;
   valid_bits_idx_ += *levels_read;
@@ -345,12 +341,7 @@ Status FlatColumnReader::Impl::ReadNullableFlatBatch<::arrow::TimestampType, Int
       data_ptr[valid_bits_idx_ + i] = impala_timestamp_to_nanoseconds(values[i]);
     }
 
-    bit_offset++;
-    if (bit_offset == 8) {
-      bit_offset = 0;
-      byte_offset++;
-      bitset = valid_bits_ptr_[byte_offset];
-    }
+    READ_NEXT_BITSET(valid_bits_ptr_);
   }
   null_count_ += null_count;
   valid_bits_idx_ += *levels_read;
@@ -375,12 +366,7 @@ Status FlatColumnReader::Impl::ReadNullableFlatBatch<::arrow::BooleanType, Boole
       if (values[i]) { ::arrow::BitUtil::SetBit(data_buffer_ptr_, valid_bits_idx_ + i); }
     }
 
-    bit_offset++;
-    if (bit_offset == 8) {
-      bit_offset = 0;
-      byte_offset++;
-      bitset = valid_bits_ptr_[byte_offset];
-    }
+    READ_NEXT_BITSET(valid_bits_ptr_);
   }
   valid_bits_idx_ += *levels_read;
   null_count_ += null_count;

--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -204,8 +204,8 @@ Status OpenFile(const std::shared_ptr<::arrow::io::ReadableFileInterface>& file,
 
 Status OpenFile(const std::shared_ptr<::arrow::io::ReadableFileInterface>& file,
     MemoryPool* allocator, std::unique_ptr<FileReader>* reader) {
-  return OpenFile(file, allocator, ::parquet::default_reader_properties(),
-      nullptr, reader);
+  return OpenFile(
+      file, allocator, ::parquet::default_reader_properties(), nullptr, reader);
 }
 
 Status FileReader::GetFlatColumn(int i, std::unique_ptr<FlatColumnReader>* out) {

--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -100,10 +100,10 @@ class FlatColumnReader::Impl {
   Status InitDataBuffer(int batch_size);
   template <typename ArrowType, typename ParquetType>
   Status ReadNullableFlatBatch(TypedColumnReader<ParquetType>* reader,
-      int16_t* def_levels, typename ParquetType::c_type* values, int64_t values_to_read,
-      int64_t* levels_read);
+      int16_t* def_levels, int64_t values_to_read, int64_t* levels_read);
   template <typename ArrowType, typename ParquetType>
-  void ReadNonNullableBatch(typename ParquetType::c_type* values, int64_t levels_read);
+  Status ReadNonNullableBatch(TypedColumnReader<ParquetType>* reader,
+      int64_t values_to_read, int64_t* levels_read);
 
  private:
   void NextRowGroup();
@@ -246,40 +246,90 @@ FlatColumnReader::Impl::Impl(MemoryPool* pool, const ColumnDescriptor* descr,
 }
 
 template <typename ArrowType, typename ParquetType>
-void FlatColumnReader::Impl::ReadNonNullableBatch(
-    typename ParquetType::c_type* values, int64_t values_read) {
+Status FlatColumnReader::Impl::ReadNonNullableBatch(
+    TypedColumnReader<ParquetType>* reader, int64_t values_to_read,
+    int64_t* levels_read) {
   using ArrowCType = typename ArrowType::c_type;
+  using ParquetCType = typename ParquetType::c_type;
+
+  RETURN_NOT_OK(values_buffer_.Resize(values_to_read * sizeof(ParquetCType), false));
+  auto values = reinterpret_cast<ParquetCType*>(values_buffer_.mutable_data());
+  int64_t values_read;
+  PARQUET_CATCH_NOT_OK(*levels_read = reader->ReadBatch(
+                           values_to_read, nullptr, nullptr, values, &values_read));
 
   ArrowCType* out_ptr = reinterpret_cast<ArrowCType*>(data_buffer_ptr_);
   std::copy(values, values + values_read, out_ptr + valid_bits_idx_);
   valid_bits_idx_ += values_read;
+
+  return Status::OK();
 }
 
+#define NONNULLABLE_BATCH_FAST_PATH(ArrowType, ParquetType, CType)                 \
+  template <>                                                                      \
+  Status FlatColumnReader::Impl::ReadNonNullableBatch<ArrowType, ParquetType>(     \
+      TypedColumnReader<ParquetType> * reader, int64_t values_to_read,             \
+      int64_t * levels_read) {                                                     \
+    int64_t values_read;                                                           \
+    CType* out_ptr = reinterpret_cast<CType*>(data_buffer_ptr_);                   \
+    PARQUET_CATCH_NOT_OK(*levels_read = reader->ReadBatch(values_to_read, nullptr, \
+                             nullptr, out_ptr + valid_bits_idx_, &values_read));   \
+                                                                                   \
+    valid_bits_idx_ += values_read;                                                \
+                                                                                   \
+    return Status::OK();                                                           \
+  }
+
+NONNULLABLE_BATCH_FAST_PATH(::arrow::Int32Type, Int32Type, int32_t)
+NONNULLABLE_BATCH_FAST_PATH(::arrow::Int64Type, Int64Type, int64_t)
+NONNULLABLE_BATCH_FAST_PATH(::arrow::FloatType, FloatType, float)
+NONNULLABLE_BATCH_FAST_PATH(::arrow::DoubleType, DoubleType, double)
+
 template <>
-void FlatColumnReader::Impl::ReadNonNullableBatch<::arrow::TimestampType, Int96Type>(
-    Int96* values, int64_t values_read) {
+Status FlatColumnReader::Impl::ReadNonNullableBatch<::arrow::TimestampType, Int96Type>(
+    TypedColumnReader<Int96Type>* reader, int64_t values_to_read, int64_t* levels_read) {
+  RETURN_NOT_OK(values_buffer_.Resize(values_to_read * sizeof(Int96Type), false));
+  auto values = reinterpret_cast<Int96*>(values_buffer_.mutable_data());
+  int64_t values_read;
+  PARQUET_CATCH_NOT_OK(*levels_read = reader->ReadBatch(
+                           values_to_read, nullptr, nullptr, values, &values_read));
+
   int64_t* out_ptr = reinterpret_cast<int64_t*>(data_buffer_ptr_);
   for (int64_t i = 0; i < values_read; i++) {
-    out_ptr[valid_bits_idx_ + i] = impala_timestamp_to_nanoseconds(values[i]);
+    *out_ptr++ = impala_timestamp_to_nanoseconds(values[i]);
   }
   valid_bits_idx_ += values_read;
+
+  return Status::OK();
 }
 
 template <>
-void FlatColumnReader::Impl::ReadNonNullableBatch<::arrow::BooleanType, BooleanType>(
-    bool* values, int64_t values_read) {
+Status FlatColumnReader::Impl::ReadNonNullableBatch<::arrow::BooleanType, BooleanType>(
+    TypedColumnReader<BooleanType>* reader, int64_t values_to_read,
+    int64_t* levels_read) {
+  RETURN_NOT_OK(values_buffer_.Resize(values_to_read * sizeof(bool), false));
+  auto values = reinterpret_cast<bool*>(values_buffer_.mutable_data());
+  int64_t values_read;
+  PARQUET_CATCH_NOT_OK(*levels_read = reader->ReadBatch(
+                           values_to_read, nullptr, nullptr, values, &values_read));
+
   for (int64_t i = 0; i < values_read; i++) {
     if (values[i]) { ::arrow::BitUtil::SetBit(data_buffer_ptr_, valid_bits_idx_); }
     valid_bits_idx_++;
   }
+
+  return Status::OK();
 }
 
 template <typename ArrowType, typename ParquetType>
 Status FlatColumnReader::Impl::ReadNullableFlatBatch(
-    TypedColumnReader<ParquetType>* reader, int16_t* def_levels,
-    typename ParquetType::c_type* values, int64_t values_to_read, int64_t* levels_read) {
+    TypedColumnReader<ParquetType>* reader, int16_t* def_levels, int64_t values_to_read,
+    int64_t* levels_read) {
   using ArrowCType = typename ArrowType::c_type;
+  using ParquetCType = typename ParquetType::c_type;
 
+  RETURN_NOT_OK(values_buffer_.Resize(values_to_read * sizeof(ParquetCType), false));
+  auto values = reinterpret_cast<ParquetCType*>(values_buffer_.mutable_data());
   int null_count;
   PARQUET_CATCH_NOT_OK(*levels_read =
                            reader->ReadBatchSpaced(values_to_read, def_levels, nullptr,
@@ -301,21 +351,21 @@ Status FlatColumnReader::Impl::ReadNullableFlatBatch(
   return Status::OK();
 }
 
-#define NULLABLE_BATCH_FAST_PATH(ArrowType, ParquetType, CType)                      \
-  template <>                                                                        \
-  Status FlatColumnReader::Impl::ReadNullableFlatBatch<ArrowType, ParquetType>(      \
-      TypedColumnReader<ParquetType> * reader, int16_t * def_levels, CType * values, \
-      int64_t values_to_read, int64_t * levels_read) {                               \
-    auto data_ptr = reinterpret_cast<CType*>(data_buffer_ptr_);                      \
-    int null_count;                                                                  \
-    PARQUET_CATCH_NOT_OK(*levels_read = reader->ReadBatchSpaced(values_to_read,      \
-                             def_levels, nullptr, data_ptr + valid_bits_idx_,        \
-                             &null_count, valid_bits_ptr_, valid_bits_idx_));        \
-                                                                                     \
-    valid_bits_idx_ += *levels_read;                                                 \
-    null_count_ += null_count;                                                       \
-                                                                                     \
-    return Status::OK();                                                             \
+#define NULLABLE_BATCH_FAST_PATH(ArrowType, ParquetType, CType)                 \
+  template <>                                                                   \
+  Status FlatColumnReader::Impl::ReadNullableFlatBatch<ArrowType, ParquetType>( \
+      TypedColumnReader<ParquetType> * reader, int16_t * def_levels,            \
+      int64_t values_to_read, int64_t * levels_read) {                          \
+    auto data_ptr = reinterpret_cast<CType*>(data_buffer_ptr_);                 \
+    int null_count;                                                             \
+    PARQUET_CATCH_NOT_OK(*levels_read = reader->ReadBatchSpaced(values_to_read, \
+                             def_levels, nullptr, data_ptr + valid_bits_idx_,   \
+                             &null_count, valid_bits_ptr_, valid_bits_idx_));   \
+                                                                                \
+    valid_bits_idx_ += *levels_read;                                            \
+    null_count_ += null_count;                                                  \
+                                                                                \
+    return Status::OK();                                                        \
   }
 
 NULLABLE_BATCH_FAST_PATH(::arrow::Int32Type, Int32Type, int32_t)
@@ -325,8 +375,10 @@ NULLABLE_BATCH_FAST_PATH(::arrow::DoubleType, DoubleType, double)
 
 template <>
 Status FlatColumnReader::Impl::ReadNullableFlatBatch<::arrow::TimestampType, Int96Type>(
-    TypedColumnReader<Int96Type>* reader, int16_t* def_levels, Int96* values,
-    int64_t values_to_read, int64_t* levels_read) {
+    TypedColumnReader<Int96Type>* reader, int16_t* def_levels, int64_t values_to_read,
+    int64_t* levels_read) {
+  RETURN_NOT_OK(values_buffer_.Resize(values_to_read * sizeof(Int96Type), false));
+  auto values = reinterpret_cast<Int96*>(values_buffer_.mutable_data());
   int null_count;
   PARQUET_CATCH_NOT_OK(*levels_read =
                            reader->ReadBatchSpaced(values_to_read, def_levels, nullptr,
@@ -351,8 +403,10 @@ Status FlatColumnReader::Impl::ReadNullableFlatBatch<::arrow::TimestampType, Int
 
 template <>
 Status FlatColumnReader::Impl::ReadNullableFlatBatch<::arrow::BooleanType, BooleanType>(
-    TypedColumnReader<BooleanType>* reader, int16_t* def_levels, bool* values,
-    int64_t values_to_read, int64_t* levels_read) {
+    TypedColumnReader<BooleanType>* reader, int16_t* def_levels, int64_t values_to_read,
+    int64_t* levels_read) {
+  RETURN_NOT_OK(values_buffer_.Resize(values_to_read * sizeof(bool), false));
+  auto values = reinterpret_cast<bool*>(values_buffer_.mutable_data());
   int null_count;
   PARQUET_CATCH_NOT_OK(*levels_read =
                            reader->ReadBatchSpaced(values_to_read, def_levels, nullptr,
@@ -398,7 +452,6 @@ template <typename ArrowType, typename ParquetType>
 Status FlatColumnReader::Impl::TypedReadBatch(
     int batch_size, std::shared_ptr<Array>* out) {
   using ArrowCType = typename ArrowType::c_type;
-  using ParquetCType = typename ParquetType::c_type;
 
   int values_to_read = batch_size;
   RETURN_NOT_OK(InitDataBuffer<ArrowType>(batch_size));
@@ -413,24 +466,20 @@ Status FlatColumnReader::Impl::TypedReadBatch(
   }
 
   while ((values_to_read > 0) && column_reader_) {
-    RETURN_NOT_OK(values_buffer_.Resize(values_to_read * sizeof(ParquetCType), false));
     if (descr_->max_definition_level() > 0) {
       RETURN_NOT_OK(def_levels_buffer_.Resize(values_to_read * sizeof(int16_t), false));
     }
     auto reader = dynamic_cast<TypedColumnReader<ParquetType>*>(column_reader_.get());
     int64_t levels_read;
     int16_t* def_levels = reinterpret_cast<int16_t*>(def_levels_buffer_.mutable_data());
-    auto values = reinterpret_cast<ParquetCType*>(values_buffer_.mutable_data());
     if (descr_->max_definition_level() == 0) {
-      int64_t values_read;
-      PARQUET_CATCH_NOT_OK(levels_read = reader->ReadBatch(
-                               values_to_read, nullptr, nullptr, values, &values_read));
-      ReadNonNullableBatch<ArrowType, ParquetType>(values, levels_read);
+      RETURN_NOT_OK((ReadNonNullableBatch<ArrowType, ParquetType>(
+          reader, values_to_read, &levels_read)));
     } else {
       // As per the defintion and checks for flat columns:
       // descr_->max_definition_level() == 1
       RETURN_NOT_OK((ReadNullableFlatBatch<ArrowType, ParquetType>(
-          reader, def_levels, values, values_to_read, &levels_read)));
+          reader, def_levels, values_to_read, &levels_read)));
     }
     values_to_read -= levels_read;
     if (!column_reader_->HasNext()) { NextRowGroup(); }
@@ -486,24 +535,20 @@ Status FlatColumnReader::Impl::TypedReadBatch<::arrow::BooleanType, BooleanType>
   }
 
   while ((values_to_read > 0) && column_reader_) {
-    RETURN_NOT_OK(values_buffer_.Resize(values_to_read * sizeof(bool), false));
     if (descr_->max_definition_level() > 0) {
       RETURN_NOT_OK(def_levels_buffer_.Resize(values_to_read * sizeof(int16_t), false));
     }
     auto reader = dynamic_cast<TypedColumnReader<BooleanType>*>(column_reader_.get());
     int64_t levels_read;
     int16_t* def_levels = reinterpret_cast<int16_t*>(def_levels_buffer_.mutable_data());
-    auto values = reinterpret_cast<bool*>(values_buffer_.mutable_data());
     if (descr_->max_definition_level() == 0) {
-      int64_t values_read;
-      PARQUET_CATCH_NOT_OK(levels_read = reader->ReadBatch(
-                               values_to_read, nullptr, nullptr, values, &values_read));
-      ReadNonNullableBatch<::arrow::BooleanType, BooleanType>(values, levels_read);
+      RETURN_NOT_OK((ReadNonNullableBatch<::arrow::BooleanType, BooleanType>(
+          reader, values_to_read, &levels_read)));
     } else {
       // As per the defintion and checks for flat columns:
       // descr_->max_definition_level() == 1
       RETURN_NOT_OK((ReadNullableFlatBatch<::arrow::BooleanType, BooleanType>(
-          reader, def_levels, values, values_to_read, &levels_read)));
+          reader, def_levels, values_to_read, &levels_read)));
     }
     values_to_read -= levels_read;
     if (!column_reader_->HasNext()) { NextRowGroup(); }

--- a/src/parquet/column/column-writer-test.cc
+++ b/src/parquet/column/column-writer-test.cc
@@ -216,8 +216,7 @@ void TestPrimitiveWriter<FLBAType>::ReadColumnFully(Compression::type compressio
 }
 
 typedef ::testing::Types<Int32Type, Int64Type, Int96Type, FloatType, DoubleType,
-    BooleanType, ByteArrayType, FLBAType>
-    TestTypes;
+    BooleanType, ByteArrayType, FLBAType> TestTypes;
 
 TYPED_TEST_CASE(TestPrimitiveWriter, TestTypes);
 

--- a/src/parquet/column/reader.h
+++ b/src/parquet/column/reader.h
@@ -129,21 +129,24 @@ class PARQUET_EXPORT TypedColumnReader : public ColumnReader {
   int64_t ReadBatch(int batch_size, int16_t* def_levels, int16_t* rep_levels, T* values,
       int64_t* values_read);
 
-  // Read a batch of repetition levels, definition levels, and values from the
-  // column and leave spaces for null entries in the values buffer.
-  //
-  // In comparision to ReadBatch the length of repetition and definition levels
-  // is the same as of the number of values read.
-  //
-  // To fully exhaust a row group, you must read batches until the number of
-  // values read reaches the number of stored values according to the metadata.
-  //
-  // This function also needs memory allocated for a bitmap that indicates if
-  // the row is null or on the maximum definition level.
-  //
-  // This API is the same for both V1 and V2 of the DataPage
-  //
-  // @returns: actual number of levels read
+  /// Read a batch of repetition levels, definition levels, and values from the
+  /// column and leave spaces for null entries in the values buffer.
+  ///
+  /// In comparision to ReadBatch the length of repetition and definition levels
+  /// is the same as of the number of values read.
+  ///
+  /// To fully exhaust a row group, you must read batches until the number of
+  /// values read reaches the number of stored values according to the metadata.
+  ///
+  /// @param valid_bits Memory allocated for a bitmap that indicates if
+  ///   the row is null or on the maximum definition level. For performance
+  ///   reasons the underlying buffer should be able to store 1 bit more than
+  ///   required. If this requires an additional byte, this byte is only read
+  ///   but never written to.
+  /// @param valid_bits_offset The offset in bits of the valid_bits where the
+  ///  first relevant bit resides.
+  ///
+  /// @return actual number of levels read
   int64_t ReadBatchSpaced(int batch_size, int16_t* def_levels, int16_t* rep_levels,
       T* values, int* null_count, uint8_t* valid_bits, int64_t valid_bits_offset);
 

--- a/src/parquet/column/reader.h
+++ b/src/parquet/column/reader.h
@@ -170,8 +170,8 @@ class PARQUET_EXPORT TypedColumnReader : public ColumnReader {
   // to the def_levels.
   //
   // @returns: the number of values read into the out buffer
-  int64_t ReadValuesSpaced(int64_t batch_size, T* out,
-      int null_count, uint8_t* valid_bits, int64_t valid_bits_offset);
+  int64_t ReadValuesSpaced(int64_t batch_size, T* out, int null_count,
+      uint8_t* valid_bits, int64_t valid_bits_offset);
 
   // Map of encoding type to the respective decoder object. For example, a
   // column chunk's data pages may include both dictionary-encoded and
@@ -190,11 +190,10 @@ inline int64_t TypedColumnReader<DType>::ReadValues(int64_t batch_size, T* out) 
 }
 
 template <typename DType>
-inline int64_t TypedColumnReader<DType>::ReadValuesSpaced(int64_t batch_size,
-    T* out, int null_count, uint8_t* valid_bits,
-    int64_t valid_bits_offset) {
-  return current_decoder_->DecodeSpaced(out,
-      batch_size, null_count, valid_bits, valid_bits_offset);
+inline int64_t TypedColumnReader<DType>::ReadValuesSpaced(int64_t batch_size, T* out,
+    int null_count, uint8_t* valid_bits, int64_t valid_bits_offset) {
+  return current_decoder_->DecodeSpaced(
+      out, batch_size, null_count, valid_bits, valid_bits_offset);
 }
 
 template <typename DType>
@@ -266,7 +265,7 @@ inline int64_t TypedColumnReader<DType>::ReadBatchSpaced(int batch_size,
         throw ParquetException("Number of decoded rep / def levels did not match");
       }
     }
-    
+
     // TODO: Move this into the DefinitionLevels reader
     int null_count = 0;
     int16_t max_definition_level = descr_->max_definition_level();

--- a/src/parquet/column/reader.h
+++ b/src/parquet/column/reader.h
@@ -272,7 +272,10 @@ inline int64_t TypedColumnReader<DType>::ReadBatchSpaced(int batch_size,
     int16_t* def_levels, int16_t* rep_levels, T* values, int* null_count_out,
     uint8_t* valid_bits, int64_t valid_bits_offset) {
   // HasNext invokes ReadNewPage
-  if (!HasNext()) { return 0; }
+  if (!HasNext()) {
+    *null_count_out = 0;
+    return 0;
+  }
 
   int64_t total_values;
   // TODO(wesm): keep reading data pages until batch_size is reached, or the

--- a/src/parquet/column/scanner-test.cc
+++ b/src/parquet/column/scanner-test.cc
@@ -146,8 +146,7 @@ static int num_pages = 20;
 static int batch_size = 32;
 
 typedef ::testing::Types<Int32Type, Int64Type, Int96Type, FloatType, DoubleType,
-    ByteArrayType>
-    TestTypes;
+    ByteArrayType> TestTypes;
 
 using TestBooleanFlatScanner = TestFlatScanner<BooleanType>;
 using TestFLBAFlatScanner = TestFlatScanner<FLBAType>;

--- a/src/parquet/encodings/decoder.h
+++ b/src/parquet/encodings/decoder.h
@@ -54,8 +54,8 @@ class Decoder {
   //
   // num_values is the size of the def_levels and buffer arrays including the number of
   // null values.
-  virtual int DecodeSpaced(T* buffer,
-      int num_values, int null_count, const uint8_t* valid_bits, int64_t valid_bits_offset) {
+  virtual int DecodeSpaced(T* buffer, int num_values, int null_count,
+      const uint8_t* valid_bits, int64_t valid_bits_offset) {
     int values_to_read = num_values - null_count;
     int values_read = Decode(buffer, values_to_read);
     if (values_read != values_to_read) {
@@ -66,7 +66,9 @@ class Decoder {
     // we need to add the spacing from the back.
     int values_to_move = values_read;
     for (int i = num_values - 1; i >= 0; i--) {
-      if (::arrow::BitUtil::GetBit(valid_bits, valid_bits_offset + i))  { buffer[i] = buffer[--values_to_move]; }
+      if (::arrow::BitUtil::GetBit(valid_bits, valid_bits_offset + i)) {
+        buffer[i] = buffer[--values_to_move];
+      }
     }
     return num_values;
   }

--- a/src/parquet/encodings/dictionary-encoding.h
+++ b/src/parquet/encodings/dictionary-encoding.h
@@ -67,10 +67,11 @@ class DictionaryDecoder : public Decoder<Type> {
     num_values_ -= max_values;
     return max_values;
   }
-  
-  int DecodeSpaced(T* buffer,
-      int num_values, int null_count, const uint8_t* valid_bits, int64_t valid_bits_offset) override {
-    int decoded_values = idx_decoder_.GetBatchWithDictSpaced(dictionary_, buffer, num_values, null_count, valid_bits, valid_bits_offset);
+
+  int DecodeSpaced(T* buffer, int num_values, int null_count, const uint8_t* valid_bits,
+      int64_t valid_bits_offset) override {
+    int decoded_values = idx_decoder_.GetBatchWithDictSpaced(
+        dictionary_, buffer, num_values, null_count, valid_bits, valid_bits_offset);
     if (decoded_values != num_values) { ParquetException::EofException(); }
     return decoded_values;
   }

--- a/src/parquet/encodings/dictionary-encoding.h
+++ b/src/parquet/encodings/dictionary-encoding.h
@@ -51,7 +51,7 @@ class DictionaryDecoder : public Decoder<Type> {
   // Perform type-specific initiatialization
   void SetDict(Decoder<Type>* dictionary);
 
-  virtual void SetData(int num_values, const uint8_t* data, int len) {
+  void SetData(int num_values, const uint8_t* data, int len) override {
     num_values_ = num_values;
     if (len == 0) return;
     uint8_t bit_width = *data;
@@ -60,7 +60,7 @@ class DictionaryDecoder : public Decoder<Type> {
     idx_decoder_ = RleDecoder(data, len, bit_width);
   }
 
-  virtual int Decode(T* buffer, int max_values) {
+  int Decode(T* buffer, int max_values) override {
     max_values = std::min(max_values, num_values_);
     int decoded_values = idx_decoder_.GetBatchWithDict(dictionary_, buffer, max_values);
     if (decoded_values != max_values) { ParquetException::EofException(); }

--- a/src/parquet/encodings/dictionary-encoding.h
+++ b/src/parquet/encodings/dictionary-encoding.h
@@ -67,6 +67,13 @@ class DictionaryDecoder : public Decoder<Type> {
     num_values_ -= max_values;
     return max_values;
   }
+  
+  int DecodeSpaced(T* buffer,
+      int num_values, int null_count, const uint8_t* valid_bits, int64_t valid_bits_offset) override {
+    int decoded_values = idx_decoder_.GetBatchWithDictSpaced(dictionary_, buffer, num_values, null_count, valid_bits, valid_bits_offset);
+    if (decoded_values != num_values) { ParquetException::EofException(); }
+    return decoded_values;
+  }
 
  private:
   using Decoder<Type>::num_values_;

--- a/src/parquet/encodings/encoding-test.cc
+++ b/src/parquet/encodings/encoding-test.cc
@@ -273,7 +273,7 @@ class TestDictionaryEncoding : public TestEncodingBase<Type> {
 
     // Also test spaced decoding
     decoder.SetData(num_values_, indices->data(), indices->size());
-    std::vector<uint8_t> valid_bits(BitUtil::RoundUpNumBytes(num_values_), 255);
+    std::vector<uint8_t> valid_bits(BitUtil::RoundUpNumBytes(num_values_) + 1, 255);
     values_decoded =
         decoder.DecodeSpaced(decode_buf_, num_values_, 0, valid_bits.data(), 0);
     ASSERT_EQ(num_values_, values_decoded);

--- a/src/parquet/encodings/encoding-test.cc
+++ b/src/parquet/encodings/encoding-test.cc
@@ -274,7 +274,8 @@ class TestDictionaryEncoding : public TestEncodingBase<Type> {
     // Also test spaced decoding
     decoder.SetData(num_values_, indices->data(), indices->size());
     std::vector<uint8_t> valid_bits(BitUtil::RoundUpNumBytes(num_values_), 255);
-    values_decoded = decoder.DecodeSpaced(decode_buf_, num_values_, 0, valid_bits.data(), 0);
+    values_decoded =
+        decoder.DecodeSpaced(decode_buf_, num_values_, 0, valid_bits.data(), 0);
     ASSERT_EQ(num_values_, values_decoded);
     VerifyResults<T>(decode_buf_, draws_, num_values_);
   }

--- a/src/parquet/encodings/encoding-test.cc
+++ b/src/parquet/encodings/encoding-test.cc
@@ -237,8 +237,7 @@ TYPED_TEST(TestPlainEncoding, BasicRoundTrip) {
 // Dictionary encoding tests
 
 typedef ::testing::Types<Int32Type, Int64Type, Int96Type, FloatType, DoubleType,
-    ByteArrayType, FLBAType>
-    DictEncodedTypes;
+    ByteArrayType, FLBAType> DictEncodedTypes;
 
 template <typename Type>
 class TestDictionaryEncoding : public TestEncodingBase<Type> {

--- a/src/parquet/encodings/encoding-test.cc
+++ b/src/parquet/encodings/encoding-test.cc
@@ -270,6 +270,13 @@ class TestDictionaryEncoding : public TestEncodingBase<Type> {
     // values' data is owned by a buffer inside the DictionaryEncoder. We
     // should revisit when data lifetime is reviewed more generally.
     VerifyResults<T>(decode_buf_, draws_, num_values_);
+
+    // Also test spaced decoding
+    decoder.SetData(num_values_, indices->data(), indices->size());
+    std::vector<uint8_t> valid_bits(BitUtil::RoundUpNumBytes(num_values_), 255);
+    values_decoded = decoder.DecodeSpaced(decode_buf_, num_values_, 0, valid_bits.data(), 0);
+    ASSERT_EQ(num_values_, values_decoded);
+    VerifyResults<T>(decode_buf_, draws_, num_values_);
   }
 
  protected:

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -106,8 +106,7 @@ class TestSerialize : public PrimitiveTypedTest<TestType> {
 };
 
 typedef ::testing::Types<Int32Type, Int64Type, Int96Type, FloatType, DoubleType,
-    BooleanType, ByteArrayType, FLBAType>
-    TestTypes;
+    BooleanType, ByteArrayType, FLBAType> TestTypes;
 
 TYPED_TEST_CASE(TestSerialize, TestTypes);
 

--- a/src/parquet/thrift/util.h
+++ b/src/parquet/thrift/util.h
@@ -99,8 +99,7 @@ inline void DeserializeThriftMsg(const uint8_t* buf, uint32_t* len, T* deseriali
   boost::shared_ptr<apache::thrift::transport::TMemoryBuffer> tmem_transport(
       new apache::thrift::transport::TMemoryBuffer(const_cast<uint8_t*>(buf), *len));
   apache::thrift::protocol::TCompactProtocolFactoryT<
-      apache::thrift::transport::TMemoryBuffer>
-      tproto_factory;
+      apache::thrift::transport::TMemoryBuffer> tproto_factory;
   boost::shared_ptr<apache::thrift::protocol::TProtocol> tproto =
       tproto_factory.getProtocol(tmem_transport);
   try {
@@ -122,8 +121,7 @@ inline void SerializeThriftMsg(T* obj, uint32_t len, OutputStream* out) {
   boost::shared_ptr<apache::thrift::transport::TMemoryBuffer> mem_buffer(
       new apache::thrift::transport::TMemoryBuffer(len));
   apache::thrift::protocol::TCompactProtocolFactoryT<
-      apache::thrift::transport::TMemoryBuffer>
-      tproto_factory;
+      apache::thrift::transport::TMemoryBuffer> tproto_factory;
   boost::shared_ptr<apache::thrift::protocol::TProtocol> tproto =
       tproto_factory.getProtocol(mem_buffer);
   try {

--- a/src/parquet/util/bit-util.h
+++ b/src/parquet/util/bit-util.h
@@ -34,6 +34,11 @@
 
 namespace parquet {
 
+#define INIT_BITSET(valid_bits_vector, valid_bits_index) \
+  int byte_offset = valid_bits_index / 8; \
+  int bit_offset = valid_bits_index % 8; \
+  uint8_t bitset = valid_bits_vector[byte_offset];
+
 #define READ_NEXT_BITSET(valid_bits_vector)  \
   bit_offset++;                              \
   if (bit_offset == 8) {                     \

--- a/src/parquet/util/bit-util.h
+++ b/src/parquet/util/bit-util.h
@@ -34,6 +34,14 @@
 
 namespace parquet {
 
+#define READ_NEXT_BITSET(valid_bits_vector)  \
+  bit_offset++;                              \
+  if (bit_offset == 8) {                     \
+    bit_offset = 0;                          \
+    byte_offset++;                           \
+    bitset = valid_bits_vector[byte_offset]; \
+  }
+
 // TODO(wesm): The source from Impala was depending on boost::make_unsigned
 //
 // We add a partial stub implementation here

--- a/src/parquet/util/rle-encoding.h
+++ b/src/parquet/util/rle-encoding.h
@@ -355,12 +355,7 @@ inline int RleDecoder::GetBatchWithDictSpaced(const Vector<T>& dictionary, T* va
 
   while (values_read < batch_size) {
     bool is_valid = (bitset & (1 << bit_offset));
-    bit_offset++;
-    if (bit_offset == 8) {
-      bit_offset = 0;
-      byte_offset++;
-      bitset = valid_bits[byte_offset];
-    }
+    READ_NEXT_BITSET(valid_bits);
 
     if (is_valid) {
       if ((repeat_count_ == 0) && (literal_count_ == 0)) {
@@ -380,12 +375,7 @@ inline int RleDecoder::GetBatchWithDictSpaced(const Vector<T>& dictionary, T* va
           }
           repeat_batch++;
 
-          bit_offset++;
-          if (bit_offset == 8) {
-            bit_offset = 0;
-            byte_offset++;
-            bitset = valid_bits[byte_offset];
-          }
+          READ_NEXT_BITSET(valid_bits);
         }
         std::fill(values + values_read, values + values_read + repeat_batch, value);
         values_read += repeat_batch;
@@ -394,7 +384,7 @@ inline int RleDecoder::GetBatchWithDictSpaced(const Vector<T>& dictionary, T* va
             batch_size - values_read - remaining_nulls, static_cast<int>(literal_count_));
 
         // Decode the literals
-        const int kBufferSize = 1024;
+        constexpr int kBufferSize = 1024;
         int indices[kBufferSize];
         literal_batch = std::min(literal_batch, kBufferSize);
         int actual_read = bit_reader_.GetBatch(bit_width_, &indices[0], literal_batch);
@@ -414,12 +404,7 @@ inline int RleDecoder::GetBatchWithDictSpaced(const Vector<T>& dictionary, T* va
             skipped++;
           }
 
-          bit_offset++;
-          if (bit_offset == 8) {
-            bit_offset = 0;
-            byte_offset++;
-            bitset = valid_bits[byte_offset];
-          }
+          READ_NEXT_BITSET(valid_bits);
         }
         literal_count_ -= literal_batch;
         values_read += literal_batch + skipped;

--- a/src/parquet/util/rle-encoding.h
+++ b/src/parquet/util/rle-encoding.h
@@ -351,9 +351,6 @@ inline int RleDecoder::GetBatchWithDictSpaced(const Vector<T>& dictionary, T* va
   DCHECK_GE(bit_width_, 0);
   int values_read = 0;
   int remaining_nulls = null_count;
-  int byte_offset = valid_bits_offset / 8;
-  int bit_offset = valid_bits_offset % 8;
-  uint8_t bitset = valid_bits[byte_offset];
 
   while (values_read < batch_size) {
     if (::arrow::BitUtil::GetBit(valid_bits, valid_bits_offset + values_read)) {

--- a/src/parquet/util/rle-encoding.h
+++ b/src/parquet/util/rle-encoding.h
@@ -349,9 +349,7 @@ inline int RleDecoder::GetBatchWithDictSpaced(const Vector<T>& dictionary, T* va
   DCHECK_GE(bit_width_, 0);
   int values_read = 0;
   int remaining_nulls = null_count;
-  int byte_offset = valid_bits_offset / 8;
-  int bit_offset = valid_bits_offset % 8;
-  uint8_t bitset = valid_bits[byte_offset];
+  INIT_BITSET(valid_bits, valid_bits_offset);
 
   while (values_read < batch_size) {
     bool is_valid = (bitset & (1 << bit_offset));

--- a/src/parquet/util/rle-encoding.h
+++ b/src/parquet/util/rle-encoding.h
@@ -23,8 +23,6 @@
 #include <algorithm>
 #include <math.h>
 
-#include <arrow/util/bit-util.h>
-
 #include "parquet/util/bit-stream-utils.inline.h"
 #include "parquet/util/bit-util.h"
 #include "parquet/util/compiler-util.h"

--- a/src/parquet/util/test-common.h
+++ b/src/parquet/util/test-common.h
@@ -32,8 +32,7 @@ namespace parquet {
 namespace test {
 
 typedef ::testing::Types<BooleanType, Int32Type, Int64Type, Int96Type, FloatType,
-    DoubleType, ByteArrayType, FLBAType>
-    ParquetTypes;
+    DoubleType, ByteArrayType, FLBAType> ParquetTypes;
 
 template <typename T>
 static inline void assert_vector_equal(const vector<T>& left, const vector<T>& right) {


### PR DESCRIPTION
Old:

```
In [3]: import pyarrow.io as paio
   ...: import pyarrow.parquet as pq
   ...:
   ...: with open('yellow_tripdata_2016-01.parquet', 'r') as f:
   ...:     buf = f.read()
   ...: buf = paio.buffer_from_bytes(buf)
   ...:
   ...: def read_parquet():
   ...:   reader = paio.BufferReader(buf)
   ...:   df = pq.read_table(reader)
   ...:
   ...: %timeit read_parquet()
   ...:
1 loop, best of 3: 1.21 s per loop
```

New:

```
In [1]: import pyarrow.io as paio
   ...: import pyarrow.parquet as pq
   ...:
   ...: with open('yellow_tripdata_2016-01.parquet', 'r') as f:
   ...:     buf = f.read()
   ...: buf = paio.buffer_from_bytes(buf)
   ...:
   ...: def read_parquet():
   ...:   reader = paio.BufferReader(buf)
   ...:   df = pq.read_table(reader)
   ...:
   ...: %timeit read_parquet()
   ...:
1 loop, best of 3: 906 ms per loop
```

Arrow->Pandas conversion for comparison:

```
In [5]: %timeit df.to_pandas()
1 loop, best of 3: 567 ms per loop
```

All benchmarks were done on a single core CPU

I have to add a better test coverage before this can go in. There is still some room for future improvements that won't be done in this PR:
 * `DefinitionLevelsToBitmap` should be done in the DefinitionLevelsDecoder
 * `GetBatchWithDictSpaced` is something for a vectorization/bitmap ninja.