### PR TITLE
PARQUET-923: Account for Time type changes in Arrow

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -22,7 +22,7 @@ set(THRIFT_VERSION "0.10.0")
 
 # Brotli 0.5.2 does not install headers/libraries yet, but 0.6.0.dev does
 set(BROTLI_VERSION "5db62dcc9d386579609540cdf8869e95ad334bbd")
-set(ARROW_VERSION "e8f6a492d30d32cd67fe3a537b3aec4cbae566c9")
+set(ARROW_VERSION "c7947dc2d08a0a2295016d34db201cc38a38360c")
 
 # find boost headers and libs
 # Find shared Boost libraries.

--- a/src/parquet/arrow/schema.cc
+++ b/src/parquet/arrow/schema.cc
@@ -110,6 +110,12 @@ static Status FromInt32(const PrimitiveNode* node, TypePtr* out) {
     case LogicalType::DATE:
       *out = ::arrow::date64();
       break;
+    case LogicalType::TIME_MILLIS:
+      *out = ::arrow::time32(::arrow::TimeUnit::MILLI);
+      break;
+    case LogicalType::TIME_MICROS:
+      *out = ::arrow::time64(::arrow::TimeUnit::MICRO);
+      break;
     case LogicalType::DECIMAL:
       *out = MakeDecimalType(node);
       break;
@@ -395,9 +401,13 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
       type = ParquetType::INT64;
       logical_type = LogicalType::TIMESTAMP_MILLIS;
     } break;
-    case ArrowType::TIME:
+    case ArrowType::TIME32:
       type = ParquetType::INT64;
       logical_type = LogicalType::TIME_MILLIS;
+      break;
+    case ArrowType::TIME64:
+      type = ParquetType::INT64;
+      logical_type = LogicalType::TIME_MICROS;
       break;
     case ArrowType::STRUCT: {
       auto struct_type = std::static_pointer_cast<::arrow::StructType>(field->type);

--- a/src/parquet/arrow/writer.cc
+++ b/src/parquet/arrow/writer.cc
@@ -81,7 +81,8 @@ class LevelBuilder : public ::arrow::ArrayVisitor {
   PRIMITIVE_VISIT(String)
   PRIMITIVE_VISIT(Binary)
   PRIMITIVE_VISIT(Date64)
-  PRIMITIVE_VISIT(Time)
+  PRIMITIVE_VISIT(Time32)
+  PRIMITIVE_VISIT(Time64)
   PRIMITIVE_VISIT(Timestamp)
   PRIMITIVE_VISIT(Interval)
 


### PR DESCRIPTION
Needs ARROW-709 (https://github.com/apache/arrow/pull/439), will update Arrow commit hash once that's done