### PR TITLE
PARQUET-934: Support multiarch on Debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,13 @@ string(REPLACE "\n" "" PARQUET_VERSION "${PARQUET_VERSION}")
 include(ExternalProject)
 include(FindPkgConfig)
 
+if(CMAKE_MAJOR_VERSION LESS 3)
+  set(CMAKE_INSTALL_INCLUDEDIR "include")
+  set(CMAKE_INSTALL_LIBDIR "lib")
+else()
+  include(GNUInstallDirs)
+endif()
+
 if (NOT "$ENV{PARQUET_GCC_ROOT}" STREQUAL "")
   set(GCC_ROOT $ENV{PARQUET_GCC_ROOT})
   set(CMAKE_C_COMPILER ${GCC_ROOT}/bin/gcc)
@@ -659,11 +666,11 @@ add_custom_target(clean-all
 
 if (PARQUET_BUILD_STATIC)
     install(TARGETS parquet_static
-      ARCHIVE DESTINATION lib
-      LIBRARY DESTINATION lib)
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 if (PARQUET_BUILD_SHARED)
     install(TARGETS parquet_shared
-      ARCHIVE DESTINATION lib
-      LIBRARY DESTINATION lib)
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()

--- a/src/parquet/CMakeLists.txt
+++ b/src/parquet/CMakeLists.txt
@@ -22,7 +22,7 @@ install(FILES
   exception.h
   schema.h
   types.h
-  DESTINATION include/parquet)
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/parquet")
 
 # pkg-config support
 configure_file(parquet.pc.in
@@ -30,7 +30,7 @@ configure_file(parquet.pc.in
   @ONLY)
 install(
   FILES "${CMAKE_CURRENT_BINARY_DIR}/parquet.pc"
-  DESTINATION "lib/pkgconfig/")
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
 
 ADD_PARQUET_TEST(compression-test)
 ADD_PARQUET_TEST(encoding-test)

--- a/src/parquet/api/CMakeLists.txt
+++ b/src/parquet/api/CMakeLists.txt
@@ -21,4 +21,4 @@ install(FILES
   reader.h
   writer.h
   schema.h
-  DESTINATION include/parquet/api)
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/parquet/api")

--- a/src/parquet/arrow/CMakeLists.txt
+++ b/src/parquet/arrow/CMakeLists.txt
@@ -63,8 +63,8 @@ if (PARQUET_BUILD_SHARED)
     endif()
 
   install(TARGETS parquet_arrow_shared
-      ARCHIVE DESTINATION lib
-      LIBRARY DESTINATION lib)
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 if (PARQUET_BUILD_STATIC)
@@ -78,8 +78,8 @@ if (PARQUET_BUILD_STATIC)
       arrow_io_static
       parquet_static)
   install(TARGETS parquet_arrow_static
-      ARCHIVE DESTINATION lib
-      LIBRARY DESTINATION lib)
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 ADD_PARQUET_TEST(arrow-schema-test)
@@ -107,7 +107,7 @@ install(FILES
   reader.h
   schema.h
   writer.h
-  DESTINATION include/parquet/arrow)
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/parquet/arrow")
 
 # pkg-config support
 configure_file(parquet-arrow.pc.in
@@ -115,4 +115,4 @@ configure_file(parquet-arrow.pc.in
   @ONLY)
 install(
   FILES "${CMAKE_CURRENT_BINARY_DIR}/parquet-arrow.pc"
-  DESTINATION "lib/pkgconfig/")
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")

--- a/src/parquet/arrow/parquet-arrow.pc.in
+++ b/src/parquet/arrow/parquet-arrow.pc.in
@@ -16,8 +16,8 @@
 # under the License.
 
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/lib
-includedir=${prefix}/include
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: Apache Parquet Apache Arrow adapter
 Description: Apache Parquet Apache arrow adapter provides Arrow IPC modules for reading and writing Parquet format.

--- a/src/parquet/column/CMakeLists.txt
+++ b/src/parquet/column/CMakeLists.txt
@@ -25,7 +25,7 @@ install(FILES
   scanner.h
   writer.h
   statistics.h
-  DESTINATION include/parquet/column)
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/parquet/column")
 
 ADD_PARQUET_TEST(column-reader-test)
 ADD_PARQUET_TEST(column-writer-test)

--- a/src/parquet/file/CMakeLists.txt
+++ b/src/parquet/file/CMakeLists.txt
@@ -19,7 +19,7 @@ install(FILES
   metadata.h
   reader.h
   writer.h
-  DESTINATION include/parquet/file)
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/parquet/file")
 
 ADD_PARQUET_TEST(file-deserialize-test)
 ADD_PARQUET_TEST(file-metadata-test)

--- a/src/parquet/parquet.pc.in
+++ b/src/parquet/parquet.pc.in
@@ -16,8 +16,8 @@
 # under the License.
 
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/lib
-includedir=${prefix}/include
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: Apache Parquet
 Description: Apache Parquet is a columnar storage format.

--- a/src/parquet/util/CMakeLists.txt
+++ b/src/parquet/util/CMakeLists.txt
@@ -31,7 +31,7 @@ install(FILES
   stopwatch.h
   sse-util.h
   visibility.h
-  DESTINATION include/parquet/util)
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/parquet/util")
 
 if(PARQUET_BUILD_TESTS)
   add_library(parquet_test_main


### PR DESCRIPTION
On multiarch enabled Debian, we need to install libraries into
${CMAKE_INSTALL_PREFIX}/lib/${ARCH}/ instead of
${CMAKE_INSTALL_PREFIX}/lib/.

See also: https://wiki.debian.org/Multiarch/HOWTO

Using CMAKE_INSTALL_INCLUDEDIR isn't required for multiarch support. I used it for consistency. If you don't like it, I'll remove it.