### PR TITLE
PARQUET-847: Fix CMake compilation error on Debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,7 +504,7 @@ set(LIBPARQUET_LINK_LIBS
 )
 
 set(BUNDLED_STATIC_LIBS
-  parquet_thrift
+  parquet_thrift_static
   brotlistatic_dec
   brotlistatic_enc
   brotlistatic_common
@@ -579,7 +579,14 @@ add_subdirectory(src/parquet/util)
 
 # Ensure that thrift compilation is done before using its generated headers
 # in parquet code.
-add_dependencies(parquet_objlib parquet_thrift)
+
+if (PARQUET_BUILD_SHARED)
+  add_dependencies(parquet_objlib parquet_thrift_shared)
+endif()
+
+if (PARQUET_BUILD_STATIC)
+  add_dependencies(parquet_objlib parquet_thrift_static)
+endif()
 
 add_subdirectory(benchmarks)
 add_subdirectory(examples)

--- a/src/parquet/thrift/CMakeLists.txt
+++ b/src/parquet/thrift/CMakeLists.txt
@@ -22,13 +22,29 @@ set(THRIFT_SRCS
 set_source_files_properties(parquet_types.cpp PROPERTIES
   COMPILE_FLAGS -Wno-unused-variable)
 
-add_library(parquet_thrift STATIC
-  ${THRIFT_SRCS}
-)
-
-set_target_properties(parquet_thrift
+if (PARQUET_BUILD_SHARED)
+  add_library(parquet_thrift_shared SHARED
+    ${THRIFT_SRCS}
+  )
+  
+  set_target_properties(parquet_thrift_shared
   PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY "${BUILD_OUTPUT_ROOT_DIRECTORY}")
+endif()
+
+if (PARQUET_BUILD_STATIC)
+  add_library(parquet_thrift_static STATIC
+    ${THRIFT_SRCS}
+  )
+  
+  set_target_properties(parquet_thrift_static
+  PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${BUILD_OUTPUT_ROOT_DIRECTORY}")
+  
+endif()
+  
+
+  
 set_source_files_properties(${THRIFT_SRCS} PROPERTIES GENERATED TRUE)
 
 # List of thrift output targets


### PR DESCRIPTION
this fix a problem during the linking of thrift library for shared version of parquet