### PR TITLE
PARQUET-889: Fix compilation when SSE is enabled

### DIFF
--- a/src/parquet/util/bit-util.h
+++ b/src/parquet/util/bit-util.h
@@ -30,6 +30,11 @@
 
 #include "parquet/util/compiler-util.h"
 
+#ifdef PARQUET_USE_SSE
+#include "parquet/util/cpu-info.h"
+#include "parquet/util/sse-util.h"
+#endif
+
 namespace parquet {
 
 #define INIT_BITSET(valid_bits_vector, valid_bits_index)        \

--- a/src/parquet/util/cpu-info.cc
+++ b/src/parquet/util/cpu-info.cc
@@ -39,6 +39,7 @@
 #include <string>
 
 #include "parquet/exception.h"
+#include "parquet/util/logging.h"
 
 using boost::algorithm::contains;
 using boost::algorithm::trim;
@@ -174,6 +175,31 @@ void CpuInfo::EnableFeature(int64_t flag, bool enable) {
     DCHECK((original_hardware_flags_ & flag) != 0);
     hardware_flags_ |= flag;
   }
+}
+
+int64_t CpuInfo::hardware_flags() {
+  DCHECK(initialized_);
+  return hardware_flags_;
+}
+
+int64_t CpuInfo::CacheSize(CacheLevel level) {
+  DCHECK(initialized_);
+  return cache_sizes_[level];
+}
+
+int64_t CpuInfo::cycles_per_ms() {
+  DCHECK(initialized_);
+  return cycles_per_ms_;
+}
+
+int CpuInfo::num_cores() {
+  DCHECK(initialized_);
+  return num_cores_;
+}
+
+std::string CpuInfo::model_name() {
+  DCHECK(initialized_);
+  return model_name_;
 }
 
 }  // namespace parquet

--- a/src/parquet/util/cpu-info.h
+++ b/src/parquet/util/cpu-info.h
@@ -24,8 +24,6 @@
 #include <cstdint>
 #include <string>
 
-#include "parquet/util/logging.h"
-
 namespace parquet {
 
 /// CpuInfo is an interface to query for cpu information at runtime.  The caller can
@@ -54,14 +52,10 @@ class CpuInfo {
   static void VerifyCpuRequirements();
 
   /// Returns all the flags for this cpu
-  static int64_t hardware_flags() {
-    DCHECK(initialized_);
-    return hardware_flags_;
-  }
+  static int64_t hardware_flags();
 
   /// Returns whether of not the cpu supports this flag
   inline static bool IsSupported(int64_t flag) {
-    DCHECK(initialized_);
     return (hardware_flags_ & flag) != 0;
   }
 
@@ -70,28 +64,16 @@ class CpuInfo {
   static void EnableFeature(int64_t flag, bool enable);
 
   /// Returns the size of the cache in KB at this cache level
-  static int64_t CacheSize(CacheLevel level) {
-    DCHECK(initialized_);
-    return cache_sizes_[level];
-  }
+  static int64_t CacheSize(CacheLevel level);
 
   /// Returns the number of cpu cycles per millisecond
-  static int64_t cycles_per_ms() {
-    DCHECK(initialized_);
-    return cycles_per_ms_;
-  }
+  static int64_t cycles_per_ms();
 
   /// Returns the number of cores (including hyper-threaded) on this machine.
-  static int num_cores() {
-    DCHECK(initialized_);
-    return num_cores_;
-  }
+  static int num_cores();
 
   /// Returns the model name of the cpu (e.g. Intel i7-2600)
-  static std::string model_name() {
-    DCHECK(initialized_);
-    return model_name_;
-  }
+  static std::string model_name();
 
   static bool initialized() { return initialized_; }
 


### PR DESCRIPTION
bit-util.h was missing a couple of include. cpu-util.h was including
parquet/logging.h which is an internal header so the implementations of
the static functions have been moved in the source file.