### PR TITLE
PARQUET-1029: [C++] Some extern template symbols not being exported in gcc

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,5 +17,5 @@
 
 if (PARQUET_BUILD_EXECUTABLES)
   add_executable(reader-writer reader-writer.cc)
-  target_link_libraries(reader-writer parquet_static)
+  target_link_libraries(reader-writer parquet_shared arrow)
 endif()

--- a/src/parquet/column/reader.h
+++ b/src/parquet/column/reader.h
@@ -403,14 +403,14 @@ typedef TypedColumnReader<DoubleType> DoubleReader;
 typedef TypedColumnReader<ByteArrayType> ByteArrayReader;
 typedef TypedColumnReader<FLBAType> FixedLenByteArrayReader;
 
-PARQUET_EXTERN_TEMPLATE TypedColumnReader<BooleanType>;
-PARQUET_EXTERN_TEMPLATE TypedColumnReader<Int32Type>;
-PARQUET_EXTERN_TEMPLATE TypedColumnReader<Int64Type>;
-PARQUET_EXTERN_TEMPLATE TypedColumnReader<Int96Type>;
-PARQUET_EXTERN_TEMPLATE TypedColumnReader<FloatType>;
-PARQUET_EXTERN_TEMPLATE TypedColumnReader<DoubleType>;
-PARQUET_EXTERN_TEMPLATE TypedColumnReader<ByteArrayType>;
-PARQUET_EXTERN_TEMPLATE TypedColumnReader<FLBAType>;
+extern template class PARQUET_EXPORT TypedColumnReader<BooleanType>;
+extern template class PARQUET_EXPORT TypedColumnReader<Int32Type>;
+extern template class PARQUET_EXPORT TypedColumnReader<Int64Type>;
+extern template class PARQUET_EXPORT TypedColumnReader<Int96Type>;
+extern template class PARQUET_EXPORT TypedColumnReader<FloatType>;
+extern template class PARQUET_EXPORT TypedColumnReader<DoubleType>;
+extern template class PARQUET_EXPORT TypedColumnReader<ByteArrayType>;
+extern template class PARQUET_EXPORT TypedColumnReader<FLBAType>;
 
 }  // namespace parquet
 

--- a/src/parquet/column/writer.h
+++ b/src/parquet/column/writer.h
@@ -212,14 +212,14 @@ typedef TypedColumnWriter<DoubleType> DoubleWriter;
 typedef TypedColumnWriter<ByteArrayType> ByteArrayWriter;
 typedef TypedColumnWriter<FLBAType> FixedLenByteArrayWriter;
 
-PARQUET_EXTERN_TEMPLATE TypedColumnWriter<BooleanType>;
-PARQUET_EXTERN_TEMPLATE TypedColumnWriter<Int32Type>;
-PARQUET_EXTERN_TEMPLATE TypedColumnWriter<Int64Type>;
-PARQUET_EXTERN_TEMPLATE TypedColumnWriter<Int96Type>;
-PARQUET_EXTERN_TEMPLATE TypedColumnWriter<FloatType>;
-PARQUET_EXTERN_TEMPLATE TypedColumnWriter<DoubleType>;
-PARQUET_EXTERN_TEMPLATE TypedColumnWriter<ByteArrayType>;
-PARQUET_EXTERN_TEMPLATE TypedColumnWriter<FLBAType>;
+extern template class PARQUET_EXPORT TypedColumnWriter<BooleanType>;
+extern template class PARQUET_EXPORT TypedColumnWriter<Int32Type>;
+extern template class PARQUET_EXPORT TypedColumnWriter<Int64Type>;
+extern template class PARQUET_EXPORT TypedColumnWriter<Int96Type>;
+extern template class PARQUET_EXPORT TypedColumnWriter<FloatType>;
+extern template class PARQUET_EXPORT TypedColumnWriter<DoubleType>;
+extern template class PARQUET_EXPORT TypedColumnWriter<ByteArrayType>;
+extern template class PARQUET_EXPORT TypedColumnWriter<FLBAType>;
 
 }  // namespace parquet
 


### PR DESCRIPTION
Extern template visibility contributes to be a mystery to me, but this fixes the regression from PARQUET-991.

cc @saatvikshah1994