### PR TITLE
PARQUET-836: Bugfix + testcase for column subsetting in arrow::FileReader::ReadFlatTable

### DIFF
--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -222,7 +222,7 @@ Status FileReader::Impl::ReadFlatTable(
   auto ReadColumn = [&indices, &schema, &columns, this](int i) {
     std::shared_ptr<Array> array;
     RETURN_NOT_OK(ReadFlatColumn(indices[i], &array));
-    columns[i] = std::make_shared<Column>(schema->field(indices[i]), array);
+    columns[i] = std::make_shared<Column>(schema->field(i), array);
     return Status::OK();
   };
 

--- a/src/parquet/arrow/test-util.h
+++ b/src/parquet/arrow/test-util.h
@@ -90,9 +90,10 @@ typename std::enable_if<is_arrow_bool<ArrowType>::value, Status>::type NonNullAr
 // This helper function only supports (size/2) nulls.
 template <typename ArrowType>
 typename std::enable_if<is_arrow_float<ArrowType>::value, Status>::type NullableArray(
-    size_t size, size_t num_nulls, std::shared_ptr<Array>* out) {
+    size_t size, size_t num_nulls, uint32_t seed, std::shared_ptr<Array>* out) {
   std::vector<typename ArrowType::c_type> values;
-  ::arrow::test::random_real<typename ArrowType::c_type>(size, 0, 0, 1, &values);
+  ::arrow::test::random_real<typename ArrowType::c_type>(
+      size, seed, -1e10, 1e10, &values);
   std::vector<uint8_t> valid_bytes(size, 1);
 
   for (size_t i = 0; i < num_nulls; i++) {
@@ -108,8 +109,11 @@ typename std::enable_if<is_arrow_float<ArrowType>::value, Status>::type Nullable
 // This helper function only supports (size/2) nulls.
 template <typename ArrowType>
 typename std::enable_if<is_arrow_int<ArrowType>::value, Status>::type NullableArray(
-    size_t size, size_t num_nulls, std::shared_ptr<Array>* out) {
+    size_t size, size_t num_nulls, uint32_t seed, std::shared_ptr<Array>* out) {
   std::vector<typename ArrowType::c_type> values;
+
+  // Seed is random in Arrow right now
+  (void)seed;
   ::arrow::test::randint<typename ArrowType::c_type>(size, 0, 64, &values);
   std::vector<uint8_t> valid_bytes(size, 1);
 
@@ -127,7 +131,8 @@ typename std::enable_if<is_arrow_int<ArrowType>::value, Status>::type NullableAr
 template <typename ArrowType>
 typename std::enable_if<
     is_arrow_string<ArrowType>::value || is_arrow_binary<ArrowType>::value, Status>::type
-NullableArray(size_t size, size_t num_nulls, std::shared_ptr<::arrow::Array>* out) {
+NullableArray(
+    size_t size, size_t num_nulls, uint32_t seed, std::shared_ptr<::arrow::Array>* out) {
   std::vector<uint8_t> valid_bytes(size, 1);
 
   for (size_t i = 0; i < num_nulls; i++) {
@@ -136,8 +141,16 @@ NullableArray(size_t size, size_t num_nulls, std::shared_ptr<::arrow::Array>* ou
 
   using BuilderType = typename ::arrow::TypeTraits<ArrowType>::BuilderType;
   BuilderType builder(::arrow::default_memory_pool(), std::make_shared<ArrowType>());
+
+  const int kBufferSize = 10;
+  uint8_t buffer[kBufferSize];
   for (size_t i = 0; i < size; i++) {
-    builder.Append("test-string");
+    if (!valid_bytes[i]) {
+      builder.AppendNull();
+    } else {
+      ::arrow::test::random_bytes(kBufferSize, seed + i, buffer);
+      builder.Append(buffer, kBufferSize);
+    }
   }
   return builder.Finish(out);
 }
@@ -145,8 +158,12 @@ NullableArray(size_t size, size_t num_nulls, std::shared_ptr<::arrow::Array>* ou
 // This helper function only supports (size/2) nulls yet.
 template <class ArrowType>
 typename std::enable_if<is_arrow_bool<ArrowType>::value, Status>::type NullableArray(
-    size_t size, size_t num_nulls, std::shared_ptr<Array>* out) {
+    size_t size, size_t num_nulls, uint32_t seed, std::shared_ptr<Array>* out) {
   std::vector<uint8_t> values;
+
+  // Seed is random in Arrow right now
+  (void)seed;
+
   ::arrow::test::randint<uint8_t>(size, 0, 1, &values);
   std::vector<uint8_t> valid_bytes(size, 1);
 


### PR DESCRIPTION
Also adds an option to set the random seed when generating data for the Arrow test cases