### PR TITLE
PARQUET-849: Upgrade to Thrift 0.10 in thirdparty toolchain, build Thrift in Travis CI on OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
     ON)
   set(PARQUET_ARROW_LINKAGE "shared" CACHE STRING
     "Libraries to link for Apache Arrow. static|shared (default shared)")
+  set(PARQUET_CXXFLAGS "" CACHE STRING
+    "Compiler flags to use when compiling Parquet")
   option(PARQUET_USE_SSE
     "Build with SSE4 optimizations"
     OFF)
@@ -333,7 +335,7 @@ endif ()
 
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -fno-strict-aliasing")
+SET(CMAKE_CXX_FLAGS "${PARQUET_CXXFLAGS} ${CMAKE_CXX_FLAGS} -std=c++11 -Wall -fno-strict-aliasing")
 
 if (PARQUET_USE_SSE)
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")

--- a/ci/before_script_travis.sh
+++ b/ci/before_script_travis.sh
@@ -14,7 +14,7 @@
 
 if [ $TRAVIS_OS_NAME == "osx" ]; then
   brew update > /dev/null
-  brew install thrift
+  brew install boost
 else
   # Use a C++11 compiler on Linux
   export CC="gcc-4.9"

--- a/ci/before_script_travis.sh
+++ b/ci/before_script_travis.sh
@@ -24,7 +24,7 @@ fi
 export PARQUET_TEST_DATA=$TRAVIS_BUILD_DIR/data
 
 if [ $TRAVIS_OS_NAME == "linux" ]; then
-    cmake -DCMAKE_CXX_FLAGS="-Werror" \
+    cmake -DPARQUET_CXXFLAGS=-Werror \
           -DPARQUET_TEST_MEMCHECK=ON \
           -DPARQUET_BUILD_BENCHMARKS=ON \
           -DPARQUET_ARROW=ON \
@@ -32,7 +32,7 @@ if [ $TRAVIS_OS_NAME == "linux" ]; then
           -DPARQUET_GENERATE_COVERAGE=1 \
           $TRAVIS_BUILD_DIR
 else
-    cmake -DCMAKE_CXX_FLAGS="-Werror" \
+    cmake -DPARQUET_CXXFLAGS=-Werror \
           -DPARQUET_ARROW=ON \
           -DPARQUET_ARROW_LINKAGE=static \
           $TRAVIS_BUILD_DIR

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -18,7 +18,7 @@
 set(GTEST_VERSION "1.7.0")
 set(GBENCHMARK_VERSION "1.0.0")
 set(SNAPPY_VERSION "1.1.3")
-set(THRIFT_VERSION "0.9.1")
+set(THRIFT_VERSION "0.10.0")
 
 # Brotli 0.5.2 does not install headers/libraries yet, but 0.6.0.dev does
 set(BROTLI_VERSION "5db62dcc9d386579609540cdf8869e95ad334bbd")

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -77,7 +77,7 @@ if (NOT THRIFT_FOUND)
   set(THRIFT_VENDORED 1)
   set(THRIFT_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                         "-DCMAKE_CXX_FLAGS=${EP_CXX_FLAGS}"
-                        "-DCMAKE_C_FLAGS=${EX_C_FLAGS}"
+                        "-DCMAKE_C_FLAGS=${EP_C_FLAGS}"
                         "-DCMAKE_INSTALL_PREFIX=${THRIFT_PREFIX}"
                         "-DCMAKE_INSTALL_RPATH=${THRIFT_PREFIX}/lib"
                         "-DBUILD_SHARED_LIBS=OFF"

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -83,7 +83,6 @@ if (NOT THRIFT_FOUND)
                         "-DCMAKE_C_FLAGS=${EX_C_FLAGS}"
                         "-DCMAKE_INSTALL_PREFIX=${THRIFT_PREFIX}"
                         "-DCMAKE_INSTALL_RPATH=${THRIFT_PREFIX}/lib"
-                        "-DCMAKE_INSTALL_LIBDIR=lib/${CMAKE_LIBRARY_ARCHITECTURE}"
                         "-DBUILD_SHARED_LIBS=OFF"
                         "-DBUILD_TESTING=OFF"
                         "-DWITH_QT4=OFF"

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -99,7 +99,6 @@ if (NOT THRIFT_FOUND)
   else()
     ExternalProject_Add(thrift_ep
       URL "http://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz"
-      BUILD_BYPRODUCTS "${THRIFT_STATIC_LIB}" "${THRIFT_COMPILER}"
       CMAKE_ARGS ${THRIFT_CMAKE_ARGS})
   endif()
     set(THRIFT_VENDORED 1)

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -64,9 +64,6 @@ set(EP_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${UPPERCASE_BUILD_TYPE}} -fPIC"
 find_package(Thrift)
 
 if (NOT THRIFT_FOUND)
-  if (APPLE)
-      message(FATAL_ERROR "thrift compilation under OSX is not currently supported.")
-  endif()
 
   set(THRIFT_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/thrift_ep/src/thrift_ep-install")
   set(THRIFT_HOME "${THRIFT_PREFIX}")

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -71,34 +71,40 @@ if (NOT THRIFT_FOUND)
   set(THRIFT_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/thrift_ep/src/thrift_ep-install")
   set(THRIFT_HOME "${THRIFT_PREFIX}")
   set(THRIFT_INCLUDE_DIR "${THRIFT_PREFIX}/include")
-  set(THRIFT_STATIC_LIB "${THRIFT_PREFIX}/lib/libthrift.a")
+  IF (${UPPERCASE_BUILD_TYPE} STREQUAL "DEBUG")
+    set(THRIFT_STATIC_LIB "${THRIFT_PREFIX}/lib/libthriftd.a")
+  ELSE()
+    set(THRIFT_STATIC_LIB "${THRIFT_PREFIX}/lib/libthrift.a")
+  ENDIF()
   set(THRIFT_COMPILER "${THRIFT_PREFIX}/bin/thrift")
   set(THRIFT_VENDORED 1)
-  set(THRIFT_CONFIGURE_COMMAND
-      ./configure "CFLAGS=${EP_C_FLAGS}" "CXXFLAGS=${EP_CXX_FLAGS}" --without-qt4 --without-c_glib --without-csharp --without-java --without-erlang --without-nodejs --without-lua --without-python --without-perl --without-php --without-php_extension --without-ruby --without-haskell --without-go --without-d --with-cpp "--prefix=${THRIFT_PREFIX}")
+  set(THRIFT_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                        "-DCMAKE_CXX_FLAGS=${EP_CXX_FLAGS}"
+                        "-DCMAKE_C_FLAGS=${EX_C_FLAGS}"
+                        "-DCMAKE_INSTALL_PREFIX=${THRIFT_PREFIX}"
+                        "-DCMAKE_INSTALL_RPATH=${THRIFT_PREFIX}/lib"
+                        "-DCMAKE_INSTALL_LIBDIR=lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+                        "-DBUILD_SHARED_LIBS=OFF"
+                        "-DBUILD_TESTING=OFF"
+                        "-DWITH_QT4=OFF"
+                        "-DWITH_C_GLIB=OFF"
+                        "-DWITH_JAVA=OFF"
+                        "-DWITH_PYTHON=OFF"
+                        "-DWITH_CPP=ON"
+                        "-DWITH_STATIC_LIB=ON"
+                        )
 
   if (CMAKE_VERSION VERSION_GREATER "3.2")
     # BUILD_BYPRODUCTS is a 3.2+ feature
     ExternalProject_Add(thrift_ep
-      CONFIGURE_COMMAND ${THRIFT_CONFIGURE_COMMAND}
-      BUILD_IN_SOURCE 1
-      # This is needed for 0.9.1 and can be removed for 0.9.3 again
-      BUILD_COMMAND make clean
-      INSTALL_COMMAND make install
-      INSTALL_DIR ${THRIFT_PREFIX}
       URL "http://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz"
       BUILD_BYPRODUCTS "${THRIFT_STATIC_LIB}" "${THRIFT_COMPILER}"
-      )
+      CMAKE_ARGS ${THRIFT_CMAKE_ARGS})
   else()
     ExternalProject_Add(thrift_ep
-      CONFIGURE_COMMAND ${THRIFT_CONFIGURE_COMMAND}
-      BUILD_IN_SOURCE 1
-      # This is needed for 0.9.1 and can be removed for 0.9.3 again
-      BUILD_COMMAND make clean
-      INSTALL_COMMAND make install
-      INSTALL_DIR ${THRIFT_PREFIX}
       URL "http://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz"
-      )
+      BUILD_BYPRODUCTS "${THRIFT_STATIC_LIB}" "${THRIFT_COMPILER}"
+      CMAKE_ARGS ${THRIFT_CMAKE_ARGS})
   endif()
     set(THRIFT_VENDORED 1)
 else()


### PR DESCRIPTION
Closes #251.

Also resolves PARQUET-871 by adding `-DPARQUET_CXXFLAGS=...` option