### PR TITLE
PARQUET-691: Write ColumnChunk metadata after chunk is complete

### DIFF
--- a/src/parquet/file/metadata.cc
+++ b/src/parquet/file/metadata.cc
@@ -501,6 +501,10 @@ class ColumnChunkMetaDataBuilder::ColumnChunkMetaDataBuilderImpl {
     column_chunk_->meta_data.__set_encodings(thrift_encodings);
   }
 
+  void WriteTo(OutputStream* sink) {
+    SerializeThriftMsg(column_chunk_, sizeof(format::ColumnChunk), sink);
+  }
+
   const ColumnDescriptor* descr() const { return column_; }
 
  private:
@@ -534,6 +538,10 @@ void ColumnChunkMetaDataBuilder::Finish(int64_t num_values,
     bool dictionary_fallback) {
   impl_->Finish(num_values, dictionary_page_offset, index_page_offset, data_page_offset,
       compressed_size, uncompressed_size, has_dictionary, dictionary_fallback);
+}
+
+void ColumnChunkMetaDataBuilder::WriteTo(OutputStream* sink) {
+  impl_->WriteTo(sink);
 }
 
 const ColumnDescriptor* ColumnChunkMetaDataBuilder::descr() const {

--- a/src/parquet/file/metadata.h
+++ b/src/parquet/file/metadata.h
@@ -174,6 +174,9 @@ class PARQUET_EXPORT ColumnChunkMetaDataBuilder {
       int64_t index_page_offset, int64_t data_page_offset, int64_t compressed_size,
       int64_t uncompressed_size, bool has_dictionary, bool dictionary_fallback);
 
+  // For writing metadata at end of column chunk
+  void WriteTo(OutputStream* sink);
+
  private:
   explicit ColumnChunkMetaDataBuilder(const std::shared_ptr<WriterProperties>& props,
       const ColumnDescriptor* column, uint8_t* contents);

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -81,9 +81,6 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
   int num_columns() const override;
   int64_t num_rows() const override;
 
-  // TODO: PARQUET-579
-  // void WriteRowGroupStatitics() override;
-
   ColumnWriter* NextColumn() override;
   void Close() override;
 

--- a/src/parquet/thrift/util.h
+++ b/src/parquet/thrift/util.h
@@ -118,7 +118,7 @@ inline void DeserializeThriftMsg(const uint8_t* buf, uint32_t* len, T* deseriali
 // The arguments are the object to be serialized and
 // the expected size of the serialized object
 template <class T>
-inline void SerializeThriftMsg(T* obj, uint32_t len, OutputStream* out) {
+inline int64_t SerializeThriftMsg(T* obj, uint32_t len, OutputStream* out) {
   boost::shared_ptr<apache::thrift::transport::TMemoryBuffer> mem_buffer(
       new apache::thrift::transport::TMemoryBuffer(len));
   apache::thrift::protocol::TCompactProtocolFactoryT<
@@ -139,6 +139,7 @@ inline void SerializeThriftMsg(T* obj, uint32_t len, OutputStream* out) {
   uint32_t out_length;
   mem_buffer->getBuffer(&out_buffer, &out_length);
   out->Write(out_buffer, out_length);
+  return out_length;
 }
 
 }  // namespace parquet


### PR DESCRIPTION
See corresponding logic in Impala's Parquet implementation: https://github.com/apache/incubator-impala/blob/master/be/src/exec/hdfs-parquet-table-writer.cc#L973