### PR TITLE
PARQUET-1042: Fix Compilation breaks on GCC 4.8

### DIFF
--- a/src/parquet/arrow/reader.h
+++ b/src/parquet/arrow/reader.h
@@ -169,6 +169,7 @@ class PARQUET_EXPORT FileReader {
 // might change in the future.
 class PARQUET_EXPORT ColumnReader {
  public:
+  class PARQUET_NO_EXPORT Impl;
   virtual ~ColumnReader();
 
   // Scan the next array of the indicated size. The actual size of the
@@ -183,7 +184,6 @@ class PARQUET_EXPORT ColumnReader {
   ::arrow::Status NextBatch(int batch_size, std::shared_ptr<::arrow::Array>* out);
 
  private:
-  class PARQUET_NO_EXPORT Impl;
   std::unique_ptr<Impl> impl_;
   explicit ColumnReader(std::unique_ptr<Impl> impl);
 


### PR DESCRIPTION
Not the most beautiful, but verified locally in docker.