### PR TITLE
PARQUET-963: Return NotImplemented when attempting to read a struct field

### DIFF
--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -948,26 +948,14 @@ class TestNestedSchemaRead : public ::testing::Test {
 
 TEST_F(TestNestedSchemaRead, ReadIntoTableFull) {
   std::shared_ptr<Table> table;
-  ASSERT_OK_NO_THROW(reader_->ReadTable(&table));
-  ASSERT_EQ(table->num_rows(), 0);
-  ASSERT_EQ(table->num_columns(), 2);
-  ASSERT_EQ(table->schema()->field(0)->type()->num_children(), 2);
+  ASSERT_RAISES(NotImplemented, reader_->ReadTable(&table));
 }
 
 TEST_F(TestNestedSchemaRead, ReadTablePartial) {
   std::shared_ptr<Table> table;
 
-  // columns: {group1.leaf1, leaf3}
-  ASSERT_OK_NO_THROW(reader_->ReadTable({0, 2}, &table));
-  ASSERT_EQ(table->num_rows(), 0);
-  ASSERT_EQ(table->num_columns(), 2);
-  ASSERT_EQ(table->schema()->field(0)->type()->num_children(), 1);
-
-  // columns: {group1.leaf1, group1.leaf2}
-  ASSERT_OK_NO_THROW(reader_->ReadTable({0, 1}, &table));
-  ASSERT_EQ(table->num_rows(), 0);
-  ASSERT_EQ(table->num_columns(), 1);
-  ASSERT_EQ(table->schema()->field(0)->type()->num_children(), 2);
+  ASSERT_RAISES(NotImplemented, reader_->ReadTable({0, 2}, &table));
+  ASSERT_RAISES(NotImplemented, reader_->ReadTable({0, 1}, &table));
 
   // columns: {leaf3}
   ASSERT_OK_NO_THROW(reader_->ReadTable({2}, &table));

--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -714,13 +714,18 @@ Status ColumnReader::Impl::InitValidBits(int batch_size) {
 
 Status ColumnReader::Impl::WrapIntoListArray(const int16_t* def_levels,
     const int16_t* rep_levels, int64_t total_levels_read, std::shared_ptr<Array>* array) {
-  if (descr_->max_repetition_level() > 0) {
-    std::shared_ptr<::arrow::Schema> arrow_schema;
-    RETURN_NOT_OK(
-        FromParquetSchema(input_->schema(), {input_->column_index()}, &arrow_schema));
+  std::shared_ptr<::arrow::Schema> arrow_schema;
+  RETURN_NOT_OK(
+      FromParquetSchema(input_->schema(), {input_->column_index()}, &arrow_schema));
+  std::shared_ptr<Field> current_field = arrow_schema->field(0);
 
+  if (current_field->type()->id() == ::arrow::Type::STRUCT) {
+    return Status::NotImplemented(
+        "Structs are not yet supported.");
+  }
+
+  if (descr_->max_repetition_level() > 0) {
     // Walk downwards to extract nullability
-    std::shared_ptr<Field> current_field = arrow_schema->field(0);
     std::vector<bool> nullable;
     std::vector<std::shared_ptr<::arrow::Int32Builder>> offset_builders;
     std::vector<std::shared_ptr<::arrow::BooleanBuilder>> valid_bits_builders;


### PR DESCRIPTION
cc @xhochy @itaiin @advancedxy We are not yet able to correctly to read structs. This showed up in ARROW-601, so this raises an exception for now