### PR TITLE
PARQUET-942: Fix wrong variable use in FindSnappy

### DIFF
--- a/cmake_modules/FindSnappy.cmake
+++ b/cmake_modules/FindSnappy.cmake
@@ -40,12 +40,12 @@ endif()
 
 message(STATUS "SNAPPY_HOME: $ENV{SNAPPY_HOME}")
 find_path(SNAPPY_INCLUDE_DIR snappy.h HINTS
-  $ENV{SNAPPY_HOME}
+  ${_snappy_roots}
   NO_DEFAULT_PATH
   PATH_SUFFIXES "include")
 
 find_library( SNAPPY_LIBRARIES NAMES snappy PATHS
-  $ENV{SNAPPY_HOME}
+  ${_snappy_roots}
   NO_DEFAULT_PATH
   PATH_SUFFIXES "lib")
 


### PR DESCRIPTION
It should be _snappy_roots instead of SNAPPY_HOME environment
variable. If we use SNAPPY_HOME environment variable here, we ignore
Snappy_HOME CMake variable.