### PR TITLE
PARQUET-915: Support additional Arrow date/time types and metadata

### DIFF
--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -44,6 +44,7 @@ using arrow::PrimitiveArray;
 using arrow::Status;
 using arrow::Table;
 
+using ArrowId = ::arrow::Type;
 using ParquetType = parquet::Type;
 using parquet::schema::GroupNode;
 using parquet::schema::NodePtr;
@@ -58,13 +59,98 @@ const int LARGE_SIZE = 10000;
 
 constexpr uint32_t kDefaultSeed = 0;
 
+LogicalType::type get_logical_type(const ::arrow::DataType& type) {
+  switch (type.id()) {
+    case ArrowId::UINT8:
+      return LogicalType::UINT_8;
+    case ArrowId::INT8:
+      return LogicalType::INT_8;
+    case ArrowId::UINT16:
+      return LogicalType::UINT_16;
+    case ArrowId::INT16:
+      return LogicalType::INT_16;
+    case ArrowId::UINT32:
+      return LogicalType::UINT_32;
+    case ArrowId::INT32:
+      return LogicalType::INT_32;
+    case ArrowId::UINT64:
+      return LogicalType::UINT_64;
+    case ArrowId::INT64:
+      return LogicalType::INT_64;
+    case ArrowId::STRING:
+      return LogicalType::UTF8;
+    case ArrowId::DATE32:
+      return LogicalType::DATE;
+    case ArrowId::DATE64:
+      return LogicalType::DATE;
+    case ArrowId::TIMESTAMP: {
+      const auto& ts_type = static_cast<const ::arrow::TimestampType&>(type);
+      switch (ts_type.unit()) {
+        case ::arrow::TimeUnit::MILLI:
+          return LogicalType::TIMESTAMP_MILLIS;
+        case ::arrow::TimeUnit::MICRO:
+          return LogicalType::TIMESTAMP_MICROS;
+        default:
+          DCHECK(false)
+            << "Only MILLI and MICRO units supported for Arrow timestamps with Parquet.";
+      }
+    }
+    case ArrowId::TIME32:
+      return LogicalType::TIME_MILLIS;
+    case ArrowId::TIME64:
+      return LogicalType::TIME_MICROS;
+    default:
+      break;
+  }
+  return LogicalType::NONE;
+}
+
+ParquetType::type get_physical_type(const ::arrow::DataType& type) {
+  switch (type.id()) {
+    case ArrowId::BOOL:
+      return ParquetType::BOOLEAN;
+    case ArrowId::UINT8:
+    case ArrowId::INT8:
+    case ArrowId::UINT16:
+    case ArrowId::INT16:
+    case ArrowId::UINT32:
+    case ArrowId::INT32:
+      return ParquetType::INT32;
+    case ArrowId::UINT64:
+    case ArrowId::INT64:
+      return ParquetType::INT64;
+    case ArrowId::FLOAT:
+      return ParquetType::FLOAT;
+    case ArrowId::DOUBLE:
+      return ParquetType::DOUBLE;
+    case ArrowId::BINARY:
+      return ParquetType::BYTE_ARRAY;
+    case ArrowId::STRING:
+      return ParquetType::BYTE_ARRAY;
+    case ArrowId::DATE32:
+      return ParquetType::INT32;
+    case ArrowId::DATE64:
+      // Convert to date32 internally
+      return ParquetType::INT32;
+    case ArrowId::TIME32:
+      return ParquetType::INT32;
+    case ArrowId::TIME64:
+      return ParquetType::INT64;
+    case ArrowId::TIMESTAMP:
+      return ParquetType::INT64;
+    default:
+      break;
+  }
+  DCHECK(false) << "cannot reach this code";
+  return ParquetType::INT32;
+}
+
 template <typename TestType>
 struct test_traits {};
 
 template <>
 struct test_traits<::arrow::BooleanType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::BOOLEAN;
-  static constexpr LogicalType::type logical_enum = LogicalType::NONE;
   static uint8_t const value;
 };
 
@@ -73,7 +159,6 @@ const uint8_t test_traits<::arrow::BooleanType>::value(1);
 template <>
 struct test_traits<::arrow::UInt8Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT32;
-  static constexpr LogicalType::type logical_enum = LogicalType::UINT_8;
   static uint8_t const value;
 };
 
@@ -82,7 +167,6 @@ const uint8_t test_traits<::arrow::UInt8Type>::value(64);
 template <>
 struct test_traits<::arrow::Int8Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT32;
-  static constexpr LogicalType::type logical_enum = LogicalType::INT_8;
   static int8_t const value;
 };
 
@@ -91,7 +175,6 @@ const int8_t test_traits<::arrow::Int8Type>::value(-64);
 template <>
 struct test_traits<::arrow::UInt16Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT32;
-  static constexpr LogicalType::type logical_enum = LogicalType::UINT_16;
   static uint16_t const value;
 };
 
@@ -100,7 +183,6 @@ const uint16_t test_traits<::arrow::UInt16Type>::value(1024);
 template <>
 struct test_traits<::arrow::Int16Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT32;
-  static constexpr LogicalType::type logical_enum = LogicalType::INT_16;
   static int16_t const value;
 };
 
@@ -109,7 +191,6 @@ const int16_t test_traits<::arrow::Int16Type>::value(-1024);
 template <>
 struct test_traits<::arrow::UInt32Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT32;
-  static constexpr LogicalType::type logical_enum = LogicalType::UINT_32;
   static uint32_t const value;
 };
 
@@ -118,7 +199,6 @@ const uint32_t test_traits<::arrow::UInt32Type>::value(1024);
 template <>
 struct test_traits<::arrow::Int32Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT32;
-  static constexpr LogicalType::type logical_enum = LogicalType::NONE;
   static int32_t const value;
 };
 
@@ -127,7 +207,6 @@ const int32_t test_traits<::arrow::Int32Type>::value(-1024);
 template <>
 struct test_traits<::arrow::UInt64Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT64;
-  static constexpr LogicalType::type logical_enum = LogicalType::UINT_64;
   static uint64_t const value;
 };
 
@@ -136,7 +215,6 @@ const uint64_t test_traits<::arrow::UInt64Type>::value(1024);
 template <>
 struct test_traits<::arrow::Int64Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT64;
-  static constexpr LogicalType::type logical_enum = LogicalType::NONE;
   static int64_t const value;
 };
 
@@ -145,25 +223,22 @@ const int64_t test_traits<::arrow::Int64Type>::value(-1024);
 template <>
 struct test_traits<::arrow::TimestampType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT64;
-  static constexpr LogicalType::type logical_enum = LogicalType::TIMESTAMP_MILLIS;
   static int64_t const value;
 };
 
 const int64_t test_traits<::arrow::TimestampType>::value(14695634030000);
 
 template <>
-struct test_traits<::arrow::Date64Type> {
+struct test_traits<::arrow::Date32Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT32;
-  static constexpr LogicalType::type logical_enum = LogicalType::DATE;
-  static int64_t const value;
+  static int32_t const value;
 };
 
-const int64_t test_traits<::arrow::Date64Type>::value(14688000000000);
+const int32_t test_traits<::arrow::Date32Type>::value(170000);
 
 template <>
 struct test_traits<::arrow::FloatType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::FLOAT;
-  static constexpr LogicalType::type logical_enum = LogicalType::NONE;
   static float const value;
 };
 
@@ -172,7 +247,6 @@ const float test_traits<::arrow::FloatType>::value(2.1f);
 template <>
 struct test_traits<::arrow::DoubleType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::DOUBLE;
-  static constexpr LogicalType::type logical_enum = LogicalType::NONE;
   static double const value;
 };
 
@@ -181,14 +255,12 @@ const double test_traits<::arrow::DoubleType>::value(4.2);
 template <>
 struct test_traits<::arrow::StringType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::BYTE_ARRAY;
-  static constexpr LogicalType::type logical_enum = LogicalType::UTF8;
   static std::string const value;
 };
 
 template <>
 struct test_traits<::arrow::BinaryType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::BYTE_ARRAY;
-  static constexpr LogicalType::type logical_enum = LogicalType::NONE;
   static std::string const value;
 };
 
@@ -231,18 +303,19 @@ void DoSimpleRoundtrip(const std::shared_ptr<Table>& table, int num_threads,
   }
 }
 
+static std::shared_ptr<GroupNode> MakeSimpleSchema(
+    const ::arrow::DataType& type, Repetition::type repetition) {
+  auto pnode = PrimitiveNode::Make("column1", repetition,
+      get_physical_type(type), get_logical_type(type));
+  NodePtr node_ =
+    GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
+  return std::static_pointer_cast<GroupNode>(node_);
+}
+
 template <typename TestType>
 class TestParquetIO : public ::testing::Test {
  public:
   virtual void SetUp() {}
-
-  std::shared_ptr<GroupNode> MakeSchema(Repetition::type repetition) {
-    auto pnode = PrimitiveNode::Make("column1", repetition,
-        test_traits<TestType>::parquet_enum, test_traits<TestType>::logical_enum);
-    NodePtr node_ =
-        GroupNode::Make("schema", Repetition::REQUIRED, std::vector<NodePtr>({pnode}));
-    return std::static_pointer_cast<GroupNode>(node_);
-  }
 
   std::unique_ptr<ParquetFileWriter> MakeWriter(
       const std::shared_ptr<GroupNode>& schema) {
@@ -348,7 +421,7 @@ class TestParquetIO : public ::testing::Test {
 
 typedef ::testing::Types<::arrow::BooleanType, ::arrow::UInt8Type, ::arrow::Int8Type,
     ::arrow::UInt16Type, ::arrow::Int16Type, ::arrow::Int32Type, ::arrow::UInt64Type,
-    ::arrow::Int64Type, ::arrow::TimestampType, ::arrow::Date64Type, ::arrow::FloatType,
+    ::arrow::Int64Type, ::arrow::TimestampType, ::arrow::Date32Type, ::arrow::FloatType,
     ::arrow::DoubleType, ::arrow::StringType, ::arrow::BinaryType>
     TestTypes;
 
@@ -358,7 +431,8 @@ TYPED_TEST(TestParquetIO, SingleColumnRequiredWrite) {
   std::shared_ptr<Array> values;
   ASSERT_OK(NonNullArray<TypeParam>(SMALL_SIZE, &values));
 
-  std::shared_ptr<GroupNode> schema = this->MakeSchema(Repetition::REQUIRED);
+  std::shared_ptr<GroupNode> schema = MakeSimpleSchema(
+      *values->type(), Repetition::REQUIRED);
   this->WriteColumn(schema, values);
 
   this->ReadAndCheckSingleColumnFile(values.get());
@@ -390,7 +464,8 @@ TYPED_TEST(TestParquetIO, SingleColumnOptionalReadWrite) {
 
   ASSERT_OK(NullableArray<TypeParam>(SMALL_SIZE, 10, kDefaultSeed, &values));
 
-  std::shared_ptr<GroupNode> schema = this->MakeSchema(Repetition::OPTIONAL);
+  std::shared_ptr<GroupNode> schema = MakeSimpleSchema(
+      *values->type(), Repetition::OPTIONAL);
   this->WriteColumn(schema, values);
 
   this->ReadAndCheckSingleColumnFile(values.get());
@@ -399,7 +474,8 @@ TYPED_TEST(TestParquetIO, SingleColumnOptionalReadWrite) {
 TYPED_TEST(TestParquetIO, SingleColumnRequiredSliceWrite) {
   std::shared_ptr<Array> values;
   ASSERT_OK(NonNullArray<TypeParam>(2 * SMALL_SIZE, &values));
-  std::shared_ptr<GroupNode> schema = this->MakeSchema(Repetition::REQUIRED);
+  std::shared_ptr<GroupNode> schema = MakeSimpleSchema(
+      *values->type(), Repetition::REQUIRED);
 
   std::shared_ptr<Array> sliced_values = values->Slice(SMALL_SIZE / 2, SMALL_SIZE);
   this->WriteColumn(schema, sliced_values);
@@ -414,7 +490,8 @@ TYPED_TEST(TestParquetIO, SingleColumnRequiredSliceWrite) {
 TYPED_TEST(TestParquetIO, SingleColumnOptionalSliceWrite) {
   std::shared_ptr<Array> values;
   ASSERT_OK(NullableArray<TypeParam>(2 * SMALL_SIZE, SMALL_SIZE, kDefaultSeed, &values));
-  std::shared_ptr<GroupNode> schema = this->MakeSchema(Repetition::OPTIONAL);
+  std::shared_ptr<GroupNode> schema = MakeSimpleSchema(
+      *values->type(), Repetition::OPTIONAL);
 
   std::shared_ptr<Array> sliced_values = values->Slice(SMALL_SIZE / 2, SMALL_SIZE);
   this->WriteColumn(schema, sliced_values);
@@ -470,7 +547,8 @@ TYPED_TEST(TestParquetIO, SingleColumnRequiredChunkedWrite) {
   ASSERT_OK(NonNullArray<TypeParam>(SMALL_SIZE, &values));
   int64_t chunk_size = values->length() / 4;
 
-  std::shared_ptr<GroupNode> schema = this->MakeSchema(Repetition::REQUIRED);
+  std::shared_ptr<GroupNode> schema = MakeSimpleSchema(
+      *values->type(), Repetition::REQUIRED);
   FileWriter writer(default_memory_pool(), this->MakeWriter(schema));
   for (int i = 0; i < 4; i++) {
     ASSERT_OK_NO_THROW(writer.NewRowGroup(chunk_size));
@@ -531,7 +609,8 @@ TYPED_TEST(TestParquetIO, SingleColumnOptionalChunkedWrite) {
 
   ASSERT_OK(NullableArray<TypeParam>(SMALL_SIZE, 10, kDefaultSeed, &values));
 
-  std::shared_ptr<GroupNode> schema = this->MakeSchema(Repetition::OPTIONAL);
+  std::shared_ptr<GroupNode> schema = MakeSimpleSchema(
+      *values->type(), Repetition::OPTIONAL);
   FileWriter writer(::arrow::default_memory_pool(), this->MakeWriter(schema));
   for (int i = 0; i < 4; i++) {
     ASSERT_OK_NO_THROW(writer.NewRowGroup(chunk_size));
@@ -715,7 +794,9 @@ class TestPrimitiveParquetIO : public TestParquetIO<TestType> {
 
   void MakeTestFile(
       std::vector<T>& values, int num_chunks, std::unique_ptr<FileReader>* reader) {
-    std::shared_ptr<GroupNode> schema = this->MakeSchema(Repetition::REQUIRED);
+    TestType dummy;
+
+    std::shared_ptr<GroupNode> schema = MakeSimpleSchema(dummy, Repetition::REQUIRED);
     std::unique_ptr<ParquetFileWriter> file_writer = this->MakeWriter(schema);
     size_t chunk_size = values.size() / num_chunks;
     // Convert to Parquet's expected physical type

--- a/src/parquet/arrow/arrow-schema-test.cc
+++ b/src/parquet/arrow/arrow-schema-test.cc
@@ -26,6 +26,7 @@
 #include "arrow/test-util.h"
 
 using arrow::Field;
+using arrow::TimeUnit;
 
 using ParquetType = parquet::Type;
 using parquet::LogicalType;
@@ -45,9 +46,9 @@ const auto INT64 = ::arrow::int64();
 const auto FLOAT = ::arrow::float32();
 const auto DOUBLE = ::arrow::float64();
 const auto UTF8 = ::arrow::utf8();
-const auto TIMESTAMP_MS = ::arrow::timestamp(::arrow::TimeUnit::MILLI);
-const auto TIMESTAMP_US = ::arrow::timestamp(::arrow::TimeUnit::MICRO);
-const auto TIMESTAMP_NS = ::arrow::timestamp(::arrow::TimeUnit::NANO);
+const auto TIMESTAMP_MS = ::arrow::timestamp(TimeUnit::MILLI);
+const auto TIMESTAMP_US = ::arrow::timestamp(TimeUnit::MICRO);
+const auto TIMESTAMP_NS = ::arrow::timestamp(TimeUnit::NANO);
 const auto BINARY = ::arrow::binary();
 const auto DECIMAL_8_4 = std::make_shared<::arrow::DecimalType>(8, 4);
 
@@ -114,12 +115,12 @@ TEST_F(TestConvertParquetSchema, ParquetFlatPrimitives) {
   parquet_fields.push_back(PrimitiveNode::Make(
       "time32", Repetition::REQUIRED, ParquetType::INT32, LogicalType::TIME_MILLIS));
   arrow_fields.push_back(std::make_shared<Field>(
-      "time32", ::arrow::time32(::arrow::TimeUnit::MILLI), false));
+      "time32", ::arrow::time32(TimeUnit::MILLI), false));
 
   parquet_fields.push_back(PrimitiveNode::Make(
       "time64", Repetition::REQUIRED, ParquetType::INT64, LogicalType::TIME_MICROS));
   arrow_fields.push_back(std::make_shared<Field>(
-      "time64", ::arrow::time64(::arrow::TimeUnit::MICRO), false));
+      "time64", ::arrow::time64(TimeUnit::MICRO), false));
 
   parquet_fields.push_back(
       PrimitiveNode::Make("timestamp96", Repetition::REQUIRED, ParquetType::INT96));
@@ -660,6 +661,16 @@ TEST_F(TestConvertArrowSchema, ParquetLists) {
   CheckFlatSchema(parquet_fields);
 }
 
+TEST_F(TestConvertArrowSchema, UnsupportedTypes) {
+  std::vector<std::shared_ptr<Field>> unsupported_fields = {
+    ::arrow::field("f0", ::arrow::time64(TimeUnit::NANO))
+  };
+
+  for (const auto& field : unsupported_fields) {
+    ASSERT_RAISES(NotImplemented, ConvertSchema({field}));
+  }
+}
+
 TEST_F(TestConvertArrowSchema, ParquetFlatDecimals) {
   std::vector<NodePtr> parquet_fields;
   std::vector<std::shared_ptr<Field>> arrow_fields;
@@ -671,8 +682,5 @@ TEST_F(TestConvertArrowSchema, ParquetFlatDecimals) {
   CheckFlatSchema(parquet_fields);
 }
 
-TEST(TestNodeConversion, DateAndTime) {}
-
 }  // namespace arrow
-
 }  // namespace parquet

--- a/src/parquet/arrow/arrow-schema-test.cc
+++ b/src/parquet/arrow/arrow-schema-test.cc
@@ -60,8 +60,8 @@ class TestConvertParquetSchema : public ::testing::Test {
     for (int i = 0; i < expected_schema->num_fields(); ++i) {
       auto lhs = result_schema_->field(i);
       auto rhs = expected_schema->field(i);
-      EXPECT_TRUE(lhs->Equals(rhs))
-          << i << " " << lhs->ToString() << " != " << rhs->ToString();
+      EXPECT_TRUE(lhs->Equals(rhs)) << i << " " << lhs->ToString()
+                                    << " != " << rhs->ToString();
     }
   }
 
@@ -114,12 +114,12 @@ TEST_F(TestConvertParquetSchema, ParquetFlatPrimitives) {
   parquet_fields.push_back(PrimitiveNode::Make(
       "time32", Repetition::REQUIRED, ParquetType::INT32, LogicalType::TIME_MILLIS));
   arrow_fields.push_back(std::make_shared<Field>(
-          "time32", ::arrow::time32(::arrow::TimeUnit::MILLI), false));
+      "time32", ::arrow::time32(::arrow::TimeUnit::MILLI), false));
 
   parquet_fields.push_back(PrimitiveNode::Make(
       "time64", Repetition::REQUIRED, ParquetType::INT64, LogicalType::TIME_MICROS));
   arrow_fields.push_back(std::make_shared<Field>(
-          "time64", ::arrow::time64(::arrow::TimeUnit::MICRO), false));
+      "time64", ::arrow::time64(::arrow::TimeUnit::MICRO), false));
 
   parquet_fields.push_back(
       PrimitiveNode::Make("timestamp96", Repetition::REQUIRED, ParquetType::INT96));

--- a/src/parquet/arrow/arrow-schema-test.cc
+++ b/src/parquet/arrow/arrow-schema-test.cc
@@ -46,10 +46,8 @@ const auto FLOAT = ::arrow::float32();
 const auto DOUBLE = ::arrow::float64();
 const auto UTF8 = ::arrow::utf8();
 const auto TIMESTAMP_MS = ::arrow::timestamp(::arrow::TimeUnit::MILLI);
+const auto TIMESTAMP_US = ::arrow::timestamp(::arrow::TimeUnit::MICRO);
 const auto TIMESTAMP_NS = ::arrow::timestamp(::arrow::TimeUnit::NANO);
-
-// TODO: This requires parquet-cpp implementing the MICROS enum value
-// const auto TIMESTAMP_US = std::make_shared<TimestampType>(TimestampType::Unit::MICRO);
 const auto BINARY = ::arrow::binary();
 const auto DECIMAL_8_4 = std::make_shared<::arrow::DecimalType>(8, 4);
 
@@ -105,9 +103,23 @@ TEST_F(TestConvertParquetSchema, ParquetFlatPrimitives) {
       ParquetType::INT64, LogicalType::TIMESTAMP_MILLIS));
   arrow_fields.push_back(std::make_shared<Field>("timestamp", TIMESTAMP_MS, false));
 
+  parquet_fields.push_back(PrimitiveNode::Make("timestamp[us]", Repetition::REQUIRED,
+      ParquetType::INT64, LogicalType::TIMESTAMP_MICROS));
+  arrow_fields.push_back(std::make_shared<Field>("timestamp[us]", TIMESTAMP_US, false));
+
   parquet_fields.push_back(PrimitiveNode::Make(
       "date", Repetition::REQUIRED, ParquetType::INT32, LogicalType::DATE));
-  arrow_fields.push_back(std::make_shared<Field>("date", ::arrow::date64(), false));
+  arrow_fields.push_back(std::make_shared<Field>("date", ::arrow::date32(), false));
+
+  parquet_fields.push_back(PrimitiveNode::Make(
+      "time32", Repetition::REQUIRED, ParquetType::INT32, LogicalType::TIME_MILLIS));
+  arrow_fields.push_back(std::make_shared<Field>(
+          "time32", ::arrow::time32(::arrow::TimeUnit::MILLI), false));
+
+  parquet_fields.push_back(PrimitiveNode::Make(
+      "time64", Repetition::REQUIRED, ParquetType::INT64, LogicalType::TIME_MICROS));
+  arrow_fields.push_back(std::make_shared<Field>(
+          "time64", ::arrow::time64(::arrow::TimeUnit::MICRO), false));
 
   parquet_fields.push_back(
       PrimitiveNode::Make("timestamp96", Repetition::REQUIRED, ParquetType::INT96));
@@ -568,7 +580,11 @@ TEST_F(TestConvertArrowSchema, ParquetFlatPrimitives) {
 
   parquet_fields.push_back(PrimitiveNode::Make(
       "date", Repetition::REQUIRED, ParquetType::INT32, LogicalType::DATE));
-  arrow_fields.push_back(std::make_shared<Field>("date", ::arrow::date64(), false));
+  arrow_fields.push_back(std::make_shared<Field>("date", ::arrow::date32(), false));
+
+  parquet_fields.push_back(PrimitiveNode::Make(
+      "date64", Repetition::REQUIRED, ParquetType::INT32, LogicalType::DATE));
+  arrow_fields.push_back(std::make_shared<Field>("date64", ::arrow::date64(), false));
 
   parquet_fields.push_back(PrimitiveNode::Make("timestamp", Repetition::REQUIRED,
       ParquetType::INT64, LogicalType::TIMESTAMP_MILLIS));

--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -1070,8 +1070,8 @@ Status ColumnReader::Impl::NextBatch(int batch_size, std::shared_ptr<Array>* out
       }
       break;
     }
-    TYPED_BATCH_CASE(TIME32, ::arrow::Time32Type, Int32Type)
-    TYPED_BATCH_CASE(TIME64, ::arrow::Time64Type, Int64Type)
+      TYPED_BATCH_CASE(TIME32, ::arrow::Time32Type, Int32Type)
+      TYPED_BATCH_CASE(TIME64, ::arrow::Time64Type, Int64Type)
     default:
       std::stringstream ss;
       ss << "No support for reading columns of type " << field_->type()->ToString();

--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -502,6 +502,10 @@ NONNULLABLE_BATCH_FAST_PATH(::arrow::Int32Type, Int32Type, int32_t)
 NONNULLABLE_BATCH_FAST_PATH(::arrow::Int64Type, Int64Type, int64_t)
 NONNULLABLE_BATCH_FAST_PATH(::arrow::FloatType, FloatType, float)
 NONNULLABLE_BATCH_FAST_PATH(::arrow::DoubleType, DoubleType, double)
+NONNULLABLE_BATCH_FAST_PATH(::arrow::Date32Type, Int32Type, int32_t)
+NONNULLABLE_BATCH_FAST_PATH(::arrow::TimestampType, Int64Type, int64_t)
+NONNULLABLE_BATCH_FAST_PATH(::arrow::Time32Type, Int32Type, int32_t)
+NONNULLABLE_BATCH_FAST_PATH(::arrow::Time64Type, Int64Type, int64_t)
 
 template <>
 Status ColumnReader::Impl::ReadNonNullableBatch<::arrow::TimestampType, Int96Type>(
@@ -607,6 +611,10 @@ NULLABLE_BATCH_FAST_PATH(::arrow::Int32Type, Int32Type, int32_t)
 NULLABLE_BATCH_FAST_PATH(::arrow::Int64Type, Int64Type, int64_t)
 NULLABLE_BATCH_FAST_PATH(::arrow::FloatType, FloatType, float)
 NULLABLE_BATCH_FAST_PATH(::arrow::DoubleType, DoubleType, double)
+NULLABLE_BATCH_FAST_PATH(::arrow::Date32Type, Int32Type, int32_t)
+NULLABLE_BATCH_FAST_PATH(::arrow::TimestampType, Int64Type, int64_t)
+NULLABLE_BATCH_FAST_PATH(::arrow::Time32Type, Int32Type, int32_t)
+NULLABLE_BATCH_FAST_PATH(::arrow::Time64Type, Int64Type, int64_t)
 
 template <>
 Status ColumnReader::Impl::ReadNullableBatch<::arrow::TimestampType, Int96Type>(
@@ -1036,18 +1044,22 @@ Status ColumnReader::Impl::NextBatch(int batch_size, std::shared_ptr<Array>* out
     TYPED_BATCH_CASE(INT16, ::arrow::Int16Type, Int32Type)
     TYPED_BATCH_CASE(UINT32, ::arrow::UInt32Type, Int32Type)
     TYPED_BATCH_CASE(INT32, ::arrow::Int32Type, Int32Type)
-    TYPED_BATCH_CASE(DATE64, ::arrow::Date64Type, Int32Type)
     TYPED_BATCH_CASE(UINT64, ::arrow::UInt64Type, Int64Type)
     TYPED_BATCH_CASE(INT64, ::arrow::Int64Type, Int64Type)
     TYPED_BATCH_CASE(FLOAT, ::arrow::FloatType, FloatType)
     TYPED_BATCH_CASE(DOUBLE, ::arrow::DoubleType, DoubleType)
     TYPED_BATCH_CASE(STRING, ::arrow::StringType, ByteArrayType)
     TYPED_BATCH_CASE(BINARY, ::arrow::BinaryType, ByteArrayType)
+    TYPED_BATCH_CASE(DATE32, ::arrow::Date32Type, Int32Type)
+    TYPED_BATCH_CASE(DATE64, ::arrow::Date64Type, Int32Type)
     case ::arrow::Type::TIMESTAMP: {
       ::arrow::TimestampType* timestamp_type =
           static_cast<::arrow::TimestampType*>(field_->type().get());
       switch (timestamp_type->unit()) {
         case ::arrow::TimeUnit::MILLI:
+          return TypedReadBatch<::arrow::TimestampType, Int64Type>(batch_size, out);
+          break;
+        case ::arrow::TimeUnit::MICRO:
           return TypedReadBatch<::arrow::TimestampType, Int64Type>(batch_size, out);
           break;
         case ::arrow::TimeUnit::NANO:
@@ -1058,6 +1070,8 @@ Status ColumnReader::Impl::NextBatch(int batch_size, std::shared_ptr<Array>* out
       }
       break;
     }
+    TYPED_BATCH_CASE(TIME32, ::arrow::Time32Type, Int32Type)
+    TYPED_BATCH_CASE(TIME64, ::arrow::Time64Type, Int64Type)
     default:
       std::stringstream ss;
       ss << "No support for reading columns of type " << field_->type()->ToString();

--- a/src/parquet/arrow/schema.cc
+++ b/src/parquet/arrow/schema.cc
@@ -45,6 +45,7 @@ namespace parquet {
 namespace arrow {
 
 const auto TIMESTAMP_MS = ::arrow::timestamp(::arrow::TimeUnit::MILLI);
+const auto TIMESTAMP_US = ::arrow::timestamp(::arrow::TimeUnit::MICRO);
 const auto TIMESTAMP_NS = ::arrow::timestamp(::arrow::TimeUnit::NANO);
 
 TypePtr MakeDecimalType(const PrimitiveNode* node) {
@@ -105,17 +106,17 @@ static Status FromInt32(const PrimitiveNode* node, TypePtr* out) {
     case LogicalType::INT_16:
       *out = ::arrow::int16();
       break;
+    case LogicalType::INT_32:
+      *out = ::arrow::int32();
+      break;
     case LogicalType::UINT_32:
       *out = ::arrow::uint32();
       break;
     case LogicalType::DATE:
-      *out = ::arrow::date64();
+      *out = ::arrow::date32();
       break;
     case LogicalType::TIME_MILLIS:
       *out = ::arrow::time32(::arrow::TimeUnit::MILLI);
-      break;
-    case LogicalType::TIME_MICROS:
-      *out = ::arrow::time64(::arrow::TimeUnit::MICRO);
       break;
     case LogicalType::DECIMAL:
       *out = MakeDecimalType(node);
@@ -135,6 +136,9 @@ static Status FromInt64(const PrimitiveNode* node, TypePtr* out) {
     case LogicalType::NONE:
       *out = ::arrow::int64();
       break;
+    case LogicalType::INT_64:
+      *out = ::arrow::int64();
+      break;
     case LogicalType::UINT_64:
       *out = ::arrow::uint64();
       break;
@@ -143,6 +147,12 @@ static Status FromInt64(const PrimitiveNode* node, TypePtr* out) {
       break;
     case LogicalType::TIMESTAMP_MILLIS:
       *out = TIMESTAMP_MS;
+      break;
+    case LogicalType::TIMESTAMP_MICROS:
+      *out = TIMESTAMP_US;
+      break;
+    case LogicalType::TIME_MICROS:
+      *out = ::arrow::time64(::arrow::TimeUnit::MICRO);
       break;
     default:
       std::stringstream ss;

--- a/src/parquet/arrow/schema.cc
+++ b/src/parquet/arrow/schema.cc
@@ -480,10 +480,15 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
       type = ParquetType::INT32;
       logical_type = LogicalType::TIME_MILLIS;
       break;
-    case ArrowType::TIME64:
+    case ArrowType::TIME64: {
+      auto time_type = static_cast<::arrow::Time64Type*>(field->type().get());
+      if (time_type->unit() == ::arrow::TimeUnit::NANO) {
+        return Status::NotImplemented(
+            "Nanosecond time not supported in Parquet.");
+      }
       type = ParquetType::INT64;
       logical_type = LogicalType::TIME_MICROS;
-      break;
+    } break;
     case ArrowType::STRUCT: {
       auto struct_type = std::static_pointer_cast<::arrow::StructType>(field->type());
       return StructToNode(struct_type, field->name(), field->nullable(), properties, out);

--- a/src/parquet/arrow/schema.cc
+++ b/src/parquet/arrow/schema.cc
@@ -477,7 +477,7 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
       }
     } break;
     case ArrowType::TIME32:
-      type = ParquetType::INT64;
+      type = ParquetType::INT32;
       logical_type = LogicalType::TIME_MILLIS;
       break;
     case ArrowType::TIME64:

--- a/src/parquet/arrow/schema.cc
+++ b/src/parquet/arrow/schema.cc
@@ -455,12 +455,16 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
       break;
     case ArrowType::TIMESTAMP: {
       auto timestamp_type = static_cast<::arrow::TimestampType*>(field->type().get());
-      if (timestamp_type->unit() != ::arrow::TimestampType::Unit::MILLI) {
-        return Status::NotImplemented(
-            "Other timestamp units than millisecond are not yet support with parquet.");
-      }
+      auto unit = timestamp_type->unit();
       type = ParquetType::INT64;
-      logical_type = LogicalType::TIMESTAMP_MILLIS;
+      if (unit == ::arrow::TimeUnit::MILLI) {
+        logical_type = LogicalType::TIMESTAMP_MILLIS;
+      } else if (unit == ::arrow::TimeUnit::MICRO) {
+        logical_type = LogicalType::TIMESTAMP_MICROS;
+      } else {
+        return Status::NotImplemented(
+            "Only MILLI and MICRO units supported for Arrow timestamps with Parquet.");
+      }
     } break;
     case ArrowType::TIME32:
       type = ParquetType::INT64;

--- a/src/parquet/arrow/test-util.h
+++ b/src/parquet/arrow/test-util.h
@@ -20,6 +20,7 @@
 
 #include "arrow/api.h"
 #include "arrow/test-util.h"
+#include "arrow/type_traits.h"
 
 namespace parquet {
 namespace arrow {

--- a/src/parquet/arrow/writer.cc
+++ b/src/parquet/arrow/writer.cc
@@ -80,6 +80,7 @@ class LevelBuilder : public ::arrow::ArrayVisitor {
   PRIMITIVE_VISIT(Double)
   PRIMITIVE_VISIT(String)
   PRIMITIVE_VISIT(Binary)
+  PRIMITIVE_VISIT(Date32)
   PRIMITIVE_VISIT(Date64)
   PRIMITIVE_VISIT(Time32)
   PRIMITIVE_VISIT(Time64)
@@ -357,8 +358,11 @@ Status FileWriter::Impl::WriteNonNullableBatch<Int32Type, ::arrow::Date64Type>(
   }
 
 NONNULLABLE_BATCH_FAST_PATH(Int32Type, ::arrow::Int32Type, int32_t)
+NONNULLABLE_BATCH_FAST_PATH(Int32Type, ::arrow::Date32Type, int32_t)
+NONNULLABLE_BATCH_FAST_PATH(Int32Type, ::arrow::Time32Type, int32_t)
 NONNULLABLE_BATCH_FAST_PATH(Int64Type, ::arrow::Int64Type, int64_t)
 NONNULLABLE_BATCH_FAST_PATH(Int64Type, ::arrow::TimestampType, int64_t)
+NONNULLABLE_BATCH_FAST_PATH(Int64Type, ::arrow::Time64Type, int64_t)
 NONNULLABLE_BATCH_FAST_PATH(FloatType, ::arrow::FloatType, float)
 NONNULLABLE_BATCH_FAST_PATH(DoubleType, ::arrow::DoubleType, double)
 
@@ -417,8 +421,11 @@ Status FileWriter::Impl::WriteNullableBatch<Int32Type, ::arrow::Date64Type>(
   }
 
 NULLABLE_BATCH_FAST_PATH(Int32Type, ::arrow::Int32Type, int32_t)
+NULLABLE_BATCH_FAST_PATH(Int32Type, ::arrow::Date32Type, int32_t)
+NULLABLE_BATCH_FAST_PATH(Int32Type, ::arrow::Time32Type, int32_t)
 NULLABLE_BATCH_FAST_PATH(Int64Type, ::arrow::Int64Type, int64_t)
 NULLABLE_BATCH_FAST_PATH(Int64Type, ::arrow::TimestampType, int64_t)
+NULLABLE_BATCH_FAST_PATH(Int64Type, ::arrow::Time64Type, int64_t)
 NULLABLE_BATCH_FAST_PATH(FloatType, ::arrow::FloatType, float)
 NULLABLE_BATCH_FAST_PATH(DoubleType, ::arrow::DoubleType, double)
 
@@ -553,14 +560,17 @@ Status FileWriter::Impl::WriteColumnChunk(const Array& data) {
       WRITE_BATCH_CASE(INT16, Int16Type, Int32Type)
       WRITE_BATCH_CASE(UINT16, UInt16Type, Int32Type)
       WRITE_BATCH_CASE(INT32, Int32Type, Int32Type)
-      WRITE_BATCH_CASE(DATE64, Date64Type, Int32Type)
       WRITE_BATCH_CASE(INT64, Int64Type, Int64Type)
-      WRITE_BATCH_CASE(TIMESTAMP, TimestampType, Int64Type)
       WRITE_BATCH_CASE(UINT64, UInt64Type, Int64Type)
       WRITE_BATCH_CASE(FLOAT, FloatType, FloatType)
       WRITE_BATCH_CASE(DOUBLE, DoubleType, DoubleType)
       WRITE_BATCH_CASE(BINARY, BinaryType, ByteArrayType)
       WRITE_BATCH_CASE(STRING, BinaryType, ByteArrayType)
+      WRITE_BATCH_CASE(DATE32, Date32Type, Int32Type)
+      WRITE_BATCH_CASE(DATE64, Date64Type, Int32Type)
+      WRITE_BATCH_CASE(TIMESTAMP, TimestampType, Int64Type)
+      WRITE_BATCH_CASE(TIME32, Time32Type, Int32Type)
+      WRITE_BATCH_CASE(TIME64, Time64Type, Int64Type)
     default:
       std::stringstream ss;
       ss << "Data type not supported as list value: " << values_array->type()->ToString();

--- a/src/parquet/arrow/writer.cc
+++ b/src/parquet/arrow/writer.cc
@@ -89,10 +89,10 @@ class LevelBuilder {
     return VisitInline(*array.values());
   }
 
-#define NOT_IMPLEMENTED_VIST(ArrowTypePrefix)                       \
-  Status Visit(const ::arrow::ArrowTypePrefix##Array& array) {      \
-    return Status::NotImplemented(                                  \
-        "Level generation for ArrowTypePrefix not supported yet");  \
+#define NOT_IMPLEMENTED_VIST(ArrowTypePrefix)                      \
+  Status Visit(const ::arrow::ArrowTypePrefix##Array& array) {     \
+    return Status::NotImplemented(                                 \
+        "Level generation for ArrowTypePrefix not supported yet"); \
   };
 
   NOT_IMPLEMENTED_VIST(Null)

--- a/src/parquet/arrow/writer.cc
+++ b/src/parquet/arrow/writer.cc
@@ -93,7 +93,7 @@ class LevelBuilder {
   Status Visit(const ::arrow::ArrowTypePrefix##Array& array) {     \
     return Status::NotImplemented(                                 \
         "Level generation for ArrowTypePrefix not supported yet"); \
-  };
+  }
 
   NOT_IMPLEMENTED_VIST(Null)
   NOT_IMPLEMENTED_VIST(Struct)

--- a/src/parquet/file/printer.h
+++ b/src/parquet/file/printer.h
@@ -32,6 +32,7 @@ namespace parquet {
 class PARQUET_EXPORT ParquetFilePrinter {
  private:
   ParquetFileReader* fileReader;
+
  public:
   explicit ParquetFilePrinter(ParquetFileReader* reader) : fileReader(reader) {}
   ~ParquetFilePrinter() {}


### PR DESCRIPTION
I am working on ARROW-865 which exposes these to Python users

Closes #270 