### PR TITLE
PARQUET-830: Add parquet::arrow::OpenFile with additional properties and metadata args

### DIFF
--- a/src/parquet/arrow/reader.h
+++ b/src/parquet/arrow/reader.h
@@ -139,6 +139,13 @@ class PARQUET_EXPORT FlatColumnReader {
 
 // Helper function to create a file reader from an implementation of an Arrow
 // readable file
+//
+// metadata : separately-computed file metadata, can be nullptr
+PARQUET_EXPORT
+::arrow::Status OpenFile(const std::shared_ptr<::arrow::io::ReadableFileInterface>& file,
+    ::arrow::MemoryPool* allocator, const ReaderProperties& properties,
+    const std::shared_ptr<FileMetaData>& metadata, std::unique_ptr<FileReader>* reader);
+
 PARQUET_EXPORT
 ::arrow::Status OpenFile(const std::shared_ptr<::arrow::io::ReadableFileInterface>& file,
     ::arrow::MemoryPool* allocator, std::unique_ptr<FileReader>* reader);


### PR DESCRIPTION
I also slightly refactored the test suite to use OpenFile rather than using the `ParquetFileReader` ctor directly (`OpenFile` wasn't being used in the test suite). 

Needed for ARROW-471