### PR TITLE
PARQUET-953: Add static constructors to arrow::FileWriter for initializing from schema, add WriteTable method

### DIFF
--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -23,9 +23,9 @@
 #include "parquet/api/writer.h"
 
 #include "parquet/arrow/reader.h"
+#include "parquet/arrow/schema.h"
 #include "parquet/arrow/test-util.h"
 #include "parquet/arrow/writer.h"
-#include "parquet/arrow/schema.h"
 
 #include "parquet/file/writer.h"
 
@@ -890,17 +890,17 @@ class TestNestedSchemaRead : public ::testing::Test {
   void InitReader(std::shared_ptr<FileReader>* out) {
     std::shared_ptr<Buffer> buffer = nested_parquet_->GetBuffer();
     std::unique_ptr<FileReader> reader;
-    ASSERT_OK_NO_THROW(OpenFile(
-      std::make_shared<BufferReader>(buffer), ::arrow::default_memory_pool(),
-      ::parquet::default_reader_properties(), nullptr, &reader));
+    ASSERT_OK_NO_THROW(
+        OpenFile(std::make_shared<BufferReader>(buffer), ::arrow::default_memory_pool(),
+            ::parquet::default_reader_properties(), nullptr, &reader));
 
     *out = std::move(reader);
   }
 
   void InitNewParquetFile(const std::shared_ptr<GroupNode>& schema, int num_rows) {
     nested_parquet_ = std::make_shared<InMemoryOutputStream>();
-    writer_ = parquet::ParquetFileWriter::Open(nested_parquet_,
-       schema, default_writer_properties());
+    writer_ = parquet::ParquetFileWriter::Open(
+        nested_parquet_, schema, default_writer_properties());
     row_group_writer_ = writer_->AppendRowGroup(num_rows);
   }
 
@@ -920,14 +920,11 @@ class TestNestedSchemaRead : public ::testing::Test {
     // }
     // required int32 leaf3;
 
+    parquet_fields.push_back(GroupNode::Make("group1", Repetition::REQUIRED,
+        {PrimitiveNode::Make("leaf1", Repetition::REQUIRED, ParquetType::INT32),
+            PrimitiveNode::Make("leaf2", Repetition::REQUIRED, ParquetType::INT32)}));
     parquet_fields.push_back(
-        GroupNode::Make("group1", Repetition::REQUIRED, {
-          PrimitiveNode::Make(
-            "leaf1", Repetition::REQUIRED, ParquetType::INT32),
-          PrimitiveNode::Make(
-            "leaf2", Repetition::REQUIRED, ParquetType::INT32)}));
-    parquet_fields.push_back(PrimitiveNode::Make(
-        "leaf3", Repetition::REQUIRED, ParquetType::INT32));
+        PrimitiveNode::Make("leaf3", Repetition::REQUIRED, ParquetType::INT32));
 
     const int num_columns = 3;
     auto schema_node = GroupNode::Make("schema", Repetition::REQUIRED, parquet_fields);

--- a/src/parquet/arrow/schema.cc
+++ b/src/parquet/arrow/schema.cc
@@ -18,8 +18,8 @@
 #include "parquet/arrow/schema.h"
 
 #include <string>
-#include <vector>
 #include <unordered_set>
+#include <vector>
 
 #include "parquet/api/schema.h"
 
@@ -192,11 +192,9 @@ Status NodeToFieldInternal(const NodePtr& node,
  * Auxilary function to test if a parquet schema node is a leaf node
  * that should be included in a resulting arrow schema
  */
-inline bool IsIncludedLeaf(const NodePtr& node,
-    const std::unordered_set<NodePtr>* included_leaf_nodes) {
-  if (included_leaf_nodes == nullptr) {
-    return true;
-  }
+inline bool IsIncludedLeaf(
+    const NodePtr& node, const std::unordered_set<NodePtr>* included_leaf_nodes) {
+  if (included_leaf_nodes == nullptr) { return true; }
   auto search = included_leaf_nodes->find(node);
   return (search != included_leaf_nodes->end());
 }
@@ -210,13 +208,9 @@ Status StructFromGroup(const GroupNode* group,
 
   for (int i = 0; i < group->field_count(); i++) {
     RETURN_NOT_OK(NodeToFieldInternal(group->field(i), included_leaf_nodes, &field));
-    if (field != nullptr) {
-      fields.push_back(field);
-    }
+    if (field != nullptr) { fields.push_back(field); }
   }
-  if (fields.size() > 0) {
-    *out = std::make_shared<::arrow::StructType>(fields);
-  }
+  if (fields.size() > 0) { *out = std::make_shared<::arrow::StructType>(fields); }
   return Status::OK();
 }
 
@@ -240,12 +234,10 @@ Status NodeToList(const GroupNode* group,
           !str_endswith_tuple(list_node->name())) {
         // List of primitive type
         std::shared_ptr<Field> item_field;
-        RETURN_NOT_OK(NodeToFieldInternal(
-          list_group->field(0), included_leaf_nodes, &item_field));
+        RETURN_NOT_OK(
+            NodeToFieldInternal(list_group->field(0), included_leaf_nodes, &item_field));
 
-        if (item_field != nullptr) {
-          *out = ::arrow::list(item_field);
-        }
+        if (item_field != nullptr) { *out = ::arrow::list(item_field); }
       } else {
         // List of struct
         std::shared_ptr<::arrow::DataType> inner_type;
@@ -260,7 +252,7 @@ Status NodeToList(const GroupNode* group,
       std::shared_ptr<::arrow::DataType> inner_type;
       if (IsIncludedLeaf(static_cast<NodePtr>(list_node), included_leaf_nodes)) {
         const PrimitiveNode* primitive =
-          static_cast<const PrimitiveNode*>(list_node.get());
+            static_cast<const PrimitiveNode*>(list_node.get());
         RETURN_NOT_OK(FromPrimitive(primitive, &inner_type));
         auto item_field = std::make_shared<Field>(list_node->name(), inner_type, false);
         *out = ::arrow::list(item_field);
@@ -282,7 +274,6 @@ Status NodeToField(const NodePtr& node, std::shared_ptr<Field>* out) {
 
 Status NodeToFieldInternal(const NodePtr& node,
     const std::unordered_set<NodePtr>* included_leaf_nodes, std::shared_ptr<Field>* out) {
-
   std::shared_ptr<::arrow::DataType> type = nullptr;
   bool nullable = !node->is_required();
 
@@ -317,9 +308,7 @@ Status NodeToFieldInternal(const NodePtr& node,
       RETURN_NOT_OK(FromPrimitive(primitive, &type));
     }
   }
-  if (type != nullptr) {
-    *out = std::make_shared<Field>(node->name(), type, nullable);
-  }
+  if (type != nullptr) { *out = std::make_shared<Field>(node->name(), type, nullable); }
   return Status::OK();
 }
 
@@ -354,11 +343,9 @@ Status FromParquetSchema(const SchemaDescriptor* parquet_schema,
   std::vector<std::shared_ptr<Field>> fields;
   std::shared_ptr<Field> field;
   for (int i = 0; i < schema_node->field_count(); i++) {
-    RETURN_NOT_OK(NodeToFieldInternal(
-      schema_node->field(i), &included_leaf_nodes, &field));
-    if (field != nullptr) {
-      fields.push_back(field);
-    }
+    RETURN_NOT_OK(
+        NodeToFieldInternal(schema_node->field(i), &included_leaf_nodes, &field));
+    if (field != nullptr) { fields.push_back(field); }
   }
 
   *out = std::make_shared<::arrow::Schema>(fields);

--- a/src/parquet/arrow/writer.h
+++ b/src/parquet/arrow/writer.h
@@ -47,6 +47,8 @@ namespace arrow {
  */
 class PARQUET_EXPORT FileWriter {
  public:
+  FileWriter(::arrow::MemoryPool* pool, std::unique_ptr<ParquetFileWriter> writer);
+
   static ::arrow::Status Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
       const std::shared_ptr<OutputStream>& sink,
       const std::shared_ptr<WriterProperties>& properties,
@@ -73,8 +75,6 @@ class PARQUET_EXPORT FileWriter {
   ::arrow::MemoryPool* memory_pool() const;
 
  private:
-  FileWriter(::arrow::MemoryPool* pool, std::unique_ptr<ParquetFileWriter> writer);
-
   class PARQUET_NO_EXPORT Impl;
   std::unique_ptr<Impl> impl_;
 };

--- a/src/parquet/arrow/writer.h
+++ b/src/parquet/arrow/writer.h
@@ -31,6 +31,7 @@ class Array;
 class MemoryPool;
 class PrimitiveArray;
 class RowBatch;
+class Schema;
 class Status;
 class StringArray;
 class Table;
@@ -47,7 +48,22 @@ namespace arrow {
  */
 class PARQUET_EXPORT FileWriter {
  public:
-  FileWriter(::arrow::MemoryPool* pool, std::unique_ptr<ParquetFileWriter> writer);
+  static ::arrow::Status Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
+      const std::shared_ptr<OutputStream>& sink,
+      const std::shared_ptr<WriterProperties>& properties,
+      std::unique_ptr<FileWriter>* writer);
+
+  static ::arrow::Status Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
+      const std::shared_ptr<::arrow::io::OutputStream>& sink,
+      const std::shared_ptr<WriterProperties>& properties,
+      std::unique_ptr<FileWriter>* writer);
+
+  /**
+   * Write a Table to Parquet.
+   *
+   * The table shall only consist of columns of primitive type or of primitive lists.
+   */
+  ::arrow::Status WriteTable(const ::arrow::Table& table, int64_t chunk_size);
 
   ::arrow::Status NewRowGroup(int64_t chunk_size);
   ::arrow::Status WriteColumnChunk(const ::arrow::Array& data);
@@ -58,6 +74,8 @@ class PARQUET_EXPORT FileWriter {
   ::arrow::MemoryPool* memory_pool() const;
 
  private:
+  FileWriter(::arrow::MemoryPool* pool, std::unique_ptr<ParquetFileWriter> writer);
+
   class PARQUET_NO_EXPORT Impl;
   std::unique_ptr<Impl> impl_;
 };
@@ -78,7 +96,6 @@ class PARQUET_EXPORT FileWriter {
     const std::shared_ptr<WriterProperties>& properties = default_writer_properties());
 
 }  // namespace arrow
-
 }  // namespace parquet
 
 #endif  // PARQUET_ARROW_WRITER_H

--- a/src/parquet/arrow/writer.h
+++ b/src/parquet/arrow/writer.h
@@ -35,10 +35,9 @@ class Schema;
 class Status;
 class StringArray;
 class Table;
-}
+}  // namespace arrow
 
 namespace parquet {
-
 namespace arrow {
 
 /**


### PR DESCRIPTION
I preserved the existing WriteTable top level methods, but this will unblock ARROW-528