### PR TITLE
PARQUET-958: [C++] Print Parquet metadata in JSON format

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -19,7 +19,7 @@ SET(LINK_LIBS
   snappystatic
   thriftstatic)
 
-if (PARQUET_BUILD_EXECUTABLES)
+if (PARQUET_BUILD_BENCHMARKS)
   add_executable(decode_benchmark decode_benchmark.cc)
 
   # This uses private APIs

--- a/src/parquet/file/printer.cc
+++ b/src/parquet/file/printer.cc
@@ -174,12 +174,12 @@ void ParquetFilePrinter::JSONPrint(
            << " \"LogicalType\": \"" << LogicalTypeToString(descr->logical_type())
            << "\" }";
     c++;
-    if (c != static_cast<int>(selected_columns.size())) { stream << ",\n";}
+    if (c != static_cast<int>(selected_columns.size())) { stream << ",\n"; }
   }
 
   stream << "\n  ],\n  \"RowGroups\": [\n";
   for (int r = 0; r < file_metadata->num_row_groups(); ++r) {
-    stream << "     {\n       \"Id\": \""<< r << "\", ";
+    stream << "     {\n       \"Id\": \"" << r << "\", ";
 
     auto group_reader = fileReader->RowGroup(r);
     std::unique_ptr<RowGroupMetaData> group_metadata = file_metadata->RowGroup(r);
@@ -210,11 +210,11 @@ void ParquetFilePrinter::JSONPrint(
       } else {
         stream << "\"False\", ";
       }
-        stream << "\n           \"Compression\": \""
-               << CompressionToString(column_chunk->compression())
-               << "\", \"Encodings\": \"";
+      stream << "\n           \"Compression\": \""
+             << CompressionToString(column_chunk->compression())
+             << "\", \"Encodings\": \"";
       for (auto encoding : column_chunk->encodings()) {
-        stream  << EncodingToString(encoding) << " ";
+        stream << EncodingToString(encoding) << " ";
       }
       stream << "\", "
              << "\"UncompressedSize\": \"" << column_chunk->total_uncompressed_size()
@@ -223,14 +223,13 @@ void ParquetFilePrinter::JSONPrint(
       // end of a ColumnChunk
       stream << "\" }";
       c1++;
-      if (c1 != static_cast<int>(selected_columns.size())) { stream << ",\n";}
+      if (c1 != static_cast<int>(selected_columns.size())) { stream << ",\n"; }
     }
 
     stream << "\n        ]\n     }";
-    if ((r + 1) != static_cast<int>(file_metadata->num_row_groups())) { stream << ",\n";}
+    if ((r + 1) != static_cast<int>(file_metadata->num_row_groups())) { stream << ",\n"; }
   }
   stream << "\n  ]\n}\n";
 }
-
 
 }  // namespace parquet

--- a/src/parquet/file/printer.cc
+++ b/src/parquet/file/printer.cc
@@ -33,10 +33,11 @@ namespace parquet {
 #define COL_WIDTH "30"
 
 void ParquetFilePrinter::DebugPrint(
-    std::ostream& stream, std::list<int> selected_columns, bool print_values) {
+    std::ostream& stream, std::list<int> selected_columns, bool print_values,
+    const char* filename) {
   const FileMetaData* file_metadata = fileReader->metadata().get();
 
-  stream << "File statistics:\n";
+  stream << "File Name: " << filename << "\n";
   stream << "Version: " << file_metadata->version() << "\n";
   stream << "Created By: " << file_metadata->created_by() << "\n";
   stream << "Total rows: " << file_metadata->num_rows() << "\n";
@@ -71,7 +72,7 @@ void ParquetFilePrinter::DebugPrint(
     std::unique_ptr<RowGroupMetaData> group_metadata = file_metadata->RowGroup(r);
 
     stream << "--- Total Bytes " << group_metadata->total_byte_size() << " ---\n";
-    stream << "  rows: " << group_metadata->num_rows() << "---\n";
+    stream << "  Rows: " << group_metadata->num_rows() << "---\n";
 
     // Print column metadata
     for (auto i : selected_columns) {
@@ -79,25 +80,25 @@ void ParquetFilePrinter::DebugPrint(
       std::shared_ptr<RowGroupStatistics> stats = column_chunk->statistics();
 
       const ColumnDescriptor* descr = file_metadata->schema()->Column(i);
-      stream << "Column " << i << std::endl << ", values: " << column_chunk->num_values();
+      stream << "Column " << i << std::endl << ", Values: " << column_chunk->num_values();
       if (column_chunk->is_stats_set()) {
         std::string min = stats->EncodeMin(), max = stats->EncodeMax();
-        stream << ", null values: " << stats->null_count()
-               << ", distinct values: " << stats->distinct_count() << std::endl
-               << "  max: " << FormatStatValue(descr->physical_type(), max.c_str())
-               << ", min: " << FormatStatValue(descr->physical_type(), min.c_str());
+        stream << ", Null Values: " << stats->null_count()
+               << ", Distinct Values: " << stats->distinct_count() << std::endl
+               << "  Max: " << FormatStatValue(descr->physical_type(), max.c_str())
+               << ", Min: " << FormatStatValue(descr->physical_type(), min.c_str());
       } else {
         stream << "  Statistics Not Set";
       }
       stream << std::endl
-             << "  compression: " << CompressionToString(column_chunk->compression())
-             << ", encodings: ";
+             << "  Compression: " << CompressionToString(column_chunk->compression())
+             << ", Encodings: ";
       for (auto encoding : column_chunk->encodings()) {
         stream << EncodingToString(encoding) << " ";
       }
       stream << std::endl
-             << "  uncompressed size: " << column_chunk->total_uncompressed_size()
-             << ", compressed size: " << column_chunk->total_compressed_size()
+             << "  Uncompressed Size: " << column_chunk->total_uncompressed_size()
+             << ", Compressed Size: " << column_chunk->total_compressed_size()
              << std::endl;
     }
 
@@ -141,7 +142,8 @@ void ParquetFilePrinter::DebugPrint(
 }
 
 void ParquetFilePrinter::JSONPrint(
-    std::ostream& stream, std::list<int> selected_columns, const char* filename) {
+    std::ostream& stream, std::list<int> selected_columns,
+    const char* filename) {
   const FileMetaData* file_metadata = fileReader->metadata().get();
   stream << "{\n";
   stream << "  \"FileName\": \"" << filename << "\",\n";

--- a/src/parquet/file/printer.cc
+++ b/src/parquet/file/printer.cc
@@ -140,4 +140,97 @@ void ParquetFilePrinter::DebugPrint(
   }
 }
 
+void ParquetFilePrinter::JSONPrint(
+    std::ostream& stream, std::list<int> selected_columns, const char* filename) {
+  const FileMetaData* file_metadata = fileReader->metadata().get();
+  stream << "{\n";
+  stream << "  \"FileName\": \"" << filename << "\",\n";
+  stream << "  \"Version\": \"" << file_metadata->version() << "\",\n";
+  stream << "  \"CreatedBy\": \"" << file_metadata->created_by() << "\",\n";
+  stream << "  \"TotalRows\": \"" << file_metadata->num_rows() << "\",\n";
+  stream << "  \"NumberOfRowGroups\": \"" << file_metadata->num_row_groups() << "\",\n";
+  stream << "  \"NumberOfRealColumns\": \""
+         << file_metadata->schema()->group_node()->field_count() << "\",\n";
+  stream << "  \"NumberOfColumns\": \"" << file_metadata->num_columns() << "\",\n";
+
+  if (selected_columns.size() == 0) {
+    for (int i = 0; i < file_metadata->num_columns(); i++) {
+      selected_columns.push_back(i);
+    }
+  } else {
+    for (auto i : selected_columns) {
+      if (i < 0 || i >= file_metadata->num_columns()) {
+        throw ParquetException("Selected column is out of range");
+      }
+    }
+  }
+
+  stream << "  \"Columns\": [\n";
+  int c = 0;
+  for (auto i : selected_columns) {
+    const ColumnDescriptor* descr = file_metadata->schema()->Column(i);
+    stream << "     { \"Id\": \"" << i << "\", \"Name\": \"" << descr->name() << "\","
+           << " \"PhysicalType\": \"" << TypeToString(descr->physical_type()) << "\","
+           << " \"LogicalType\": \"" << LogicalTypeToString(descr->logical_type())
+           << "\" }";
+    c++;
+    if (c != static_cast<int>(selected_columns.size())) { stream << ",\n";}
+  }
+
+  stream << "\n  ],\n  \"RowGroups\": [\n";
+  for (int r = 0; r < file_metadata->num_row_groups(); ++r) {
+    stream << "     {\n       \"Id\": \""<< r << "\", ";
+
+    auto group_reader = fileReader->RowGroup(r);
+    std::unique_ptr<RowGroupMetaData> group_metadata = file_metadata->RowGroup(r);
+
+    stream << " \"TotalBytes\": \"" << group_metadata->total_byte_size() << "\", ";
+    stream << " \"Rows\": \"" << group_metadata->num_rows() << "\",\n";
+
+    // Print column metadata
+    stream << "       \"ColumnChunks\": [\n";
+    int c1 = 0;
+    for (auto i : selected_columns) {
+      auto column_chunk = group_metadata->ColumnChunk(i);
+      std::shared_ptr<RowGroupStatistics> stats = column_chunk->statistics();
+
+      const ColumnDescriptor* descr = file_metadata->schema()->Column(i);
+      stream << "          {\"Id\": \"" << i << "\", \"Values\": \""
+             << column_chunk->num_values() << "\", "
+             << "\"StatsSet\": ";
+      if (column_chunk->is_stats_set()) {
+        stream << "\"True\", \"Stats\": {";
+        std::string min = stats->EncodeMin(), max = stats->EncodeMax();
+        stream << "\"NumNulls\": \"" << stats->null_count() << "\", "
+               << "\"DistinctValues\": \"" << stats->distinct_count() << "\", "
+               << "\"Max\": \"" << FormatStatValue(descr->physical_type(), max.c_str())
+               << "\", "
+               << "\"Min\": \"" << FormatStatValue(descr->physical_type(), min.c_str())
+               << "\" }, ";
+      } else {
+        stream << "\"False\", ";
+      }
+        stream << "\n           \"Compression\": \""
+               << CompressionToString(column_chunk->compression())
+               << "\", \"Encodings\": \"";
+      for (auto encoding : column_chunk->encodings()) {
+        stream  << EncodingToString(encoding) << " ";
+      }
+      stream << "\", "
+             << "\"UncompressedSize\": \"" << column_chunk->total_uncompressed_size()
+             << "\", \"CompressedSize\": \"" << column_chunk->total_compressed_size();
+
+      // end of a ColumnChunk
+      stream << "\" }";
+      c1++;
+      if (c1 != static_cast<int>(selected_columns.size())) { stream << ",\n";}
+    }
+
+    stream << "\n        ]\n     }";
+    if ((r + 1) != static_cast<int>(file_metadata->num_row_groups())) { stream << ",\n";}
+  }
+  stream << "\n  ]\n}\n";
+}
+
+
 }  // namespace parquet

--- a/src/parquet/file/printer.cc
+++ b/src/parquet/file/printer.cc
@@ -206,9 +206,9 @@ void ParquetFilePrinter::JSONPrint(
                << "\"Max\": \"" << FormatStatValue(descr->physical_type(), max.c_str())
                << "\", "
                << "\"Min\": \"" << FormatStatValue(descr->physical_type(), min.c_str())
-               << "\" }, ";
+               << "\" },";
       } else {
-        stream << "\"False\", ";
+        stream << "\"False\",";
       }
       stream << "\n           \"Compression\": \""
              << CompressionToString(column_chunk->compression())

--- a/src/parquet/file/printer.h
+++ b/src/parquet/file/printer.h
@@ -32,6 +32,7 @@ namespace parquet {
 class PARQUET_EXPORT ParquetFilePrinter {
  private:
   ParquetFileReader* fileReader;
+
  public:
   explicit ParquetFilePrinter(ParquetFileReader* reader) : fileReader(reader) {}
   ~ParquetFilePrinter() {}

--- a/src/parquet/file/printer.h
+++ b/src/parquet/file/printer.h
@@ -38,6 +38,9 @@ class PARQUET_EXPORT ParquetFilePrinter {
 
   void DebugPrint(
       std::ostream& stream, std::list<int> selected_columns, bool print_values = true);
+
+  void JSONPrint(
+      std::ostream& stream, std::list<int> selected_columns, const char* filename);
 };
 
 }  // namespace parquet

--- a/src/parquet/file/printer.h
+++ b/src/parquet/file/printer.h
@@ -38,10 +38,12 @@ class PARQUET_EXPORT ParquetFilePrinter {
   ~ParquetFilePrinter() {}
 
   void DebugPrint(
-      std::ostream& stream, std::list<int> selected_columns, bool print_values = true);
+      std::ostream& stream, std::list<int> selected_columns, bool print_values = true,
+      const char* fileame = "No Name");
 
   void JSONPrint(
-      std::ostream& stream, std::list<int> selected_columns, const char* filename);
+      std::ostream& stream, std::list<int> selected_columns,
+      const char* filename = "No Name");
 };
 
 }  // namespace parquet

--- a/src/parquet/reader-test.cc
+++ b/src/parquet/reader-test.cc
@@ -256,4 +256,70 @@ TEST(TestFileReaderAdHoc, NationDictTruncatedDataPage) {
   ASSERT_EQ(ss2.str(), ss.str());
 }
 
+TEST_F(TestJSONWithLocalFile, JSONOutput) {
+  std::string jsonOutput =
+      "{\n\
+  \"FileName\": \"alltypes_plain.parquet\",\n\
+  \"Version\": \"0\",\n\
+  \"CreatedBy\": \"impala version 1.3.0-INTERNAL (build 8a48ddb1eff84592b3fc06bc6f51ec120e1fffc9)\",\n\
+  \"TotalRows\": \"8\",\n\
+  \"NumberOfRowGroups\": \"1\",\n\
+  \"NumberOfRealColumns\": \"11\",\n\
+  \"NumberOfColumns\": \"11\",\n\
+  \"Columns\": [\n\
+     { \"Id\": \"0\", \"Name\": \"id\", \"PhysicalType\": \"INT32\", \"LogicalType\": \"NONE\" },\n\
+     { \"Id\": \"1\", \"Name\": \"bool_col\", \"PhysicalType\": \"BOOLEAN\", \"LogicalType\": \"NONE\" },\n\
+     { \"Id\": \"2\", \"Name\": \"tinyint_col\", \"PhysicalType\": \"INT32\", \"LogicalType\": \"NONE\" },\n\
+     { \"Id\": \"3\", \"Name\": \"smallint_col\", \"PhysicalType\": \"INT32\", \"LogicalType\": \"NONE\" },\n\
+     { \"Id\": \"4\", \"Name\": \"int_col\", \"PhysicalType\": \"INT32\", \"LogicalType\": \"NONE\" },\n\
+     { \"Id\": \"5\", \"Name\": \"bigint_col\", \"PhysicalType\": \"INT64\", \"LogicalType\": \"NONE\" },\n\
+     { \"Id\": \"6\", \"Name\": \"float_col\", \"PhysicalType\": \"FLOAT\", \"LogicalType\": \"NONE\" },\n\
+     { \"Id\": \"7\", \"Name\": \"double_col\", \"PhysicalType\": \"DOUBLE\", \"LogicalType\": \"NONE\" },\n\
+     { \"Id\": \"8\", \"Name\": \"date_string_col\", \"PhysicalType\": \"BYTE_ARRAY\", \"LogicalType\": \"NONE\" },\n\
+     { \"Id\": \"9\", \"Name\": \"string_col\", \"PhysicalType\": \"BYTE_ARRAY\", \"LogicalType\": \"NONE\" },\n\
+     { \"Id\": \"10\", \"Name\": \"timestamp_col\", \"PhysicalType\": \"INT96\", \"LogicalType\": \"NONE\" }\n\
+  ],\n\
+  \"RowGroups\": [\n\
+     {\n\
+       \"Id\": \"0\",  \"TotalBytes\": \"671\",  \"Rows\": \"8\",\n\
+       \"ColumnChunks\": [\n\
+          {\"Id\": \"0\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
+           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"73\", \"CompressedSize\": \"73\" },\n\
+          {\"Id\": \"1\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
+           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"24\", \"CompressedSize\": \"24\" },\n\
+          {\"Id\": \"2\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
+           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"47\", \"CompressedSize\": \"47\" },\n\
+          {\"Id\": \"3\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
+           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"47\", \"CompressedSize\": \"47\" },\n\
+          {\"Id\": \"4\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
+           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"47\", \"CompressedSize\": \"47\" },\n\
+          {\"Id\": \"5\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
+           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"55\", \"CompressedSize\": \"55\" },\n\
+          {\"Id\": \"6\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
+           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"47\", \"CompressedSize\": \"47\" },\n\
+          {\"Id\": \"7\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
+           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"55\", \"CompressedSize\": \"55\" },\n\
+          {\"Id\": \"8\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
+           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"88\", \"CompressedSize\": \"88\" },\n\
+          {\"Id\": \"9\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
+           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"49\", \"CompressedSize\": \"49\" },\n\
+          {\"Id\": \"10\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
+           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"139\", \"CompressedSize\": \"139\" }\n\
+        ]\n\
+     }\n\
+  ]\n\
+}\n";
+
+  std::stringstream ss;
+  // empty list means print all
+  std::list<int> columns;
+
+  auto reader =
+      ParquetFileReader::OpenFile(alltypes_plain(), false, default_reader_properties());
+  ParquetFilePrinter printer(reader.get());
+  printer.JSONPrint(ss, columns, "alltypes_plain.parquet");
+
+  ASSERT_EQ(jsonOutput, ss.str());
+}
+
 }  // namespace parquet

--- a/src/parquet/reader-test.cc
+++ b/src/parquet/reader-test.cc
@@ -256,59 +256,59 @@ TEST(TestFileReaderAdHoc, NationDictTruncatedDataPage) {
   ASSERT_EQ(ss2.str(), ss.str());
 }
 
-TEST_F(TestJSONWithLocalFile, JSONOutput) {
-  std::string jsonOutput =
-      "{\n\
-  \"FileName\": \"alltypes_plain.parquet\",\n\
-  \"Version\": \"0\",\n\
-  \"CreatedBy\": \"impala version 1.3.0-INTERNAL (build 8a48ddb1eff84592b3fc06bc6f51ec120e1fffc9)\",\n\
-  \"TotalRows\": \"8\",\n\
-  \"NumberOfRowGroups\": \"1\",\n\
-  \"NumberOfRealColumns\": \"11\",\n\
-  \"NumberOfColumns\": \"11\",\n\
-  \"Columns\": [\n\
-     { \"Id\": \"0\", \"Name\": \"id\", \"PhysicalType\": \"INT32\", \"LogicalType\": \"NONE\" },\n\
-     { \"Id\": \"1\", \"Name\": \"bool_col\", \"PhysicalType\": \"BOOLEAN\", \"LogicalType\": \"NONE\" },\n\
-     { \"Id\": \"2\", \"Name\": \"tinyint_col\", \"PhysicalType\": \"INT32\", \"LogicalType\": \"NONE\" },\n\
-     { \"Id\": \"3\", \"Name\": \"smallint_col\", \"PhysicalType\": \"INT32\", \"LogicalType\": \"NONE\" },\n\
-     { \"Id\": \"4\", \"Name\": \"int_col\", \"PhysicalType\": \"INT32\", \"LogicalType\": \"NONE\" },\n\
-     { \"Id\": \"5\", \"Name\": \"bigint_col\", \"PhysicalType\": \"INT64\", \"LogicalType\": \"NONE\" },\n\
-     { \"Id\": \"6\", \"Name\": \"float_col\", \"PhysicalType\": \"FLOAT\", \"LogicalType\": \"NONE\" },\n\
-     { \"Id\": \"7\", \"Name\": \"double_col\", \"PhysicalType\": \"DOUBLE\", \"LogicalType\": \"NONE\" },\n\
-     { \"Id\": \"8\", \"Name\": \"date_string_col\", \"PhysicalType\": \"BYTE_ARRAY\", \"LogicalType\": \"NONE\" },\n\
-     { \"Id\": \"9\", \"Name\": \"string_col\", \"PhysicalType\": \"BYTE_ARRAY\", \"LogicalType\": \"NONE\" },\n\
-     { \"Id\": \"10\", \"Name\": \"timestamp_col\", \"PhysicalType\": \"INT96\", \"LogicalType\": \"NONE\" }\n\
-  ],\n\
-  \"RowGroups\": [\n\
-     {\n\
-       \"Id\": \"0\",  \"TotalBytes\": \"671\",  \"Rows\": \"8\",\n\
-       \"ColumnChunks\": [\n\
-          {\"Id\": \"0\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
-           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"73\", \"CompressedSize\": \"73\" },\n\
-          {\"Id\": \"1\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
-           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"24\", \"CompressedSize\": \"24\" },\n\
-          {\"Id\": \"2\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
-           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"47\", \"CompressedSize\": \"47\" },\n\
-          {\"Id\": \"3\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
-           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"47\", \"CompressedSize\": \"47\" },\n\
-          {\"Id\": \"4\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
-           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"47\", \"CompressedSize\": \"47\" },\n\
-          {\"Id\": \"5\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
-           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"55\", \"CompressedSize\": \"55\" },\n\
-          {\"Id\": \"6\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
-           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"47\", \"CompressedSize\": \"47\" },\n\
-          {\"Id\": \"7\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
-           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"55\", \"CompressedSize\": \"55\" },\n\
-          {\"Id\": \"8\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
-           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"88\", \"CompressedSize\": \"88\" },\n\
-          {\"Id\": \"9\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
-           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"49\", \"CompressedSize\": \"49\" },\n\
-          {\"Id\": \"10\", \"Values\": \"8\", \"StatsSet\": \"False\", \n\
-           \"Compression\": \"UNCOMPRESSED\", \"Encodings\": \"RLE PLAIN_DICTIONARY PLAIN \", \"UncompressedSize\": \"139\", \"CompressedSize\": \"139\" }\n\
-        ]\n\
-     }\n\
-  ]\n\
-}\n";
+TEST(TestJSONWithLocalFile, JSONOutput) {
+  std::string jsonOutput = R"###({
+  "FileName": "alltypes_plain.parquet",
+  "Version": "0",
+  "CreatedBy": "impala version 1.3.0-INTERNAL (build 8a48ddb1eff84592b3fc06bc6f51ec120e1fffc9)",
+  "TotalRows": "8",
+  "NumberOfRowGroups": "1",
+  "NumberOfRealColumns": "11",
+  "NumberOfColumns": "11",
+  "Columns": [
+     { "Id": "0", "Name": "id", "PhysicalType": "INT32", "LogicalType": "NONE" },
+     { "Id": "1", "Name": "bool_col", "PhysicalType": "BOOLEAN", "LogicalType": "NONE" },
+     { "Id": "2", "Name": "tinyint_col", "PhysicalType": "INT32", "LogicalType": "NONE" },
+     { "Id": "3", "Name": "smallint_col", "PhysicalType": "INT32", "LogicalType": "NONE" },
+     { "Id": "4", "Name": "int_col", "PhysicalType": "INT32", "LogicalType": "NONE" },
+     { "Id": "5", "Name": "bigint_col", "PhysicalType": "INT64", "LogicalType": "NONE" },
+     { "Id": "6", "Name": "float_col", "PhysicalType": "FLOAT", "LogicalType": "NONE" },
+     { "Id": "7", "Name": "double_col", "PhysicalType": "DOUBLE", "LogicalType": "NONE" },
+     { "Id": "8", "Name": "date_string_col", "PhysicalType": "BYTE_ARRAY", "LogicalType": "NONE" },
+     { "Id": "9", "Name": "string_col", "PhysicalType": "BYTE_ARRAY", "LogicalType": "NONE" },
+     { "Id": "10", "Name": "timestamp_col", "PhysicalType": "INT96", "LogicalType": "NONE" }
+  ],
+  "RowGroups": [
+     {
+       "Id": "0",  "TotalBytes": "671",  "Rows": "8",
+       "ColumnChunks": [
+          {"Id": "0", "Values": "8", "StatsSet": "False",
+           "Compression": "UNCOMPRESSED", "Encodings": "RLE PLAIN_DICTIONARY PLAIN ", "UncompressedSize": "73", "CompressedSize": "73" },
+          {"Id": "1", "Values": "8", "StatsSet": "False",
+           "Compression": "UNCOMPRESSED", "Encodings": "RLE PLAIN_DICTIONARY PLAIN ", "UncompressedSize": "24", "CompressedSize": "24" },
+          {"Id": "2", "Values": "8", "StatsSet": "False",
+           "Compression": "UNCOMPRESSED", "Encodings": "RLE PLAIN_DICTIONARY PLAIN ", "UncompressedSize": "47", "CompressedSize": "47" },
+          {"Id": "3", "Values": "8", "StatsSet": "False",
+           "Compression": "UNCOMPRESSED", "Encodings": "RLE PLAIN_DICTIONARY PLAIN ", "UncompressedSize": "47", "CompressedSize": "47" },
+          {"Id": "4", "Values": "8", "StatsSet": "False",
+           "Compression": "UNCOMPRESSED", "Encodings": "RLE PLAIN_DICTIONARY PLAIN ", "UncompressedSize": "47", "CompressedSize": "47" },
+          {"Id": "5", "Values": "8", "StatsSet": "False",
+           "Compression": "UNCOMPRESSED", "Encodings": "RLE PLAIN_DICTIONARY PLAIN ", "UncompressedSize": "55", "CompressedSize": "55" },
+          {"Id": "6", "Values": "8", "StatsSet": "False",
+           "Compression": "UNCOMPRESSED", "Encodings": "RLE PLAIN_DICTIONARY PLAIN ", "UncompressedSize": "47", "CompressedSize": "47" },
+          {"Id": "7", "Values": "8", "StatsSet": "False",
+           "Compression": "UNCOMPRESSED", "Encodings": "RLE PLAIN_DICTIONARY PLAIN ", "UncompressedSize": "55", "CompressedSize": "55" },
+          {"Id": "8", "Values": "8", "StatsSet": "False",
+           "Compression": "UNCOMPRESSED", "Encodings": "RLE PLAIN_DICTIONARY PLAIN ", "UncompressedSize": "88", "CompressedSize": "88" },
+          {"Id": "9", "Values": "8", "StatsSet": "False",
+           "Compression": "UNCOMPRESSED", "Encodings": "RLE PLAIN_DICTIONARY PLAIN ", "UncompressedSize": "49", "CompressedSize": "49" },
+          {"Id": "10", "Values": "8", "StatsSet": "False",
+           "Compression": "UNCOMPRESSED", "Encodings": "RLE PLAIN_DICTIONARY PLAIN ", "UncompressedSize": "139", "CompressedSize": "139" }
+        ]
+     }
+  ]
+}
+)###";
 
   std::stringstream ss;
   // empty list means print all

--- a/tools/parquet_reader.cc
+++ b/tools/parquet_reader.cc
@@ -23,7 +23,7 @@
 
 int main(int argc, char** argv) {
   if (argc > 5 || argc < 2) {
-    std::cerr << "Usage: parquet_reader [--only-metadata] [--no-memory-map] "
+    std::cerr << "Usage: parquet_reader [--only-metadata] [--no-memory-map] [--json]"
                  "[--columns=...] <file>"
               << std::endl;
     return -1;
@@ -32,6 +32,7 @@ int main(int argc, char** argv) {
   std::string filename;
   bool print_values = true;
   bool memory_map = true;
+  bool format_json = false;
 
   // Read command-line options
   const std::string COLUMNS_PREFIX = "--columns=";
@@ -43,6 +44,8 @@ int main(int argc, char** argv) {
       print_values = false;
     } else if ((param = std::strstr(argv[i], "--no-memory-map"))) {
       memory_map = false;
+    } else if ((param = std::strstr(argv[i], "--json"))) {
+      format_json = true;
     } else if ((param = std::strstr(argv[i], COLUMNS_PREFIX.c_str()))) {
       value = std::strtok(param + COLUMNS_PREFIX.length(), ",");
       while (value) {
@@ -58,7 +61,11 @@ int main(int argc, char** argv) {
     std::unique_ptr<parquet::ParquetFileReader> reader =
         parquet::ParquetFileReader::OpenFile(filename, memory_map);
     parquet::ParquetFilePrinter printer(reader.get());
-    printer.DebugPrint(std::cout, columns, print_values);
+    if (format_json) {
+      printer.JSONPrint(std::cout, columns, filename.c_str());
+    } else {
+      printer.DebugPrint(std::cout, columns, print_values);
+    }
   } catch (const std::exception& e) {
     std::cerr << "Parquet error: " << e.what() << std::endl;
     return -1;

--- a/tools/parquet_reader.cc
+++ b/tools/parquet_reader.cc
@@ -64,7 +64,7 @@ int main(int argc, char** argv) {
     if (format_json) {
       printer.JSONPrint(std::cout, columns, filename.c_str());
     } else {
-      printer.DebugPrint(std::cout, columns, print_values);
+      printer.DebugPrint(std::cout, columns, print_values, filename.c_str());
     }
   } catch (const std::exception& e) {
     std::cerr << "Parquet error: " << e.what() << std::endl;


### PR DESCRIPTION
Made minor formatting changes to DebugPrint
No support to print values. Only the metadata is JSON formatted in this patch.