### PR TITLE
Upgrade thrift revision number to 0.10.0

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -18,7 +18,7 @@
 set(GTEST_VERSION "1.7.0")
 set(GBENCHMARK_VERSION "1.0.0")
 set(SNAPPY_VERSION "1.1.3")
-set(THRIFT_VERSION "0.9.1")
+set(THRIFT_VERSION "0.10.0")
 
 # Brotli 0.5.2 does not install headers/libraries yet, but 0.6.0.dev does
 set(BROTLI_VERSION "5db62dcc9d386579609540cdf8869e95ad334bbd")

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -42,9 +42,6 @@ set(EP_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${UPPERCASE_BUILD_TYPE}} -fPIC"
 find_package(Thrift)
 
 if (NOT THRIFT_FOUND)
-  if (APPLE)
-      message(FATAL_ERROR "thrift compilation under OSX is not currently supported.")
-  endif()
 
   set(THRIFT_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/thrift_ep/src/thrift_ep-install")
   set(THRIFT_HOME "${THRIFT_PREFIX}")

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -49,34 +49,40 @@ if (NOT THRIFT_FOUND)
   set(THRIFT_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/thrift_ep/src/thrift_ep-install")
   set(THRIFT_HOME "${THRIFT_PREFIX}")
   set(THRIFT_INCLUDE_DIR "${THRIFT_PREFIX}/include")
-  set(THRIFT_STATIC_LIB "${THRIFT_PREFIX}/lib/libthrift.a")
+  IF (${UPPERCASE_BUILD_TYPE} STREQUAL "DEBUG")
+    set(THRIFT_STATIC_LIB "${THRIFT_PREFIX}/lib/libthriftd.a")
+  ELSE()
+    set(THRIFT_STATIC_LIB "${THRIFT_PREFIX}/lib/libthrift.a")
+  ENDIF()
   set(THRIFT_COMPILER "${THRIFT_PREFIX}/bin/thrift")
   set(THRIFT_VENDORED 1)
-  set(THRIFT_CONFIGURE_COMMAND
-      ./configure "CFLAGS=${EP_C_FLAGS}" "CXXFLAGS=${EP_CXX_FLAGS}" --without-qt4 --without-c_glib --without-csharp --without-java --without-erlang --without-nodejs --without-lua --without-python --without-perl --without-php --without-php_extension --without-ruby --without-haskell --without-go --without-d --with-cpp "--prefix=${THRIFT_PREFIX}")
+  set(THRIFT_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                        "-DCMAKE_CXX_FLAGS=${EP_CXX_FLAGS}"
+                        "-DCMAKE_C_FLAGS=${EX_C_FLAGS}"
+                        "-DCMAKE_INSTALL_PREFIX=${THRIFT_PREFIX}"
+                        "-DCMAKE_INSTALL_RPATH=${THRIFT_PREFIX}/lib"
+                        "-DCMAKE_INSTALL_LIBDIR=lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+                        "-DBUILD_SHARED_LIBS=OFF"
+                        "-DBUILD_TESTING=OFF"
+                        "-DWITH_QT4=OFF"
+                        "-DWITH_C_GLIB=OFF"
+                        "-DWITH_JAVA=OFF"
+                        "-DWITH_PYTHON=OFF"
+                        "-DWITH_CPP=ON"
+                        "-DWITH_STATIC_LIB=ON"
+                        )
 
   if (CMAKE_VERSION VERSION_GREATER "3.2")
     # BUILD_BYPRODUCTS is a 3.2+ feature
     ExternalProject_Add(thrift_ep
-      CONFIGURE_COMMAND ${THRIFT_CONFIGURE_COMMAND}
-      BUILD_IN_SOURCE 1
-      # This is needed for 0.9.1 and can be removed for 0.9.3 again
-      BUILD_COMMAND make clean
-      INSTALL_COMMAND make install
-      INSTALL_DIR ${THRIFT_PREFIX}
       URL "http://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz"
       BUILD_BYPRODUCTS "${THRIFT_STATIC_LIB}" "${THRIFT_COMPILER}"
-      )
+      CMAKE_ARGS ${THRIFT_CMAKE_ARGS})
   else()
     ExternalProject_Add(thrift_ep
-      CONFIGURE_COMMAND ${THRIFT_CONFIGURE_COMMAND}
-      BUILD_IN_SOURCE 1
-      # This is needed for 0.9.1 and can be removed for 0.9.3 again
-      BUILD_COMMAND make clean
-      INSTALL_COMMAND make install
-      INSTALL_DIR ${THRIFT_PREFIX}
       URL "http://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz"
-      )
+      BUILD_BYPRODUCTS "${THRIFT_STATIC_LIB}" "${THRIFT_COMPILER}"
+      CMAKE_ARGS ${THRIFT_CMAKE_ARGS})
   endif()
     set(THRIFT_VENDORED 1)
 else()

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -61,7 +61,6 @@ if (NOT THRIFT_FOUND)
                         "-DCMAKE_C_FLAGS=${EX_C_FLAGS}"
                         "-DCMAKE_INSTALL_PREFIX=${THRIFT_PREFIX}"
                         "-DCMAKE_INSTALL_RPATH=${THRIFT_PREFIX}/lib"
-                        "-DCMAKE_INSTALL_LIBDIR=lib/${CMAKE_LIBRARY_ARCHITECTURE}"
                         "-DBUILD_SHARED_LIBS=OFF"
                         "-DBUILD_TESTING=OFF"
                         "-DWITH_QT4=OFF"

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -77,7 +77,6 @@ if (NOT THRIFT_FOUND)
   else()
     ExternalProject_Add(thrift_ep
       URL "http://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz"
-      BUILD_BYPRODUCTS "${THRIFT_STATIC_LIB}" "${THRIFT_COMPILER}"
       CMAKE_ARGS ${THRIFT_CMAKE_ARGS})
   endif()
     set(THRIFT_VENDORED 1)


### PR DESCRIPTION
Default thrift revision is 0.9.1 which gives the following compilation
error with gcc 6 (I am using 6.2.0)

src/generate/t_java_generator.cc:2830:14: error: operands to ?: have
different types ‘bool’ and ‘std::basic_ostream<char>’
        first ? first = false : indent(f_service_) << "else ";
                ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Upgrading to the latest version with the same major
number, 0.9.3, yields the compilation error below. SSLV3
has been deprecated because of security issues (see e.g.
                http://disablessl3.com/)

src/thrift/transport/TSSLSocket.cpp: In constructor 'apache::thrift::transport::SSLContext::SSLContext(
  const apache::thrift::transport::SSLProtocol&)': src/thrift/transport/TSSLSocket.cpp:143:37: error: 'SSLv3_method' was not declared in this scope
ctx_ = SSL_CTX_new(SSLv3_method());
^
Makefile:1280 : la recette pour la cible « src/

Upgrading to 0.10.0 works  fine