### PR TITLE
PARQUET-891: Do not search for snappy on system paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ brew install boost
 You can either install these dependencies separately, otherwise they will be
 built automatically as part of the build.
 
+Symbols from Thrift, Snappy, and ZLib are statically-linked into the
+`libparquet` shared library, so these dependencies must be build with `-fPIC`
+on Linux and OS X. Since Linux package managers do not consistently compile the
+static libraries for these components with `-fPIC`, you may experience issues
+with Linux packages such as `libsnappy-dev`. It may be easier for you to depend
+on the thirdparty toolchain that parquet-cpp builds automatically.
+
 ## Build
 
 - `cmake .`

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ You can either install these dependencies separately, otherwise they will be
 built automatically as part of the build.
 
 Symbols from Thrift, Snappy, and ZLib are statically-linked into the
-`libparquet` shared library, so these dependencies must be build with `-fPIC`
+`libparquet` shared library, so these dependencies must be built with `-fPIC`
 on Linux and OS X. Since Linux package managers do not consistently compile the
-static libraries for these components with `-fPIC`, you may experience issues
-with Linux packages such as `libsnappy-dev`. It may be easier for you to depend
-on the thirdparty toolchain that parquet-cpp builds automatically.
+static libraries for these components with `-fPIC`, you may have issues with
+Linux packages such as `libsnappy-dev`. It may be easier to depend on the
+thirdparty toolchain that parquet-cpp builds automatically.
 
 ## Build
 

--- a/cmake_modules/FindSnappy.cmake
+++ b/cmake_modules/FindSnappy.cmake
@@ -38,19 +38,16 @@ elseif ( Snappy_HOME )
     list( APPEND _snappy_roots ${Snappy_HOME} )
 endif()
 
-# Try the parameterized roots, if they exist
-if ( _snappy_roots )
-    find_path( SNAPPY_INCLUDE_DIR NAMES snappy.h
-        PATHS ${_snappy_roots} NO_DEFAULT_PATH
-        PATH_SUFFIXES "include" )
-    find_library( SNAPPY_LIBRARIES NAMES snappy
-        PATHS ${_snappy_roots} NO_DEFAULT_PATH
-        PATH_SUFFIXES "lib" )
-else ()
-    find_path( SNAPPY_INCLUDE_DIR NAMES snappy.h )
-    find_library( SNAPPY_LIBRARIES NAMES snappy )
-endif ()
+message(STATUS "SNAPPY_HOME: $ENV{SNAPPY_HOME}")
+find_path(SNAPPY_INCLUDE_DIR snappy.h HINTS
+  $ENV{SNAPPY_HOME}
+  NO_DEFAULT_PATH
+  PATH_SUFFIXES "include")
 
+find_library( SNAPPY_LIBRARIES NAMES snappy PATHS
+  $ENV{SNAPPY_HOME}
+  NO_DEFAULT_PATH
+  PATH_SUFFIXES "lib")
 
 if (SNAPPY_INCLUDE_DIR AND SNAPPY_LIBRARIES)
   set(SNAPPY_FOUND TRUE)


### PR DESCRIPTION
The `libsnappy.a` from Linux package mangers (e.g. Ubuntu 14.04) may not be built with -fPIC, which will cause a linker failure when creating `libparquet.so`. Add notes to README about this nuance when depending on separately built/installed thirdparty components.