### PR TITLE
PARQUET-895: Fix broken reading of nested repeated columns

### DIFF
--- a/src/parquet/file/reader-internal.cc
+++ b/src/parquet/file/reader-internal.cc
@@ -196,7 +196,7 @@ std::unique_ptr<PageReader> SerializedRowGroup::GetColumnPageReader(int i) {
   stream = properties_.GetStream(source_, col_start, col_length);
 
   return std::unique_ptr<PageReader>(new SerializedPageReader(std::move(stream),
-      row_group_metadata_->num_rows(), col->compression(), properties_.memory_pool()));
+      col->num_values(), col->compression(), properties_.memory_pool()));
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
Use the column metadata to get the number of levels to process. It
fixes a problem where not enough values are returned in the case
of nested repeated values.

@peshopetrov should get the credit for 1st attempt #250