### PR TITLE
PARQUET-862: Provide defaut cache size values

### DIFF
--- a/src/parquet/util/cpu-info.cc
+++ b/src/parquet/util/cpu-info.cc
@@ -130,10 +130,17 @@ void CpuInfo::Init() {
     cache_sizes_[i] = data[i];
   }
 #else
+#ifndef _SC_LEVEL1_DCACHE_SIZE
+  // Provide reasonable default values if no info
+  cache_sizes_[0] = 32 * 1024;   // Level 1: 32k
+  cache_sizes_[1] = 256 * 1024;  // Level 2: 256k
+  cache_sizes_[2] = 3072 * 1024; // Level 3: 3M
+#else
   // Call sysconf to query for the cache sizes
   cache_sizes_[0] = sysconf(_SC_LEVEL1_DCACHE_SIZE);
   cache_sizes_[1] = sysconf(_SC_LEVEL2_CACHE_SIZE);
   cache_sizes_[2] = sysconf(_SC_LEVEL3_CACHE_SIZE);
+#endif
 #endif
 
   if (max_mhz != 0) {


### PR DESCRIPTION
This patch allows to port parquet-cpp on non-intel architectures
and/or linux/unix flavors where CPU info is different or not
available. Tested on Alpinelinux (musl libc).