### PR TITLE
PARQUET-943: Fix build error on x86

### DIFF
--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -48,8 +48,8 @@ using ParquetReader = parquet::ParquetFileReader;
 namespace parquet {
 namespace arrow {
 
-constexpr int64_t kJulianToUnixEpochDays = 2440588L;
-constexpr int64_t kNanosecondsInADay = 86400L * 1000L * 1000L * 1000L;
+constexpr int64_t kJulianToUnixEpochDays = 2440588LL;
+constexpr int64_t kNanosecondsInADay = 86400LL * 1000LL * 1000LL * 1000LL;
 
 static inline int64_t impala_timestamp_to_nanoseconds(const Int96& impala_timestamp) {
   int64_t days_since_epoch = impala_timestamp.value[2] - kJulianToUnixEpochDays;


### PR DESCRIPTION
"L" is small on x86:

    src/parquet/arrow/reader.cc:52:55: warning: integer overflow in expression [-Woverflow]
    constexpr int64_t kNanosecondsInADay = 86400L * 1000L * 1000L * 1000L;
                                                          ^
    src/parquet/arrow/reader.cc:52:65: error: overflow in constant expression [-fpermissive]
    constexpr int64_t kNanosecondsInADay = 86400L * 1000L * 1000L * 1000L;
                                                                    ^
    src/parquet/arrow/reader.cc: In function 'int64_t parquet::arrow::impala_timestamp_to_nanoseconds(const parquet::Int96&)':
    src/parquet/arrow/reader.cc:58:1: warning: control reaches end of non-void function [-Wreturn-type]
    }
    ^