### PR TITLE
PARQUET-918: FromParquetSchema API crashes on nested schemas

### DIFF
--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -27,6 +27,8 @@
 #include "parquet/arrow/writer.h"
 #include "parquet/arrow/schema.h"
 
+#include "parquet/file/writer.h"
+
 #include "arrow/api.h"
 #include "arrow/test-util.h"
 
@@ -55,17 +57,6 @@ const int SMALL_SIZE = 100;
 const int LARGE_SIZE = 10000;
 
 constexpr uint32_t kDefaultSeed = 0;
-
-const char* data_dir = std::getenv("PARQUET_TEST_DATA");
-
-
-std::string example_nested() {
-  std::string dir_string(data_dir);
-  std::stringstream ss;
-  ss << dir_string << "/"
-     << "nested.snappy.parquet";
-  return ss.str();
-}
 
 template <typename TestType>
 struct test_traits {};
@@ -889,33 +880,103 @@ TEST(TestArrowReadWrite, ReadColumnSubset) {
 }
 
 class TestNestedSchemaRead : public ::testing::Test {
- public:
-  void SetUp() {
-    auto parquet_reader = ParquetFileReader::OpenFile(example_nested());
-    reader_ = std::make_shared<FileReader>(
-      ::arrow::default_memory_pool(),
-      std::move(parquet_reader));
+ protected:
+  virtual void SetUp() {
+    // We are using parquet low-level file api to create the nested parquet
+    CreateNestedParquet();
+    InitReader(&reader_);
   }
 
-  void TearDown() {}
+  void InitReader(std::shared_ptr<FileReader>* out) {
+    std::shared_ptr<Buffer> buffer = nested_parquet_->GetBuffer();
+    std::unique_ptr<FileReader> reader;
+    ASSERT_OK_NO_THROW(OpenFile(
+      std::make_shared<BufferReader>(buffer), ::arrow::default_memory_pool(),
+      ::parquet::default_reader_properties(), nullptr, &reader));
 
- protected:
+    *out = std::move(reader);
+  }
+
+  void InitNewParquetFile(const std::shared_ptr<GroupNode>& schema, int num_rows) {
+    nested_parquet_ = std::make_shared<InMemoryOutputStream>();
+    writer_ = parquet::ParquetFileWriter::Open(nested_parquet_,
+       schema, default_writer_properties());
+    row_group_writer_ = writer_->AppendRowGroup(num_rows);
+  }
+
+  void FinalizeParquetFile() {
+    row_group_writer_->Close();
+    writer_->Close();
+  }
+
+  void CreateNestedParquet() {
+    std::vector<NodePtr> parquet_fields;
+    std::shared_ptr<Array> values;
+
+    // create the schema:
+    // required group group1 {
+    //   required int32 leaf1;
+    //   required int32 leaf2;
+    // }
+    // required int32 leaf3;
+
+    parquet_fields.push_back(
+        GroupNode::Make("group1", Repetition::REQUIRED, {
+          PrimitiveNode::Make(
+            "leaf1", Repetition::REQUIRED, ParquetType::INT32),
+          PrimitiveNode::Make(
+            "leaf2", Repetition::REQUIRED, ParquetType::INT32)}));
+    parquet_fields.push_back(PrimitiveNode::Make(
+        "leaf3", Repetition::REQUIRED, ParquetType::INT32));
+
+    const int num_columns = 3;
+    auto schema_node = GroupNode::Make("schema", Repetition::REQUIRED, parquet_fields);
+
+    InitNewParquetFile(std::static_pointer_cast<GroupNode>(schema_node), 0);
+
+    for (int i = 0; i < num_columns; i++) {
+      auto column_writer = row_group_writer_->NextColumn();
+      auto typed_writer = reinterpret_cast<TypedColumnWriter<Int32Type>*>(column_writer);
+      typed_writer->WriteBatch(0, nullptr, nullptr, nullptr);
+    }
+
+    FinalizeParquetFile();
+  }
+
+  std::shared_ptr<InMemoryOutputStream> nested_parquet_;
   std::shared_ptr<FileReader> reader_;
+  std::unique_ptr<ParquetFileWriter> writer_;
+  RowGroupWriter* row_group_writer_;
 };
 
 TEST_F(TestNestedSchemaRead, ReadIntoTableFull) {
   std::shared_ptr<Table> table;
   ASSERT_OK_NO_THROW(reader_->ReadTable(&table));
-  ASSERT_EQ(table->num_rows(), 3);
-  ASSERT_EQ(table->num_columns(), 3);
+  ASSERT_EQ(table->num_rows(), 0);
+  ASSERT_EQ(table->num_columns(), 2);
+  ASSERT_EQ(table->schema()->field(0)->type->num_children(), 2);
 }
 
 TEST_F(TestNestedSchemaRead, ReadTablePartial) {
   std::shared_ptr<Table> table;
-  std::vector<int> indices = {0, 1, 4};
-  ASSERT_OK_NO_THROW(reader_->ReadTable(indices, &table));
-  ASSERT_EQ(table->num_rows(), 3);
+
+  // columns: {group1.leaf1, leaf3}
+  ASSERT_OK_NO_THROW(reader_->ReadTable({0, 2}, &table));
+  ASSERT_EQ(table->num_rows(), 0);
   ASSERT_EQ(table->num_columns(), 2);
+  ASSERT_EQ(table->schema()->field(0)->type->num_children(), 1);
+
+  // columns: {group1.leaf1, group1.leaf2}
+  ASSERT_OK_NO_THROW(reader_->ReadTable({0, 1}, &table));
+  ASSERT_EQ(table->num_rows(), 0);
+  ASSERT_EQ(table->num_columns(), 1);
+  ASSERT_EQ(table->schema()->field(0)->type->num_children(), 2);
+
+  // columns: {leaf3}
+  ASSERT_OK_NO_THROW(reader_->ReadTable({2}, &table));
+  ASSERT_EQ(table->num_rows(), 0);
+  ASSERT_EQ(table->num_columns(), 1);
+  ASSERT_EQ(table->schema()->field(0)->type->num_children(), 0);
 }
 
 }  // namespace arrow

--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -894,8 +894,7 @@ class TestNestedSchemaRead : public ::testing::Test {
     auto parquet_reader = ParquetFileReader::OpenFile(example_nested());
     reader_ = std::make_shared<FileReader>(
       ::arrow::default_memory_pool(),
-      std::move(parquet_reader)
-    );
+      std::move(parquet_reader));
   }
 
   void TearDown() {}
@@ -910,8 +909,7 @@ TEST_F(TestNestedSchemaRead, FromParquetSchemaFull) {
   ASSERT_OK_NO_THROW(
     FromParquetSchema(
       parquet_schema,
-      &schema)
-  );
+      &schema));
   ASSERT_EQ(schema->num_fields(), 3);
 }
 
@@ -923,8 +921,7 @@ TEST_F(TestNestedSchemaRead, FromParquetSchemaPartial) {
     FromParquetSchema(
       parquet_schema,
       indices,
-      &schema)
-  );
+      &schema));
   ASSERT_EQ(schema->num_fields(), 2);
 }
 

--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -903,28 +903,6 @@ class TestNestedSchemaRead : public ::testing::Test {
   std::shared_ptr<FileReader> reader_;
 };
 
-TEST_F(TestNestedSchemaRead, FromParquetSchemaFull) {
-  auto parquet_schema = reader_->parquet_reader()->metadata()->schema();
-  std::shared_ptr<::arrow::Schema> schema;
-  ASSERT_OK_NO_THROW(
-    FromParquetSchema(
-      parquet_schema,
-      &schema));
-  ASSERT_EQ(schema->num_fields(), 3);
-}
-
-TEST_F(TestNestedSchemaRead, FromParquetSchemaPartial) {
-  auto parquet_schema = reader_->parquet_reader()->metadata()->schema();
-  std::shared_ptr<::arrow::Schema> schema;
-  std::vector<int> indices = {0, 1, 4};
-  ASSERT_OK_NO_THROW(
-    FromParquetSchema(
-      parquet_schema,
-      indices,
-      &schema));
-  ASSERT_EQ(schema->num_fields(), 2);
-}
-
 TEST_F(TestNestedSchemaRead, ReadIntoTableFull) {
   std::shared_ptr<Table> table;
   ASSERT_OK_NO_THROW(reader_->ReadTable(&table));

--- a/src/parquet/arrow/arrow-schema-test.cc
+++ b/src/parquet/arrow/arrow-schema-test.cc
@@ -73,6 +73,13 @@ class TestConvertParquetSchema : public ::testing::Test {
     return FromParquetSchema(&descr_, &result_schema_);
   }
 
+  ::arrow::Status ConvertSchema(const std::vector<NodePtr>& nodes,
+        const std::vector<int>& column_indices) {
+    NodePtr schema = GroupNode::Make("schema", Repetition::REPEATED, nodes);
+    descr_.Init(schema);
+    return FromParquetSchema(&descr_, column_indices, &result_schema_);
+  }
+
  protected:
   SchemaDescriptor descr_;
   std::shared_ptr<::arrow::Schema> result_schema_;
@@ -346,6 +353,94 @@ TEST_F(TestConvertParquetSchema, UnsupportedThings) {
   for (const NodePtr& node : unsupported_nodes) {
     ASSERT_RAISES(NotImplemented, ConvertSchema({node}));
   }
+}
+
+TEST_F(TestConvertParquetSchema, ParuqetNestedSchema) {
+  std::vector<NodePtr> parquet_fields;
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+
+  // required group group1 {
+  //   required bool leaf1;
+  //   required int32 leaf2;
+  // }
+  // required int64 leaf3;
+  {
+    parquet_fields.push_back(
+        GroupNode::Make("group1", Repetition::REQUIRED, {
+          PrimitiveNode::Make(
+            "leaf1", Repetition::REQUIRED, ParquetType::BOOLEAN),
+          PrimitiveNode::Make(
+            "leaf2", Repetition::REQUIRED, ParquetType::INT32)}));
+    parquet_fields.push_back(PrimitiveNode::Make(
+        "leaf3", Repetition::REQUIRED, ParquetType::INT64));
+
+    auto group1_fields = {
+      std::make_shared<Field>("leaf1", BOOL, false),
+      std::make_shared<Field>("leaf2", INT32, false)};
+    auto arrow_group1_type = std::make_shared<::arrow::StructType>(group1_fields);
+    arrow_fields.push_back(std::make_shared<Field>("group1", arrow_group1_type, false));
+    arrow_fields.push_back(std::make_shared<Field>("leaf3", INT64, false));
+  }
+
+  auto arrow_schema = std::make_shared<::arrow::Schema>(arrow_fields);
+  ASSERT_OK(ConvertSchema(parquet_fields));
+
+  CheckFlatSchema(arrow_schema);
+}
+
+TEST_F(TestConvertParquetSchema, ParuqetNestedSchemaPartial) {
+  std::vector<NodePtr> parquet_fields;
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+
+  // Full Parquet Schema:
+  // required group group1 {
+  //   required int64 leaf1;
+  //   required int64 leaf2;
+  // }
+  // required group group2 {
+  //   required int64 leaf3;
+  //   required int64 leaf4;
+  // }
+  // required int64 leaf5;
+  //
+  // Expected partial arrow schema (columns 0, 3, 4):
+  // required group group1 {
+  //   required int64 leaf1;
+  // }
+  // required group group2 {
+  //   required int64 leaf4;
+  // }
+  // required int64 leaf5;
+  {
+    parquet_fields.push_back(
+        GroupNode::Make("group1", Repetition::REQUIRED, {
+          PrimitiveNode::Make(
+            "leaf1", Repetition::REQUIRED, ParquetType::INT64),
+          PrimitiveNode::Make(
+            "leaf2", Repetition::REQUIRED, ParquetType::INT64)}));
+    parquet_fields.push_back(
+        GroupNode::Make("group2", Repetition::REQUIRED, {
+          PrimitiveNode::Make(
+            "leaf3", Repetition::REQUIRED, ParquetType::INT64),
+          PrimitiveNode::Make(
+            "leaf4", Repetition::REQUIRED, ParquetType::INT64)}));
+    parquet_fields.push_back(PrimitiveNode::Make(
+        "leaf5", Repetition::REQUIRED, ParquetType::INT64));
+
+    auto group1_fields = {std::make_shared<Field>("leaf1", INT64, false)};
+    auto arrow_group1_type = std::make_shared<::arrow::StructType>(group1_fields);
+    auto group2_fields = {std::make_shared<Field>("leaf4", INT64, false)};
+    auto arrow_group2_type = std::make_shared<::arrow::StructType>(group2_fields);
+
+    arrow_fields.push_back(std::make_shared<Field>("group1", arrow_group1_type, false));
+    arrow_fields.push_back(std::make_shared<Field>("group2", arrow_group2_type, false));
+    arrow_fields.push_back(std::make_shared<Field>("leaf5", INT64, false));
+  }
+
+  auto arrow_schema = std::make_shared<::arrow::Schema>(arrow_fields);
+  ASSERT_OK(ConvertSchema(parquet_fields, {0, 3, 4}));
+
+  CheckFlatSchema(arrow_schema);
 }
 
 class TestConvertArrowSchema : public ::testing::Test {

--- a/src/parquet/arrow/arrow-schema-test.cc
+++ b/src/parquet/arrow/arrow-schema-test.cc
@@ -355,7 +355,7 @@ TEST_F(TestConvertParquetSchema, UnsupportedThings) {
   }
 }
 
-TEST_F(TestConvertParquetSchema, ParuqetNestedSchema) {
+TEST_F(TestConvertParquetSchema, ParquetNestedSchema) {
   std::vector<NodePtr> parquet_fields;
   std::vector<std::shared_ptr<Field>> arrow_fields;
 
@@ -388,7 +388,7 @@ TEST_F(TestConvertParquetSchema, ParuqetNestedSchema) {
   CheckFlatSchema(arrow_schema);
 }
 
-TEST_F(TestConvertParquetSchema, ParuqetNestedSchemaPartial) {
+TEST_F(TestConvertParquetSchema, ParquetNestedSchemaPartial) {
   std::vector<NodePtr> parquet_fields;
   std::vector<std::shared_ptr<Field>> arrow_fields;
 

--- a/src/parquet/arrow/schema.cc
+++ b/src/parquet/arrow/schema.cc
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 #include "parquet/api/schema.h"
 
@@ -183,12 +184,26 @@ Status FromPrimitive(const PrimitiveNode* primitive, TypePtr* out) {
   return Status::OK();
 }
 
-Status StructFromGroup(const GroupNode* group, TypePtr* out) {
-  std::vector<std::shared_ptr<Field>> fields(group->field_count());
+// Forward declaration
+Status NodeToFieldInternal(const NodePtr& node,
+    const std::unordered_set<NodePtr>* needed_nodes, std::shared_ptr<Field>* out);
+
+Status StructFromGroup(const GroupNode* group,
+    const std::unordered_set<NodePtr>* needed_nodes, TypePtr* out) {
+  std::vector<std::shared_ptr<Field>> fields;
+  std::shared_ptr<Field> field;
+
+  *out = nullptr;
+
   for (int i = 0; i < group->field_count(); i++) {
-    RETURN_NOT_OK(NodeToField(group->field(i), &fields[i]));
+    RETURN_NOT_OK(NodeToFieldInternal(group->field(i), needed_nodes, &field));
+    if (field != nullptr) {
+      fields.push_back(field);
+    }
   }
-  *out = std::make_shared<::arrow::StructType>(fields);
+  if (fields.size() > 0) {
+    *out = std::make_shared<::arrow::StructType>(fields);
+  }
   return Status::OK();
 }
 
@@ -197,7 +212,9 @@ bool str_endswith_tuple(const std::string& str) {
   return false;
 }
 
-Status NodeToList(const GroupNode* group, TypePtr* out) {
+Status NodeToList(const GroupNode* group,
+    const std::unordered_set<NodePtr>* needed_nodes, TypePtr* out) {
+  *out = nullptr;
   if (group->field_count() == 1) {
     // This attempts to resolve the preferred 3-level list encoding.
     NodePtr list_node = group->field(0);
@@ -210,22 +227,29 @@ Status NodeToList(const GroupNode* group, TypePtr* out) {
           !str_endswith_tuple(list_node->name())) {
         // List of primitive type
         std::shared_ptr<Field> item_field;
-        RETURN_NOT_OK(NodeToField(list_group->field(0), &item_field));
-        *out = ::arrow::list(item_field);
+        RETURN_NOT_OK(NodeToFieldInternal(list_group->field(0), needed_nodes, &item_field));
+        if (item_field != nullptr) {
+          *out = ::arrow::list(item_field);
+        }
       } else {
         // List of struct
         std::shared_ptr<::arrow::DataType> inner_type;
-        RETURN_NOT_OK(StructFromGroup(list_group, &inner_type));
-        auto item_field = std::make_shared<Field>(list_node->name(), inner_type, false);
-        *out = ::arrow::list(item_field);
+        RETURN_NOT_OK(StructFromGroup(list_group, needed_nodes, &inner_type));
+        if (inner_type != nullptr) {
+          auto item_field = std::make_shared<Field>(list_node->name(), inner_type, false);
+          *out = ::arrow::list(item_field);
+        }
       }
     } else if (list_node->is_repeated()) {
       // repeated primitive node
       std::shared_ptr<::arrow::DataType> inner_type;
-      const PrimitiveNode* primitive = static_cast<const PrimitiveNode*>(list_node.get());
-      RETURN_NOT_OK(FromPrimitive(primitive, &inner_type));
-      auto item_field = std::make_shared<Field>(list_node->name(), inner_type, false);
-      *out = ::arrow::list(item_field);
+      PrimitiveNode* primitive = static_cast<PrimitiveNode*>(list_node.get());
+      if ((needed_nodes == nullptr) ||
+          (needed_nodes->count(static_cast<NodePtr>(primitive)) > 0)) {
+        RETURN_NOT_OK(FromPrimitive(primitive, &inner_type));
+        auto item_field = std::make_shared<Field>(list_node->name(), inner_type, false);
+        *out = ::arrow::list(item_field);
+      }
     } else {
       return Status::NotImplemented(
           "Non-repeated groups in a LIST-annotated group are not supported.");
@@ -238,31 +262,46 @@ Status NodeToList(const GroupNode* group, TypePtr* out) {
 }
 
 Status NodeToField(const NodePtr& node, std::shared_ptr<Field>* out) {
-  std::shared_ptr<::arrow::DataType> type;
+  return NodeToFieldInternal(node, nullptr, out);
+}
+
+Status NodeToFieldInternal(const NodePtr& node,
+    const std::unordered_set<NodePtr>* needed_nodes, std::shared_ptr<Field>* out) {
+
+  std::shared_ptr<::arrow::DataType> type = nullptr;
   bool nullable = !node->is_required();
+
+  *out = nullptr;
 
   if (node->is_repeated()) {
     // 1-level LIST encoding fields are required
     std::shared_ptr<::arrow::DataType> inner_type;
-    const PrimitiveNode* primitive = static_cast<const PrimitiveNode*>(node.get());
-    RETURN_NOT_OK(FromPrimitive(primitive, &inner_type));
-    auto item_field = std::make_shared<Field>(node->name(), inner_type, false);
-    type = ::arrow::list(item_field);
-    nullable = false;
+    if ((needed_nodes == nullptr) ||
+        (needed_nodes->count(static_cast<NodePtr>(node)) > 0)) {
+      const PrimitiveNode* primitive = static_cast<const PrimitiveNode*>(node.get());
+      RETURN_NOT_OK(FromPrimitive(primitive, &inner_type));
+      auto item_field = std::make_shared<Field>(node->name(), inner_type, false);
+      type = ::arrow::list(item_field);
+      nullable = false;
+    }
   } else if (node->is_group()) {
     const GroupNode* group = static_cast<const GroupNode*>(node.get());
     if (node->logical_type() == LogicalType::LIST) {
-      RETURN_NOT_OK(NodeToList(group, &type));
+      RETURN_NOT_OK(NodeToList(group, needed_nodes, &type));
     } else {
-      RETURN_NOT_OK(StructFromGroup(group, &type));
+      RETURN_NOT_OK(StructFromGroup(group, needed_nodes, &type));
     }
   } else {
     // Primitive (leaf) node
-    const PrimitiveNode* primitive = static_cast<const PrimitiveNode*>(node.get());
-    RETURN_NOT_OK(FromPrimitive(primitive, &type));
+    if ((needed_nodes == nullptr) ||
+        (needed_nodes->count(static_cast<NodePtr>(node)) > 0)) {
+      const PrimitiveNode* primitive = static_cast<const PrimitiveNode*>(node.get());
+      RETURN_NOT_OK(FromPrimitive(primitive, &type));
+    }
   }
-
-  *out = std::make_shared<Field>(node->name(), type, nullable);
+  if (type != nullptr) {
+    *out = std::make_shared<Field>(node->name(), type, nullable);
+  }
   return Status::OK();
 }
 
@@ -270,8 +309,9 @@ Status FromParquetSchema(
     const SchemaDescriptor* parquet_schema, std::shared_ptr<::arrow::Schema>* out) {
   const GroupNode* schema_node = parquet_schema->group_node();
 
-  std::vector<std::shared_ptr<Field>> fields(schema_node->field_count());
-  for (int i = 0; i < schema_node->field_count(); i++) {
+  int num_fields = static_cast<int>(schema_node->field_count());
+  std::vector<std::shared_ptr<Field>> fields(num_fields);
+  for (int i = 0; i < num_fields; i++) {
     RETURN_NOT_OK(NodeToField(schema_node->field(i), &fields[i]));
   }
 
@@ -285,11 +325,21 @@ Status FromParquetSchema(const SchemaDescriptor* parquet_schema,
   // from the root Parquet node
   const GroupNode* schema_node = parquet_schema->group_node();
 
-  int num_fields = static_cast<int>(column_indices.size());
+  // Put the right leaf nodes in an unordered set
+  int num_columns = static_cast<int>(column_indices.size());
+  std::unordered_set<NodePtr> needed_nodes(num_columns);
+  for (int i = 0; i < num_columns; i++) {
+    auto column_desc = parquet_schema->Column(column_indices[i]);
+    needed_nodes.insert(column_desc->schema_node());
+  }
 
-  std::vector<std::shared_ptr<Field>> fields(num_fields);
-  for (int i = 0; i < num_fields; i++) {
-    RETURN_NOT_OK(NodeToField(schema_node->field(column_indices[i]), &fields[i]));
+  std::vector<std::shared_ptr<Field>> fields;
+  std::shared_ptr<Field> field;
+  for (int i = 0; i < schema_node->field_count(); i++) {
+    RETURN_NOT_OK(NodeToFieldInternal(schema_node->field(i), &needed_nodes, &field));
+    if (field != nullptr) {
+      fields.push_back(field);
+    }
   }
 
   *out = std::make_shared<::arrow::Schema>(fields);

--- a/src/parquet/arrow/schema.cc
+++ b/src/parquet/arrow/schema.cc
@@ -291,9 +291,14 @@ Status NodeToFieldInternal(const NodePtr& node,
   if (node->is_repeated()) {
     // 1-level LIST encoding fields are required
     std::shared_ptr<::arrow::DataType> inner_type;
-    if (IsIncludedLeaf(static_cast<NodePtr>(node), included_leaf_nodes)) {
+    if (node->is_group()) {
+      const GroupNode* group = static_cast<const GroupNode*>(node.get());
+      RETURN_NOT_OK(StructFromGroup(group, included_leaf_nodes, &inner_type));
+    } else if (IsIncludedLeaf(static_cast<NodePtr>(node), included_leaf_nodes)) {
       const PrimitiveNode* primitive = static_cast<const PrimitiveNode*>(node.get());
       RETURN_NOT_OK(FromPrimitive(primitive, &inner_type));
+    }
+    if (inner_type != nullptr) {
       auto item_field = std::make_shared<Field>(node->name(), inner_type, false);
       type = ::arrow::list(item_field);
       nullable = false;

--- a/src/parquet/arrow/schema.cc
+++ b/src/parquet/arrow/schema.cc
@@ -194,8 +194,11 @@ Status NodeToFieldInternal(const NodePtr& node,
  */
 inline bool IsIncludedLeaf(const NodePtr& node,
     const std::unordered_set<NodePtr>* included_leaf_nodes) {
-  return ((included_leaf_nodes == nullptr) ||
-          (included_leaf_nodes->count(node) > 0));
+  if (included_leaf_nodes == nullptr) {
+    return true;
+  }
+  auto search = included_leaf_nodes->find(node);
+  return (search != included_leaf_nodes->end());
 }
 
 Status StructFromGroup(const GroupNode* group,


### PR DESCRIPTION
FromParquetSchema and ReadTable APIs crashed on nested schemas parquet on partial schema reads.

The fix creates a partial schema while building the arrow::Schema object.

4 tests were added - Two for FromParquetSchema API and two for ReadTable, each function is tested with a full schema read and a partial one from a simple nested parquet file.
