### PR TITLE
PARQUET-1068: Modify .clang-format to use straight Google format with 90-character line width

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,65 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 ---
-Language:        Cpp
-# BasedOnStyle:  Google
-AccessModifierOffset: -1
-AlignAfterOpenBracket: false 
-AlignConsecutiveAssignments: false
-AlignEscapedNewlinesLeft: true
-AlignOperands:   true
-AlignTrailingComments: true
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: true 
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Inline
-AllowShortIfStatementsOnASingleLine: true
-AllowShortLoopsOnASingleLine: false 
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: true
-BinPackArguments: true
-BinPackParameters: true 
-BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Attach
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-ColumnLimit: 90 
-CommentPragmas:  '^ IWYU pragma:'
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
-DerivePointerAlignment: false 
-DisableFormat:   false
-ExperimentalAutoDetectBinPacking: false
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
-IndentCaseLabels: true
-IndentWidth:     2
-IndentWrappedFunctionNames: false
-KeepEmptyLinesAtTheStartOfBlocks: false
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBlockIndentWidth: 2
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: false
-PenaltyBreakBeforeFirstCallParameter: 1000
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
-PointerAlignment: Left
-SpaceAfterCStyleCast: false
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeParens: ControlStatements
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 2
-SpacesInAngles:  false
-SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-Standard:        Cpp11
-TabWidth:        8
-UseTab:          Never
+BasedOnStyle:  Google
+DerivePointerAlignment: false
+ColumnLimit: 90

--- a/benchmarks/decode_benchmark.cc
+++ b/benchmarks/decode_benchmark.cc
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <stdio.h>
 #include <iostream>
 #include <random>
-#include <stdio.h>
 
 #include "arrow/util/compression.h"
 #include "arrow/util/compression_snappy.h"
@@ -165,8 +165,8 @@ class DeltaByteArrayEncoder {
       }
     }
     prefix_len_encoder_.Add(prefix_len);
-    suffix_encoder_.Add(
-        reinterpret_cast<const uint8_t*>(s.data()) + prefix_len, s.size() - prefix_len);
+    suffix_encoder_.Add(reinterpret_cast<const uint8_t*>(s.data()) + prefix_len,
+                        s.size() - prefix_len);
     last_value_ = s;
   }
 
@@ -210,7 +210,8 @@ uint64_t TestPlainIntEncoding(const uint8_t* data, int num_values, int batch_siz
 }
 
 uint64_t TestBinaryPackedEncoding(const char* name, const std::vector<int64_t>& values,
-    int benchmark_iters = -1, int benchmark_batch_size = 1) {
+                                  int benchmark_iters = -1,
+                                  int benchmark_batch_size = 1) {
   int mini_block_size;
   if (values.size() < 8) {
     mini_block_size = 8;
@@ -266,7 +267,7 @@ uint64_t TestBinaryPackedEncoding(const char* name, const std::vector<int64_t>& 
     uint64_t elapsed = sw.Stop();
     double num_ints = values.size() * benchmark_iters * 1000.;
     printf("%s rate (batch size = %2d): %0.3fM per second.\n", name, benchmark_batch_size,
-        num_ints / elapsed);
+           num_ints / elapsed);
     return result;
   }
 }
@@ -278,10 +279,10 @@ uint64_t TestBinaryPackedEncoding(const char* name, const std::vector<int64_t>& 
   }                                                                            \
   elapsed = sw.Stop();                                                         \
   printf("%s rate (batch size = %2d): %0.3fM per second.\n", NAME, BATCH_SIZE, \
-      mult / elapsed);
+         mult / elapsed);
 
 void TestPlainIntCompressed(::arrow::Codec* codec, const std::vector<int64_t>& data,
-    int num_iters, int batch_size) {
+                            int num_iters, int batch_size) {
   const uint8_t* raw_data = reinterpret_cast<const uint8_t*>(&data[0]);
   int uncompressed_len = data.size() * sizeof(int64_t);
   uint8_t* decompressed_data = new uint8_t[uncompressed_len];
@@ -291,24 +292,24 @@ void TestPlainIntCompressed(::arrow::Codec* codec, const std::vector<int64_t>& d
   int64_t compressed_len;
   DCHECK(codec
              ->Compress(uncompressed_len, raw_data, max_compressed_size, compressed_data,
-                 &compressed_len)
+                        &compressed_len)
              .ok());
 
   printf("\n%s:\n  Uncompressed len: %d\n  Compressed len:   %d\n", codec->name(),
-      uncompressed_len, static_cast<int>(compressed_len));
+         uncompressed_len, static_cast<int>(compressed_len));
 
   double mult = num_iters * data.size() * 1000.;
   parquet::StopWatch sw;
   sw.Start();
   uint64_t r = 0;
   for (int i = 0; i < num_iters; ++i) {
-    codec->Decompress(
-        compressed_len, compressed_data, uncompressed_len, decompressed_data);
+    codec->Decompress(compressed_len, compressed_data, uncompressed_len,
+                      decompressed_data);
     r += TestPlainIntEncoding(decompressed_data, data.size(), batch_size);
   }
   int64_t elapsed = sw.Stop();
   printf("Compressed(%s) plain int rate (batch size = %2d): %0.3fM per second.\n",
-      codec->name(), batch_size, mult / elapsed);
+         codec->name(), batch_size, mult / elapsed);
 
   delete[] compressed_data;
   delete[] decompressed_data;
@@ -317,13 +318,11 @@ void TestPlainIntCompressed(::arrow::Codec* codec, const std::vector<int64_t>& d
 void TestBinaryPacking() {
   std::vector<int64_t> values;
   values.clear();
-  for (int i = 0; i < 100; ++i)
-    values.push_back(0);
+  for (int i = 0; i < 100; ++i) values.push_back(0);
   TestBinaryPackedEncoding("Zeros", values);
 
   values.clear();
-  for (int i = 1; i <= 5; ++i)
-    values.push_back(i);
+  for (int i = 1; i <= 5; ++i) values.push_back(i);
   TestBinaryPackedEncoding("Example 1", values);
 
   values.clear();
@@ -373,13 +372,15 @@ void TestDeltaLengthByteArray() {
   int len = 0;
   uint8_t* buffer = encoder.Encode(&len);
   printf("DeltaLengthByteArray\n  Raw len: %d\n  Encoded len: %d\n",
-      encoder.plain_encoded_len(), len);
+         encoder.plain_encoded_len(), len);
   decoder.SetData(encoder.num_values(), buffer, len);
   for (int i = 0; i < encoder.num_values(); ++i) {
     parquet::ByteArray v = {0, NULL};
     decoder.Decode(&v, 1);
     std::string r = std::string(reinterpret_cast<const char*>(v.ptr), v.len);
-    if (r != values[i]) { std::cout << "Bad " << r << " != " << values[i] << std::endl; }
+    if (r != values[i]) {
+      std::cout << "Bad " << r << " != " << values[i] << std::endl;
+    }
   }
 }
 
@@ -409,13 +410,15 @@ void TestDeltaByteArray() {
   int len = 0;
   uint8_t* buffer = encoder.Encode(&len);
   printf("DeltaLengthByteArray\n  Raw len: %d\n  Encoded len: %d\n",
-      encoder.plain_encoded_len(), len);
+         encoder.plain_encoded_len(), len);
   decoder.SetData(encoder.num_values(), buffer, len);
   for (int i = 0; i < encoder.num_values(); ++i) {
     parquet::ByteArray v;
     decoder.Decode(&v, 1);
     std::string r = std::string(reinterpret_cast<const char*>(v.ptr), v.len);
-    if (r != values[i]) { std::cout << "Bad " << r << " != " << values[i] << std::endl; }
+    if (r != values[i]) {
+      std::cout << "Bad " << r << " != " << values[i] << std::endl;
+    }
   }
 }
 

--- a/examples/reader-writer.cc
+++ b/examples/reader-writer.cc
@@ -59,35 +59,36 @@ static std::shared_ptr<GroupNode> SetupSchema() {
   parquet::schema::NodeVector fields;
   // Create a primitive node named 'boolean_field' with type:BOOLEAN,
   // repetition:REQUIRED
-  fields.push_back(PrimitiveNode::Make(
-      "boolean_field", Repetition::REQUIRED, Type::BOOLEAN, LogicalType::NONE));
+  fields.push_back(PrimitiveNode::Make("boolean_field", Repetition::REQUIRED,
+                                       Type::BOOLEAN, LogicalType::NONE));
 
   // Create a primitive node named 'int32_field' with type:INT32, repetition:REQUIRED,
   // logical type:TIME_MILLIS
-  fields.push_back(PrimitiveNode::Make(
-      "int32_field", Repetition::REQUIRED, Type::INT32, LogicalType::TIME_MILLIS));
+  fields.push_back(PrimitiveNode::Make("int32_field", Repetition::REQUIRED, Type::INT32,
+                                       LogicalType::TIME_MILLIS));
 
   // Create a primitive node named 'int64_field' with type:INT64, repetition:REPEATED
-  fields.push_back(PrimitiveNode::Make(
-      "int64_field", Repetition::REPEATED, Type::INT64, LogicalType::NONE));
+  fields.push_back(PrimitiveNode::Make("int64_field", Repetition::REPEATED, Type::INT64,
+                                       LogicalType::NONE));
 
-  fields.push_back(PrimitiveNode::Make(
-      "int96_field", Repetition::REQUIRED, Type::INT96, LogicalType::NONE));
+  fields.push_back(PrimitiveNode::Make("int96_field", Repetition::REQUIRED, Type::INT96,
+                                       LogicalType::NONE));
 
-  fields.push_back(PrimitiveNode::Make(
-      "float_field", Repetition::REQUIRED, Type::FLOAT, LogicalType::NONE));
+  fields.push_back(PrimitiveNode::Make("float_field", Repetition::REQUIRED, Type::FLOAT,
+                                       LogicalType::NONE));
 
-  fields.push_back(PrimitiveNode::Make(
-      "double_field", Repetition::REQUIRED, Type::DOUBLE, LogicalType::NONE));
+  fields.push_back(PrimitiveNode::Make("double_field", Repetition::REQUIRED, Type::DOUBLE,
+                                       LogicalType::NONE));
 
   // Create a primitive node named 'ba_field' with type:BYTE_ARRAY, repetition:OPTIONAL
-  fields.push_back(PrimitiveNode::Make(
-      "ba_field", Repetition::OPTIONAL, Type::BYTE_ARRAY, LogicalType::NONE));
+  fields.push_back(PrimitiveNode::Make("ba_field", Repetition::OPTIONAL, Type::BYTE_ARRAY,
+                                       LogicalType::NONE));
 
   // Create a primitive node named 'flba_field' with type:FIXED_LEN_BYTE_ARRAY,
   // repetition:REQUIRED, field_length = FIXED_LENGTH
   fields.push_back(PrimitiveNode::Make("flba_field", Repetition::REQUIRED,
-      Type::FIXED_LEN_BYTE_ARRAY, LogicalType::NONE, FIXED_LENGTH));
+                                       Type::FIXED_LEN_BYTE_ARRAY, LogicalType::NONE,
+                                       FIXED_LENGTH));
 
   // Create a GroupNode named 'schema' using the primitive nodes defined above
   // This GroupNode is the root node of the schema tree
@@ -308,8 +309,8 @@ int main(int argc, char** argv) {
         int64_t value;
         // Read one value at a time. The number of rows read is returned. values_read
         // contains the number of non-null rows
-        rows_read = int64_reader->ReadBatch(
-            1, &definition_level, &repetition_level, &value, &values_read);
+        rows_read = int64_reader->ReadBatch(1, &definition_level, &repetition_level,
+                                            &value, &values_read);
         // Ensure only one value is read
         assert(rows_read == 1);
         // There are no NULL values in the rows written

--- a/src/parquet/arrow/arrow-reader-writer-benchmark.cc
+++ b/src/parquet/arrow/arrow-reader-writer-benchmark.cc
@@ -64,8 +64,8 @@ using ArrowType = typename benchmark_traits<ParquetType>::arrow_type;
 template <typename ParquetType>
 std::shared_ptr<ColumnDescriptor> MakeSchema(Repetition::type repetition) {
   auto node = PrimitiveNode::Make("int64", repetition, ParquetType::type_num);
-  return std::make_shared<ColumnDescriptor>(
-      node, repetition != Repetition::REQUIRED, repetition == Repetition::REPEATED);
+  return std::make_shared<ColumnDescriptor>(node, repetition != Repetition::REQUIRED,
+                                            repetition == Repetition::REPEATED);
 }
 
 template <bool nullable, typename ParquetType>

--- a/src/parquet/arrow/arrow-schema-test.cc
+++ b/src/parquet/arrow/arrow-schema-test.cc
@@ -72,14 +72,15 @@ class TestConvertParquetSchema : public ::testing::Test {
     return FromParquetSchema(&descr_, &result_schema_);
   }
 
-  ::arrow::Status ConvertSchema(
-      const std::vector<NodePtr>& nodes, const std::vector<int>& column_indices) {
+  ::arrow::Status ConvertSchema(const std::vector<NodePtr>& nodes,
+                                const std::vector<int>& column_indices) {
     NodePtr schema = GroupNode::Make("schema", Repetition::REPEATED, nodes);
     descr_.Init(schema);
     return FromParquetSchema(&descr_, column_indices, &result_schema_);
   }
 
-  ::arrow::Status ConvertSchema(const std::vector<NodePtr>& nodes,
+  ::arrow::Status ConvertSchema(
+      const std::vector<NodePtr>& nodes,
       const std::shared_ptr<const KeyValueMetadata>& key_value_metadata) {
     NodePtr schema = GroupNode::Make("schema", Repetition::REPEATED, nodes);
     descr_.Init(schema);
@@ -108,15 +109,17 @@ TEST_F(TestConvertParquetSchema, ParquetFlatPrimitives) {
   arrow_fields.push_back(std::make_shared<Field>("int64", INT64, false));
 
   parquet_fields.push_back(PrimitiveNode::Make("timestamp", Repetition::REQUIRED,
-      ParquetType::INT64, LogicalType::TIMESTAMP_MILLIS));
+                                               ParquetType::INT64,
+                                               LogicalType::TIMESTAMP_MILLIS));
   arrow_fields.push_back(std::make_shared<Field>("timestamp", TIMESTAMP_MS, false));
 
   parquet_fields.push_back(PrimitiveNode::Make("timestamp[us]", Repetition::REQUIRED,
-      ParquetType::INT64, LogicalType::TIMESTAMP_MICROS));
+                                               ParquetType::INT64,
+                                               LogicalType::TIMESTAMP_MICROS));
   arrow_fields.push_back(std::make_shared<Field>("timestamp[us]", TIMESTAMP_US, false));
 
-  parquet_fields.push_back(PrimitiveNode::Make(
-      "date", Repetition::REQUIRED, ParquetType::INT32, LogicalType::DATE));
+  parquet_fields.push_back(PrimitiveNode::Make("date", Repetition::REQUIRED,
+                                               ParquetType::INT32, LogicalType::DATE));
   arrow_fields.push_back(std::make_shared<Field>("date", ::arrow::date32(), false));
 
   parquet_fields.push_back(PrimitiveNode::Make(
@@ -150,7 +153,8 @@ TEST_F(TestConvertParquetSchema, ParquetFlatPrimitives) {
   arrow_fields.push_back(std::make_shared<Field>("string", UTF8));
 
   parquet_fields.push_back(PrimitiveNode::Make("flba-binary", Repetition::OPTIONAL,
-      ParquetType::FIXED_LEN_BYTE_ARRAY, LogicalType::NONE, 12));
+                                               ParquetType::FIXED_LEN_BYTE_ARRAY,
+                                               LogicalType::NONE, 12));
   arrow_fields.push_back(
       std::make_shared<Field>("flba-binary", ::arrow::fixed_size_binary(12)));
 
@@ -204,19 +208,23 @@ TEST_F(TestConvertParquetSchema, ParquetFlatDecimals) {
   std::vector<std::shared_ptr<Field>> arrow_fields;
 
   parquet_fields.push_back(PrimitiveNode::Make("flba-decimal", Repetition::OPTIONAL,
-      ParquetType::FIXED_LEN_BYTE_ARRAY, LogicalType::DECIMAL, 4, 8, 4));
+                                               ParquetType::FIXED_LEN_BYTE_ARRAY,
+                                               LogicalType::DECIMAL, 4, 8, 4));
   arrow_fields.push_back(std::make_shared<Field>("flba-decimal", DECIMAL_8_4));
 
   parquet_fields.push_back(PrimitiveNode::Make("binary-decimal", Repetition::OPTIONAL,
-      ParquetType::BYTE_ARRAY, LogicalType::DECIMAL, -1, 8, 4));
+                                               ParquetType::BYTE_ARRAY,
+                                               LogicalType::DECIMAL, -1, 8, 4));
   arrow_fields.push_back(std::make_shared<Field>("binary-decimal", DECIMAL_8_4));
 
   parquet_fields.push_back(PrimitiveNode::Make("int32-decimal", Repetition::OPTIONAL,
-      ParquetType::INT32, LogicalType::DECIMAL, -1, 8, 4));
+                                               ParquetType::INT32, LogicalType::DECIMAL,
+                                               -1, 8, 4));
   arrow_fields.push_back(std::make_shared<Field>("int32-decimal", DECIMAL_8_4));
 
   parquet_fields.push_back(PrimitiveNode::Make("int64-decimal", Repetition::OPTIONAL,
-      ParquetType::INT64, LogicalType::DECIMAL, -1, 8, 4));
+                                               ParquetType::INT64, LogicalType::DECIMAL,
+                                               -1, 8, 4));
   arrow_fields.push_back(std::make_shared<Field>("int64-decimal", DECIMAL_8_4));
 
   auto arrow_schema = std::make_shared<::arrow::Schema>(arrow_fields);
@@ -238,8 +246,8 @@ TEST_F(TestConvertParquetSchema, ParquetLists) {
   //   }
   // }
   {
-    auto element = PrimitiveNode::Make(
-        "string", Repetition::OPTIONAL, ParquetType::BYTE_ARRAY, LogicalType::UTF8);
+    auto element = PrimitiveNode::Make("string", Repetition::OPTIONAL,
+                                       ParquetType::BYTE_ARRAY, LogicalType::UTF8);
     auto list = GroupNode::Make("list", Repetition::REPEATED, {element});
     parquet_fields.push_back(
         GroupNode::Make("my_list", Repetition::REQUIRED, {list}, LogicalType::LIST));
@@ -255,8 +263,8 @@ TEST_F(TestConvertParquetSchema, ParquetLists) {
   //   }
   // }
   {
-    auto element = PrimitiveNode::Make(
-        "string", Repetition::REQUIRED, ParquetType::BYTE_ARRAY, LogicalType::UTF8);
+    auto element = PrimitiveNode::Make("string", Repetition::REQUIRED,
+                                       ParquetType::BYTE_ARRAY, LogicalType::UTF8);
     auto list = GroupNode::Make("list", Repetition::REPEATED, {element});
     parquet_fields.push_back(
         GroupNode::Make("my_list", Repetition::OPTIONAL, {list}, LogicalType::LIST));
@@ -284,8 +292,8 @@ TEST_F(TestConvertParquetSchema, ParquetLists) {
     auto element =
         GroupNode::Make("element", Repetition::REQUIRED, {inner_list}, LogicalType::LIST);
     auto list = GroupNode::Make("list", Repetition::REPEATED, {element});
-    parquet_fields.push_back(GroupNode::Make(
-        "array_of_arrays", Repetition::OPTIONAL, {list}, LogicalType::LIST));
+    parquet_fields.push_back(GroupNode::Make("array_of_arrays", Repetition::OPTIONAL,
+                                             {list}, LogicalType::LIST));
     auto arrow_inner_element = std::make_shared<Field>("int32", INT32, false);
     auto arrow_inner_list = std::make_shared<::arrow::ListType>(arrow_inner_element);
     auto arrow_element = std::make_shared<Field>("element", arrow_inner_list, false);
@@ -300,8 +308,8 @@ TEST_F(TestConvertParquetSchema, ParquetLists) {
   //   };
   // }
   {
-    auto element = PrimitiveNode::Make(
-        "str", Repetition::REQUIRED, ParquetType::BYTE_ARRAY, LogicalType::UTF8);
+    auto element = PrimitiveNode::Make("str", Repetition::REQUIRED,
+                                       ParquetType::BYTE_ARRAY, LogicalType::UTF8);
     auto list = GroupNode::Make("element", Repetition::REPEATED, {element});
     parquet_fields.push_back(
         GroupNode::Make("my_list", Repetition::OPTIONAL, {list}, LogicalType::LIST));
@@ -332,8 +340,8 @@ TEST_F(TestConvertParquetSchema, ParquetLists) {
   //   };
   // }
   {
-    auto str_element = PrimitiveNode::Make(
-        "str", Repetition::REQUIRED, ParquetType::BYTE_ARRAY, LogicalType::UTF8);
+    auto str_element = PrimitiveNode::Make("str", Repetition::REQUIRED,
+                                           ParquetType::BYTE_ARRAY, LogicalType::UTF8);
     auto num_element =
         PrimitiveNode::Make("num", Repetition::REQUIRED, ParquetType::INT32);
     auto element =
@@ -357,8 +365,8 @@ TEST_F(TestConvertParquetSchema, ParquetLists) {
   // }
   // Special case: group is named array
   {
-    auto element = PrimitiveNode::Make(
-        "str", Repetition::REQUIRED, ParquetType::BYTE_ARRAY, LogicalType::UTF8);
+    auto element = PrimitiveNode::Make("str", Repetition::REQUIRED,
+                                       ParquetType::BYTE_ARRAY, LogicalType::UTF8);
     auto array = GroupNode::Make("array", Repetition::REPEATED, {element});
     parquet_fields.push_back(
         GroupNode::Make("my_list", Repetition::OPTIONAL, {array}, LogicalType::LIST));
@@ -378,8 +386,8 @@ TEST_F(TestConvertParquetSchema, ParquetLists) {
   // }
   // Special case: group named ends in _tuple
   {
-    auto element = PrimitiveNode::Make(
-        "str", Repetition::REQUIRED, ParquetType::BYTE_ARRAY, LogicalType::UTF8);
+    auto element = PrimitiveNode::Make("str", Repetition::REQUIRED,
+                                       ParquetType::BYTE_ARRAY, LogicalType::UTF8);
     auto array = GroupNode::Make("my_list_tuple", Repetition::REPEATED, {element});
     parquet_fields.push_back(
         GroupNode::Make("my_list", Repetition::OPTIONAL, {array}, LogicalType::LIST));
@@ -425,14 +433,15 @@ TEST_F(TestConvertParquetSchema, ParquetNestedSchema) {
   // }
   // required int64 leaf3;
   {
-    parquet_fields.push_back(GroupNode::Make("group1", Repetition::REQUIRED,
+    parquet_fields.push_back(GroupNode::Make(
+        "group1", Repetition::REQUIRED,
         {PrimitiveNode::Make("leaf1", Repetition::REQUIRED, ParquetType::BOOLEAN),
-            PrimitiveNode::Make("leaf2", Repetition::REQUIRED, ParquetType::INT32)}));
+         PrimitiveNode::Make("leaf2", Repetition::REQUIRED, ParquetType::INT32)}));
     parquet_fields.push_back(
         PrimitiveNode::Make("leaf3", Repetition::REQUIRED, ParquetType::INT64));
 
     auto group1_fields = {std::make_shared<Field>("leaf1", BOOL, false),
-        std::make_shared<Field>("leaf2", INT32, false)};
+                          std::make_shared<Field>("leaf2", INT32, false)};
     auto arrow_group1_type = std::make_shared<::arrow::StructType>(group1_fields);
     arrow_fields.push_back(std::make_shared<Field>("group1", arrow_group1_type, false));
     arrow_fields.push_back(std::make_shared<Field>("leaf3", INT64, false));
@@ -468,12 +477,14 @@ TEST_F(TestConvertParquetSchema, ParquetNestedSchemaPartial) {
   // }
   // required int64 leaf5;
   {
-    parquet_fields.push_back(GroupNode::Make("group1", Repetition::REQUIRED,
+    parquet_fields.push_back(GroupNode::Make(
+        "group1", Repetition::REQUIRED,
         {PrimitiveNode::Make("leaf1", Repetition::REQUIRED, ParquetType::INT64),
-            PrimitiveNode::Make("leaf2", Repetition::REQUIRED, ParquetType::INT64)}));
-    parquet_fields.push_back(GroupNode::Make("group2", Repetition::REQUIRED,
+         PrimitiveNode::Make("leaf2", Repetition::REQUIRED, ParquetType::INT64)}));
+    parquet_fields.push_back(GroupNode::Make(
+        "group2", Repetition::REQUIRED,
         {PrimitiveNode::Make("leaf3", Repetition::REQUIRED, ParquetType::INT64),
-            PrimitiveNode::Make("leaf4", Repetition::REQUIRED, ParquetType::INT64)}));
+         PrimitiveNode::Make("leaf4", Repetition::REQUIRED, ParquetType::INT64)}));
     parquet_fields.push_back(
         PrimitiveNode::Make("leaf5", Repetition::REQUIRED, ParquetType::INT64));
 
@@ -517,12 +528,14 @@ TEST_F(TestConvertParquetSchema, ParquetNestedSchemaPartialOrdering) {
   //   required int64 leaf1;
   // }
   {
-    parquet_fields.push_back(GroupNode::Make("group1", Repetition::REQUIRED,
+    parquet_fields.push_back(GroupNode::Make(
+        "group1", Repetition::REQUIRED,
         {PrimitiveNode::Make("leaf1", Repetition::REQUIRED, ParquetType::INT64),
-            PrimitiveNode::Make("leaf2", Repetition::REQUIRED, ParquetType::INT64)}));
-    parquet_fields.push_back(GroupNode::Make("group2", Repetition::REQUIRED,
+         PrimitiveNode::Make("leaf2", Repetition::REQUIRED, ParquetType::INT64)}));
+    parquet_fields.push_back(GroupNode::Make(
+        "group2", Repetition::REQUIRED,
         {PrimitiveNode::Make("leaf3", Repetition::REQUIRED, ParquetType::INT64),
-            PrimitiveNode::Make("leaf4", Repetition::REQUIRED, ParquetType::INT64)}));
+         PrimitiveNode::Make("leaf4", Repetition::REQUIRED, ParquetType::INT64)}));
     parquet_fields.push_back(
         PrimitiveNode::Make("leaf5", Repetition::REQUIRED, ParquetType::INT64));
 
@@ -554,22 +567,25 @@ TEST_F(TestConvertParquetSchema, ParquetRepeatedNestedSchema) {
     //   }
     parquet_fields.push_back(
         PrimitiveNode::Make("leaf1", Repetition::OPTIONAL, ParquetType::INT32));
-    parquet_fields.push_back(GroupNode::Make("outerGroup", Repetition::REPEATED,
+    parquet_fields.push_back(GroupNode::Make(
+        "outerGroup", Repetition::REPEATED,
         {PrimitiveNode::Make("leaf2", Repetition::OPTIONAL, ParquetType::INT32),
-            GroupNode::Make("innerGroup", Repetition::REPEATED,
-                {PrimitiveNode::Make(
-                    "leaf3", Repetition::OPTIONAL, ParquetType::INT32)})}));
+         GroupNode::Make(
+             "innerGroup", Repetition::REPEATED,
+             {PrimitiveNode::Make("leaf3", Repetition::OPTIONAL, ParquetType::INT32)})}));
 
     auto inner_group_fields = {std::make_shared<Field>("leaf3", INT32, true)};
     auto inner_group_type = std::make_shared<::arrow::StructType>(inner_group_fields);
-    auto outer_group_fields = {std::make_shared<Field>("leaf2", INT32, true),
-        std::make_shared<Field>("innerGroup",
-            ::arrow::list(std::make_shared<Field>("innerGroup", inner_group_type, false)),
-            false)};
+    auto outer_group_fields = {
+        std::make_shared<Field>("leaf2", INT32, true),
+        std::make_shared<Field>("innerGroup", ::arrow::list(std::make_shared<Field>(
+                                                  "innerGroup", inner_group_type, false)),
+                                false)};
     auto outer_group_type = std::make_shared<::arrow::StructType>(outer_group_fields);
 
     arrow_fields.push_back(std::make_shared<Field>("leaf1", INT32, true));
-    arrow_fields.push_back(std::make_shared<Field>("outerGroup",
+    arrow_fields.push_back(std::make_shared<Field>(
+        "outerGroup",
         ::arrow::list(std::make_shared<Field>("outerGroup", outer_group_type, false)),
         false));
   }
@@ -626,20 +642,22 @@ TEST_F(TestConvertArrowSchema, ParquetFlatPrimitives) {
       PrimitiveNode::Make("int64", Repetition::REQUIRED, ParquetType::INT64));
   arrow_fields.push_back(std::make_shared<Field>("int64", INT64, false));
 
-  parquet_fields.push_back(PrimitiveNode::Make(
-      "date", Repetition::REQUIRED, ParquetType::INT32, LogicalType::DATE));
+  parquet_fields.push_back(PrimitiveNode::Make("date", Repetition::REQUIRED,
+                                               ParquetType::INT32, LogicalType::DATE));
   arrow_fields.push_back(std::make_shared<Field>("date", ::arrow::date32(), false));
 
-  parquet_fields.push_back(PrimitiveNode::Make(
-      "date64", Repetition::REQUIRED, ParquetType::INT32, LogicalType::DATE));
+  parquet_fields.push_back(PrimitiveNode::Make("date64", Repetition::REQUIRED,
+                                               ParquetType::INT32, LogicalType::DATE));
   arrow_fields.push_back(std::make_shared<Field>("date64", ::arrow::date64(), false));
 
   parquet_fields.push_back(PrimitiveNode::Make("timestamp", Repetition::REQUIRED,
-      ParquetType::INT64, LogicalType::TIMESTAMP_MILLIS));
+                                               ParquetType::INT64,
+                                               LogicalType::TIMESTAMP_MILLIS));
   arrow_fields.push_back(std::make_shared<Field>("timestamp", TIMESTAMP_MS, false));
 
   parquet_fields.push_back(PrimitiveNode::Make("timestamp[us]", Repetition::REQUIRED,
-      ParquetType::INT64, LogicalType::TIMESTAMP_MICROS));
+                                               ParquetType::INT64,
+                                               LogicalType::TIMESTAMP_MICROS));
   arrow_fields.push_back(std::make_shared<Field>("timestamp[us]", TIMESTAMP_US, false));
 
   parquet_fields.push_back(
@@ -676,8 +694,8 @@ TEST_F(TestConvertArrowSchema, ParquetLists) {
   //   }
   // }
   {
-    auto element = PrimitiveNode::Make(
-        "string", Repetition::OPTIONAL, ParquetType::BYTE_ARRAY, LogicalType::UTF8);
+    auto element = PrimitiveNode::Make("string", Repetition::OPTIONAL,
+                                       ParquetType::BYTE_ARRAY, LogicalType::UTF8);
     auto list = GroupNode::Make("list", Repetition::REPEATED, {element});
     parquet_fields.push_back(
         GroupNode::Make("my_list", Repetition::REQUIRED, {list}, LogicalType::LIST));
@@ -693,8 +711,8 @@ TEST_F(TestConvertArrowSchema, ParquetLists) {
   //   }
   // }
   {
-    auto element = PrimitiveNode::Make(
-        "string", Repetition::REQUIRED, ParquetType::BYTE_ARRAY, LogicalType::UTF8);
+    auto element = PrimitiveNode::Make("string", Repetition::REQUIRED,
+                                       ParquetType::BYTE_ARRAY, LogicalType::UTF8);
     auto list = GroupNode::Make("list", Repetition::REPEATED, {element});
     parquet_fields.push_back(
         GroupNode::Make("my_list", Repetition::OPTIONAL, {list}, LogicalType::LIST));

--- a/src/parquet/arrow/reader.h
+++ b/src/parquet/arrow/reader.h
@@ -130,19 +130,19 @@ class PARQUET_EXPORT FileReader {
   // i=1 indices={3} will read foo2 column
   // i=1 indices={2} will result in out=nullptr
   // leaf indices which are unrelated to the schema field are ignored
-  ::arrow::Status ReadSchemaField(
-      int i, const std::vector<int>& indices, std::shared_ptr<::arrow::Array>* out);
+  ::arrow::Status ReadSchemaField(int i, const std::vector<int>& indices,
+                                  std::shared_ptr<::arrow::Array>* out);
 
   // Read a table of columns into a Table
   ::arrow::Status ReadTable(std::shared_ptr<::arrow::Table>* out);
 
   // Read a table of columns into a Table. Read only the indicated column
   // indices (relative to the schema)
-  ::arrow::Status ReadTable(
-      const std::vector<int>& column_indices, std::shared_ptr<::arrow::Table>* out);
+  ::arrow::Status ReadTable(const std::vector<int>& column_indices,
+                            std::shared_ptr<::arrow::Table>* out);
 
   ::arrow::Status ReadRowGroup(int i, const std::vector<int>& column_indices,
-      std::shared_ptr<::arrow::Table>* out);
+                               std::shared_ptr<::arrow::Table>* out);
 
   ::arrow::Status ReadRowGroup(int i, std::shared_ptr<::arrow::Table>* out);
 
@@ -198,12 +198,15 @@ class PARQUET_EXPORT ColumnReader {
 // metadata : separately-computed file metadata, can be nullptr
 PARQUET_EXPORT
 ::arrow::Status OpenFile(const std::shared_ptr<::arrow::io::ReadableFileInterface>& file,
-    ::arrow::MemoryPool* allocator, const ReaderProperties& properties,
-    const std::shared_ptr<FileMetaData>& metadata, std::unique_ptr<FileReader>* reader);
+                         ::arrow::MemoryPool* allocator,
+                         const ReaderProperties& properties,
+                         const std::shared_ptr<FileMetaData>& metadata,
+                         std::unique_ptr<FileReader>* reader);
 
 PARQUET_EXPORT
 ::arrow::Status OpenFile(const std::shared_ptr<::arrow::io::ReadableFileInterface>& file,
-    ::arrow::MemoryPool* allocator, std::unique_ptr<FileReader>* reader);
+                         ::arrow::MemoryPool* allocator,
+                         std::unique_ptr<FileReader>* reader);
 
 }  // namespace arrow
 }  // namespace parquet

--- a/src/parquet/arrow/schema.h
+++ b/src/parquet/arrow/schema.h
@@ -36,8 +36,8 @@ namespace parquet {
 
 namespace arrow {
 
-::arrow::Status PARQUET_EXPORT NodeToField(
-    const schema::NodePtr& node, std::shared_ptr<::arrow::Field>* out);
+::arrow::Status PARQUET_EXPORT NodeToField(const schema::NodePtr& node,
+                                           std::shared_ptr<::arrow::Field>* out);
 
 /// Convert parquet schema to arrow schema with selected indices
 /// \param parquet_schema to be converted
@@ -47,31 +47,35 @@ namespace arrow {
 /// \param key_value_metadata optional metadata, can be nullptr
 /// \param out the corresponding arrow schema
 /// \return Status::OK() on a successful conversion.
-::arrow::Status PARQUET_EXPORT FromParquetSchema(const SchemaDescriptor* parquet_schema,
-    const std::vector<int>& column_indices,
+::arrow::Status PARQUET_EXPORT FromParquetSchema(
+    const SchemaDescriptor* parquet_schema, const std::vector<int>& column_indices,
     const std::shared_ptr<const KeyValueMetadata>& key_value_metadata,
     std::shared_ptr<::arrow::Schema>* out);
 
 // Without indices
-::arrow::Status PARQUET_EXPORT FromParquetSchema(const SchemaDescriptor* parquet_schema,
-    const std::shared_ptr<const KeyValueMetadata>& key_value_metadata,
-    std::shared_ptr<::arrow::Schema>* out);
+::arrow::Status PARQUET_EXPORT
+FromParquetSchema(const SchemaDescriptor* parquet_schema,
+                  const std::shared_ptr<const KeyValueMetadata>& key_value_metadata,
+                  std::shared_ptr<::arrow::Schema>* out);
 
 // Without metadata
 ::arrow::Status PARQUET_EXPORT FromParquetSchema(const SchemaDescriptor* parquet_schema,
-    const std::vector<int>& column_indices, std::shared_ptr<::arrow::Schema>* out);
+                                                 const std::vector<int>& column_indices,
+                                                 std::shared_ptr<::arrow::Schema>* out);
 
 // Without metadata or indices
-::arrow::Status PARQUET_EXPORT FromParquetSchema(
-    const SchemaDescriptor* parquet_schema, std::shared_ptr<::arrow::Schema>* out);
+::arrow::Status PARQUET_EXPORT FromParquetSchema(const SchemaDescriptor* parquet_schema,
+                                                 std::shared_ptr<::arrow::Schema>* out);
 
 ::arrow::Status PARQUET_EXPORT FieldToNode(const std::shared_ptr<::arrow::Field>& field,
-    const WriterProperties& properties, schema::NodePtr* out,
-    bool support_int96_nanoseconds = false);
+                                           const WriterProperties& properties,
+                                           schema::NodePtr* out,
+                                           bool support_int96_nanoseconds = false);
 
 ::arrow::Status PARQUET_EXPORT ToParquetSchema(const ::arrow::Schema* arrow_schema,
-    const WriterProperties& properties, std::shared_ptr<SchemaDescriptor>* out,
-    bool support_int96_nanoseconds = false);
+                                               const WriterProperties& properties,
+                                               std::shared_ptr<SchemaDescriptor>* out,
+                                               bool support_int96_nanoseconds = false);
 
 }  // namespace arrow
 

--- a/src/parquet/arrow/writer.h
+++ b/src/parquet/arrow/writer.h
@@ -85,26 +85,28 @@ std::shared_ptr<ArrowWriterProperties> PARQUET_EXPORT default_arrow_writer_prope
 class PARQUET_EXPORT FileWriter {
  public:
   FileWriter(::arrow::MemoryPool* pool, std::unique_ptr<ParquetFileWriter> writer,
-      const std::shared_ptr<ArrowWriterProperties>& arrow_properties =
-          default_arrow_writer_properties());
+             const std::shared_ptr<ArrowWriterProperties>& arrow_properties =
+                 default_arrow_writer_properties());
 
   static ::arrow::Status Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
-      const std::shared_ptr<OutputStream>& sink,
-      const std::shared_ptr<WriterProperties>& properties,
-      std::unique_ptr<FileWriter>* writer);
+                              const std::shared_ptr<OutputStream>& sink,
+                              const std::shared_ptr<WriterProperties>& properties,
+                              std::unique_ptr<FileWriter>* writer);
 
-  static ::arrow::Status Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
+  static ::arrow::Status Open(
+      const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
       const std::shared_ptr<OutputStream>& sink,
       const std::shared_ptr<WriterProperties>& properties,
       const std::shared_ptr<ArrowWriterProperties>& arrow_properties,
       std::unique_ptr<FileWriter>* writer);
 
   static ::arrow::Status Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
-      const std::shared_ptr<::arrow::io::OutputStream>& sink,
-      const std::shared_ptr<WriterProperties>& properties,
-      std::unique_ptr<FileWriter>* writer);
+                              const std::shared_ptr<::arrow::io::OutputStream>& sink,
+                              const std::shared_ptr<WriterProperties>& properties,
+                              std::unique_ptr<FileWriter>* writer);
 
-  static ::arrow::Status Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
+  static ::arrow::Status Open(
+      const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
       const std::shared_ptr<::arrow::io::OutputStream>& sink,
       const std::shared_ptr<WriterProperties>& properties,
       const std::shared_ptr<ArrowWriterProperties>& arrow_properties,
@@ -135,16 +137,16 @@ class PARQUET_EXPORT FileWriter {
  *
  * The table shall only consist of columns of primitive type or of primitive lists.
  */
-::arrow::Status PARQUET_EXPORT WriteTable(const ::arrow::Table& table,
-    ::arrow::MemoryPool* pool, const std::shared_ptr<OutputStream>& sink,
-    int64_t chunk_size,
+::arrow::Status PARQUET_EXPORT WriteTable(
+    const ::arrow::Table& table, ::arrow::MemoryPool* pool,
+    const std::shared_ptr<OutputStream>& sink, int64_t chunk_size,
     const std::shared_ptr<WriterProperties>& properties = default_writer_properties(),
     const std::shared_ptr<ArrowWriterProperties>& arrow_properties =
         default_arrow_writer_properties());
 
-::arrow::Status PARQUET_EXPORT WriteTable(const ::arrow::Table& table,
-    ::arrow::MemoryPool* pool, const std::shared_ptr<::arrow::io::OutputStream>& sink,
-    int64_t chunk_size,
+::arrow::Status PARQUET_EXPORT WriteTable(
+    const ::arrow::Table& table, ::arrow::MemoryPool* pool,
+    const std::shared_ptr<::arrow::io::OutputStream>& sink, int64_t chunk_size,
     const std::shared_ptr<WriterProperties>& properties = default_writer_properties(),
     const std::shared_ptr<ArrowWriterProperties>& arrow_properties =
         default_arrow_writer_properties());
@@ -160,8 +162,8 @@ constexpr int64_t kNanosecondsPerDay = INT64_C(86400000000000);
 /**
  * Converts nanosecond timestamps to Impala (Int96) format
  */
-inline void NanosecondsToImpalaTimestamp(
-    const int64_t nanoseconds, Int96* impala_timestamp) {
+inline void NanosecondsToImpalaTimestamp(const int64_t nanoseconds,
+                                         Int96* impala_timestamp) {
   int64_t julian_days = (nanoseconds / kNanosecondsPerDay) + kJulianEpochOffsetDays;
   (*impala_timestamp).value[2] = (uint32_t)julian_days;
 

--- a/src/parquet/column_page.h
+++ b/src/parquet/column_page.h
@@ -62,9 +62,9 @@ class Page {
 class DataPage : public Page {
  public:
   DataPage(const std::shared_ptr<Buffer>& buffer, int32_t num_values,
-      Encoding::type encoding, Encoding::type definition_level_encoding,
-      Encoding::type repetition_level_encoding,
-      const EncodedStatistics& statistics = EncodedStatistics())
+           Encoding::type encoding, Encoding::type definition_level_encoding,
+           Encoding::type repetition_level_encoding,
+           const EncodedStatistics& statistics = EncodedStatistics())
       : Page(buffer, PageType::DATA_PAGE),
         num_values_(num_values),
         encoding_(encoding),
@@ -93,11 +93,11 @@ class DataPage : public Page {
 class CompressedDataPage : public DataPage {
  public:
   CompressedDataPage(const std::shared_ptr<Buffer>& buffer, int32_t num_values,
-      Encoding::type encoding, Encoding::type definition_level_encoding,
-      Encoding::type repetition_level_encoding, int64_t uncompressed_size,
-      const EncodedStatistics& statistics = EncodedStatistics())
+                     Encoding::type encoding, Encoding::type definition_level_encoding,
+                     Encoding::type repetition_level_encoding, int64_t uncompressed_size,
+                     const EncodedStatistics& statistics = EncodedStatistics())
       : DataPage(buffer, num_values, encoding, definition_level_encoding,
-            repetition_level_encoding, statistics),
+                 repetition_level_encoding, statistics),
         uncompressed_size_(uncompressed_size) {}
 
   int64_t uncompressed_size() const { return uncompressed_size_; }
@@ -109,8 +109,9 @@ class CompressedDataPage : public DataPage {
 class DataPageV2 : public Page {
  public:
   DataPageV2(const std::shared_ptr<Buffer>& buffer, int32_t num_values, int32_t num_nulls,
-      int32_t num_rows, Encoding::type encoding, int32_t definition_levels_byte_length,
-      int32_t repetition_levels_byte_length, bool is_compressed = false)
+             int32_t num_rows, Encoding::type encoding,
+             int32_t definition_levels_byte_length, int32_t repetition_levels_byte_length,
+             bool is_compressed = false)
       : Page(buffer, PageType::DATA_PAGE_V2),
         num_values_(num_values),
         num_nulls_(num_nulls),
@@ -149,7 +150,7 @@ class DataPageV2 : public Page {
 class DictionaryPage : public Page {
  public:
   DictionaryPage(const std::shared_ptr<Buffer>& buffer, int32_t num_values,
-      Encoding::type encoding, bool is_sorted = false)
+                 Encoding::type encoding, bool is_sorted = false)
       : Page(buffer, PageType::DICTIONARY_PAGE),
         num_values_(num_values),
         encoding_(encoding),

--- a/src/parquet/column_reader-test.cc
+++ b/src/parquet/column_reader-test.cc
@@ -44,8 +44,10 @@ namespace test {
 
 template <typename T>
 static inline bool vector_equal_with_def_levels(const vector<T>& left,
-    const vector<int16_t>& def_levels, int16_t max_def_levels, int16_t max_rep_levels,
-    const vector<T>& right) {
+                                                const vector<int16_t>& def_levels,
+                                                int16_t max_def_levels,
+                                                int16_t max_rep_levels,
+                                                const vector<T>& right) {
   size_t i_left = 0;
   size_t i_right = 0;
   for (size_t i = 0; i < def_levels.size(); i++) {
@@ -63,7 +65,9 @@ static inline bool vector_equal_with_def_levels(const vector<T>& left,
       i_right++;
     } else if (def_levels[i] < (max_def_levels - 1)) {
       // Null entry on a higher nesting level, only supported for non-repeating data
-      if (max_rep_levels == 0) { i_right++; }
+      if (max_rep_levels == 0) {
+        i_right++;
+      }
     }
   }
 
@@ -93,8 +97,9 @@ class TestPrimitiveReader : public ::testing::Test {
     // 1) batch_size < page_size (multiple ReadBatch from a single page)
     // 2) batch_size > page_size (BatchRead limits to a single page)
     do {
-      batch = static_cast<int>(reader->ReadBatch(batch_size, &dresult[0] + batch_actual,
-          &rresult[0] + batch_actual, &vresult[0] + total_values_read, &values_read));
+      batch = static_cast<int>(reader->ReadBatch(
+          batch_size, &dresult[0] + batch_actual, &rresult[0] + batch_actual,
+          &vresult[0] + total_values_read, &values_read));
       total_values_read += static_cast<int>(values_read);
       batch_actual += batch;
       batch_size = std::max(batch_size * 2, 4096);
@@ -103,8 +108,12 @@ class TestPrimitiveReader : public ::testing::Test {
     ASSERT_EQ(num_levels_, batch_actual);
     ASSERT_EQ(num_values_, total_values_read);
     ASSERT_TRUE(vector_equal(values_, vresult));
-    if (max_def_level_ > 0) { ASSERT_TRUE(vector_equal(def_levels_, dresult)); }
-    if (max_rep_level_ > 0) { ASSERT_TRUE(vector_equal(rep_levels_, rresult)); }
+    if (max_def_level_ > 0) {
+      ASSERT_TRUE(vector_equal(def_levels_, dresult));
+    }
+    if (max_rep_level_ > 0) {
+      ASSERT_TRUE(vector_equal(rep_levels_, rresult));
+    }
     // catch improper writes at EOS
     batch_actual =
         static_cast<int>(reader->ReadBatch(5, nullptr, nullptr, nullptr, &values_read));
@@ -131,8 +140,8 @@ class TestPrimitiveReader : public ::testing::Test {
     // 1) batch_size < page_size (multiple ReadBatch from a single page)
     // 2) batch_size > page_size (BatchRead limits to a single page)
     do {
-      batch = static_cast<int>(reader->ReadBatchSpaced(batch_size,
-          dresult.data() + levels_actual, rresult.data() + levels_actual,
+      batch = static_cast<int>(reader->ReadBatchSpaced(
+          batch_size, dresult.data() + levels_actual, rresult.data() + levels_actual,
           vresult.data() + batch_actual, valid_bits.data() + batch_actual, 0,
           &levels_read, &values_read, &null_count));
       total_values_read += batch - static_cast<int>(null_count);
@@ -145,15 +154,18 @@ class TestPrimitiveReader : public ::testing::Test {
     ASSERT_EQ(num_values_, total_values_read);
     if (max_def_level_ > 0) {
       ASSERT_TRUE(vector_equal(def_levels_, dresult));
-      ASSERT_TRUE(vector_equal_with_def_levels(
-          values_, dresult, max_def_level_, max_rep_level_, vresult));
+      ASSERT_TRUE(vector_equal_with_def_levels(values_, dresult, max_def_level_,
+                                               max_rep_level_, vresult));
     } else {
       ASSERT_TRUE(vector_equal(values_, vresult));
     }
-    if (max_rep_level_ > 0) { ASSERT_TRUE(vector_equal(rep_levels_, rresult)); }
+    if (max_rep_level_ > 0) {
+      ASSERT_TRUE(vector_equal(rep_levels_, rresult));
+    }
     // catch improper writes at EOS
-    batch_actual = static_cast<int>(reader->ReadBatchSpaced(5, nullptr, nullptr, nullptr,
-        valid_bits.data(), 0, &levels_read, &values_read, &null_count));
+    batch_actual = static_cast<int>(
+        reader->ReadBatchSpaced(5, nullptr, nullptr, nullptr, valid_bits.data(), 0,
+                                &levels_read, &values_read, &null_count));
     ASSERT_EQ(0, batch_actual);
     ASSERT_EQ(0, null_count);
   }
@@ -167,15 +179,17 @@ class TestPrimitiveReader : public ::testing::Test {
   }
 
   void ExecutePlain(int num_pages, int levels_per_page, const ColumnDescriptor* d) {
-    num_values_ = MakePages<Int32Type>(d, num_pages, levels_per_page, def_levels_,
-        rep_levels_, values_, data_buffer_, pages_, Encoding::PLAIN);
+    num_values_ =
+        MakePages<Int32Type>(d, num_pages, levels_per_page, def_levels_, rep_levels_,
+                             values_, data_buffer_, pages_, Encoding::PLAIN);
     num_levels_ = num_pages * levels_per_page;
     InitReader(d);
     CheckResults();
     Clear();
 
-    num_values_ = MakePages<Int32Type>(d, num_pages, levels_per_page, def_levels_,
-        rep_levels_, values_, data_buffer_, pages_, Encoding::PLAIN);
+    num_values_ =
+        MakePages<Int32Type>(d, num_pages, levels_per_page, def_levels_, rep_levels_,
+                             values_, data_buffer_, pages_, Encoding::PLAIN);
     num_levels_ = num_pages * levels_per_page;
     InitReader(d);
     CheckResultsSpaced();
@@ -183,15 +197,17 @@ class TestPrimitiveReader : public ::testing::Test {
   }
 
   void ExecuteDict(int num_pages, int levels_per_page, const ColumnDescriptor* d) {
-    num_values_ = MakePages<Int32Type>(d, num_pages, levels_per_page, def_levels_,
-        rep_levels_, values_, data_buffer_, pages_, Encoding::RLE_DICTIONARY);
+    num_values_ =
+        MakePages<Int32Type>(d, num_pages, levels_per_page, def_levels_, rep_levels_,
+                             values_, data_buffer_, pages_, Encoding::RLE_DICTIONARY);
     num_levels_ = num_pages * levels_per_page;
     InitReader(d);
     CheckResults();
     Clear();
 
-    num_values_ = MakePages<Int32Type>(d, num_pages, levels_per_page, def_levels_,
-        rep_levels_, values_, data_buffer_, pages_, Encoding::RLE_DICTIONARY);
+    num_values_ =
+        MakePages<Int32Type>(d, num_pages, levels_per_page, def_levels_, rep_levels_,
+                             values_, data_buffer_, pages_, Encoding::RLE_DICTIONARY);
     num_levels_ = num_pages * levels_per_page;
     InitReader(d);
     CheckResultsSpaced();
@@ -252,7 +268,7 @@ TEST_F(TestPrimitiveReader, TestInt32FlatRequiredSkip) {
   NodePtr type = schema::Int32("b", Repetition::REQUIRED);
   const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
   MakePages<Int32Type>(&descr, num_pages, levels_per_page, def_levels_, rep_levels_,
-      values_, data_buffer_, pages_, Encoding::PLAIN);
+                       values_, data_buffer_, pages_, Encoding::PLAIN);
   InitReader(&descr);
   vector<int32_t> vresult(levels_per_page / 2, -1);
   vector<int16_t> dresult(levels_per_page / 2, -1);
@@ -266,9 +282,10 @@ TEST_F(TestPrimitiveReader, TestInt32FlatRequiredSkip) {
   int64_t levels_skipped = reader->Skip(2 * levels_per_page);
   ASSERT_EQ(2 * levels_per_page, levels_skipped);
   // Read half a page
-  reader->ReadBatch(
-      levels_per_page / 2, dresult.data(), rresult.data(), vresult.data(), &values_read);
-  vector<int32_t> sub_values(values_.begin() + 2 * levels_per_page,
+  reader->ReadBatch(levels_per_page / 2, dresult.data(), rresult.data(), vresult.data(),
+                    &values_read);
+  vector<int32_t> sub_values(
+      values_.begin() + 2 * levels_per_page,
       values_.begin() + static_cast<int>(2.5 * static_cast<double>(levels_per_page)));
   ASSERT_TRUE(vector_equal(sub_values, vresult));
 
@@ -276,10 +293,11 @@ TEST_F(TestPrimitiveReader, TestInt32FlatRequiredSkip) {
   levels_skipped = reader->Skip(levels_per_page);
   ASSERT_EQ(levels_per_page, levels_skipped);
   // Read half a page
-  reader->ReadBatch(
-      levels_per_page / 2, dresult.data(), rresult.data(), vresult.data(), &values_read);
+  reader->ReadBatch(levels_per_page / 2, dresult.data(), rresult.data(), vresult.data(),
+                    &values_read);
   sub_values.clear();
-  sub_values.insert(sub_values.end(),
+  sub_values.insert(
+      sub_values.end(),
       values_.begin() + static_cast<int>(3.5 * static_cast<double>(levels_per_page)),
       values_.begin() + 4 * levels_per_page);
   ASSERT_TRUE(vector_equal(sub_values, vresult));
@@ -289,10 +307,11 @@ TEST_F(TestPrimitiveReader, TestInt32FlatRequiredSkip) {
   levels_skipped = reader->Skip(levels_per_page / 2);
   ASSERT_EQ(0.5 * levels_per_page, levels_skipped);
   // Read half a page
-  reader->ReadBatch(
-      levels_per_page / 2, dresult.data(), rresult.data(), vresult.data(), &values_read);
+  reader->ReadBatch(levels_per_page / 2, dresult.data(), rresult.data(), vresult.data(),
+                    &values_read);
   sub_values.clear();
-  sub_values.insert(sub_values.end(),
+  sub_values.insert(
+      sub_values.end(),
       values_.begin() + static_cast<int>(4.5 * static_cast<double>(levels_per_page)),
       values_.end());
   ASSERT_TRUE(vector_equal(sub_values, vresult));
@@ -323,8 +342,8 @@ TEST_F(TestPrimitiveReader, TestDictionaryEncodedPages) {
   pages_.clear();
 
   dict_page = std::make_shared<DictionaryPage>(dummy, 0, Encoding::PLAIN_DICTIONARY);
-  data_page = MakeDataPage<Int32Type>(
-      &descr, {}, 0, Encoding::PLAIN_DICTIONARY, {}, 0, {}, 0, {}, 0);
+  data_page = MakeDataPage<Int32Type>(&descr, {}, 0, Encoding::PLAIN_DICTIONARY, {}, 0,
+                                      {}, 0, {}, 0);
   pages_.push_back(dict_page);
   pages_.push_back(data_page);
   InitReader(&descr);
@@ -332,8 +351,8 @@ TEST_F(TestPrimitiveReader, TestDictionaryEncodedPages) {
   ASSERT_NO_THROW(reader_->HasNext());
   pages_.clear();
 
-  data_page = MakeDataPage<Int32Type>(
-      &descr, {}, 0, Encoding::RLE_DICTIONARY, {}, 0, {}, 0, {}, 0);
+  data_page = MakeDataPage<Int32Type>(&descr, {}, 0, Encoding::RLE_DICTIONARY, {}, 0, {},
+                                      0, {}, 0);
   pages_.push_back(data_page);
   InitReader(&descr);
   // Tests dictionary page must occur before data page
@@ -358,8 +377,8 @@ TEST_F(TestPrimitiveReader, TestDictionaryEncodedPages) {
   ASSERT_THROW(reader_->HasNext(), ParquetException);
   pages_.clear();
 
-  data_page = MakeDataPage<Int32Type>(
-      &descr, {}, 0, Encoding::DELTA_BYTE_ARRAY, {}, 0, {}, 0, {}, 0);
+  data_page = MakeDataPage<Int32Type>(&descr, {}, 0, Encoding::DELTA_BYTE_ARRAY, {}, 0,
+                                      {}, 0, {}, 0);
   pages_.push_back(data_page);
   InitReader(&descr);
   // unsupported encoding

--- a/src/parquet/column_reader.cc
+++ b/src/parquet/column_reader.cc
@@ -36,7 +36,7 @@ LevelDecoder::LevelDecoder() : num_values_remaining_(0) {}
 LevelDecoder::~LevelDecoder() {}
 
 int LevelDecoder::SetData(Encoding::type encoding, int16_t max_level,
-    int num_buffered_values, const uint8_t* data) {
+                          int num_buffered_values, const uint8_t* data) {
   int32_t num_bytes = 0;
   encoding_ = encoding;
   num_values_remaining_ = num_buffered_values;
@@ -86,8 +86,8 @@ ReaderProperties default_reader_properties() {
   return default_reader_properties;
 }
 
-ColumnReader::ColumnReader(
-    const ColumnDescriptor* descr, std::unique_ptr<PageReader> pager, MemoryPool* pool)
+ColumnReader::ColumnReader(const ColumnDescriptor* descr,
+                           std::unique_ptr<PageReader> pager, MemoryPool* pool)
     : descr_(descr),
       pager_(std::move(pager)),
       num_buffered_values_(0),
@@ -193,7 +193,9 @@ bool TypedColumnReader<DType>::ReadNewPage() {
       // first page with this encoding.
       Encoding::type encoding = page->encoding();
 
-      if (IsDictionaryIndexEncoding(encoding)) { encoding = Encoding::RLE_DICTIONARY; }
+      if (IsDictionaryIndexEncoding(encoding)) {
+        encoding = Encoding::RLE_DICTIONARY;
+      }
 
       auto it = decoders_.find(static_cast<int>(encoding));
       if (it != decoders_.end()) {
@@ -221,8 +223,8 @@ bool TypedColumnReader<DType>::ReadNewPage() {
             throw ParquetException("Unknown encoding type.");
         }
       }
-      current_decoder_->SetData(
-          static_cast<int>(num_buffered_values_), buffer, static_cast<int>(data_size));
+      current_decoder_->SetData(static_cast<int>(num_buffered_values_), buffer,
+                                static_cast<int>(data_size));
       return true;
     } else {
       // We don't know what this page type is. We're allowed to skip non-data
@@ -237,20 +239,25 @@ bool TypedColumnReader<DType>::ReadNewPage() {
 // Batch read APIs
 
 int64_t ColumnReader::ReadDefinitionLevels(int64_t batch_size, int16_t* levels) {
-  if (descr_->max_definition_level() == 0) { return 0; }
+  if (descr_->max_definition_level() == 0) {
+    return 0;
+  }
   return definition_level_decoder_.Decode(static_cast<int>(batch_size), levels);
 }
 
 int64_t ColumnReader::ReadRepetitionLevels(int64_t batch_size, int16_t* levels) {
-  if (descr_->max_repetition_level() == 0) { return 0; }
+  if (descr_->max_repetition_level() == 0) {
+    return 0;
+  }
   return repetition_level_decoder_.Decode(static_cast<int>(batch_size), levels);
 }
 
 // ----------------------------------------------------------------------
 // Dynamic column reader constructor
 
-std::shared_ptr<ColumnReader> ColumnReader::Make(
-    const ColumnDescriptor* descr, std::unique_ptr<PageReader> pager, MemoryPool* pool) {
+std::shared_ptr<ColumnReader> ColumnReader::Make(const ColumnDescriptor* descr,
+                                                 std::unique_ptr<PageReader> pager,
+                                                 MemoryPool* pool) {
   switch (descr->physical_type()) {
     case Type::BOOLEAN:
       return std::make_shared<BoolReader>(descr, std::move(pager), pool);

--- a/src/parquet/column_scanner-test.cc
+++ b/src/parquet/column_scanner-test.cc
@@ -43,8 +43,8 @@ using schema::NodePtr;
 namespace test {
 
 template <>
-void InitDictValues<bool>(
-    int num_values, int dict_per_page, vector<bool>& values, vector<uint8_t>& buffer) {
+void InitDictValues<bool>(int num_values, int dict_per_page, vector<bool>& values,
+                          vector<uint8_t>& buffer) {
   // No op for bool
 }
 
@@ -91,9 +91,9 @@ class TestFlatScanner : public ::testing::Test {
   }
 
   void Execute(int num_pages, int levels_per_page, int batch_size,
-      const ColumnDescriptor* d, Encoding::type encoding) {
+               const ColumnDescriptor* d, Encoding::type encoding) {
     num_values_ = MakePages<Type>(d, num_pages, levels_per_page, def_levels_, rep_levels_,
-        values_, data_buffer_, pages_, encoding);
+                                  values_, data_buffer_, pages_, encoding);
     num_levels_ = num_pages * levels_per_page;
     InitScanner(d);
     CheckResults(batch_size, d);
@@ -101,22 +101,22 @@ class TestFlatScanner : public ::testing::Test {
   }
 
   void InitDescriptors(std::shared_ptr<ColumnDescriptor>& d1,
-      std::shared_ptr<ColumnDescriptor>& d2, std::shared_ptr<ColumnDescriptor>& d3,
-      int length) {
+                       std::shared_ptr<ColumnDescriptor>& d2,
+                       std::shared_ptr<ColumnDescriptor>& d3, int length) {
     NodePtr type;
-    type = schema::PrimitiveNode::Make(
-        "c1", Repetition::REQUIRED, Type::type_num, LogicalType::NONE, length);
+    type = schema::PrimitiveNode::Make("c1", Repetition::REQUIRED, Type::type_num,
+                                       LogicalType::NONE, length);
     d1.reset(new ColumnDescriptor(type, 0, 0));
-    type = schema::PrimitiveNode::Make(
-        "c2", Repetition::OPTIONAL, Type::type_num, LogicalType::NONE, length);
+    type = schema::PrimitiveNode::Make("c2", Repetition::OPTIONAL, Type::type_num,
+                                       LogicalType::NONE, length);
     d2.reset(new ColumnDescriptor(type, 4, 0));
-    type = schema::PrimitiveNode::Make(
-        "c3", Repetition::REPEATED, Type::type_num, LogicalType::NONE, length);
+    type = schema::PrimitiveNode::Make("c3", Repetition::REPEATED, Type::type_num,
+                                       LogicalType::NONE, length);
     d3.reset(new ColumnDescriptor(type, 4, 2));
   }
 
   void ExecuteAll(int num_pages, int num_levels, int batch_size, int type_length,
-      Encoding::type encoding = Encoding::PLAIN) {
+                  Encoding::type encoding = Encoding::PLAIN) {
     std::shared_ptr<ColumnDescriptor> d1;
     std::shared_ptr<ColumnDescriptor> d2;
     std::shared_ptr<ColumnDescriptor> d3;
@@ -145,7 +145,7 @@ static int num_pages = 20;
 static int batch_size = 32;
 
 typedef ::testing::Types<Int32Type, Int64Type, Int96Type, FloatType, DoubleType,
-    ByteArrayType>
+                         ByteArrayType>
     TestTypes;
 
 using TestBooleanFlatScanner = TestFlatScanner<BooleanType>;
@@ -158,8 +158,8 @@ TYPED_TEST(TestFlatScanner, TestPlainScanner) {
 }
 
 TYPED_TEST(TestFlatScanner, TestDictScanner) {
-  this->ExecuteAll(
-      num_pages, num_levels_per_page, batch_size, 0, Encoding::RLE_DICTIONARY);
+  this->ExecuteAll(num_pages, num_levels_per_page, batch_size, 0,
+                   Encoding::RLE_DICTIONARY);
 }
 
 TEST_F(TestBooleanFlatScanner, TestPlainScanner) {
@@ -171,33 +171,35 @@ TEST_F(TestFLBAFlatScanner, TestPlainScanner) {
 }
 
 TEST_F(TestFLBAFlatScanner, TestDictScanner) {
-  this->ExecuteAll(
-      num_pages, num_levels_per_page, batch_size, FLBA_LENGTH, Encoding::RLE_DICTIONARY);
+  this->ExecuteAll(num_pages, num_levels_per_page, batch_size, FLBA_LENGTH,
+                   Encoding::RLE_DICTIONARY);
 }
 
 TEST_F(TestFLBAFlatScanner, TestPlainDictScanner) {
   this->ExecuteAll(num_pages, num_levels_per_page, batch_size, FLBA_LENGTH,
-      Encoding::PLAIN_DICTIONARY);
+                   Encoding::PLAIN_DICTIONARY);
 }
 
 // PARQUET 502
 TEST_F(TestFLBAFlatScanner, TestSmallBatch) {
-  NodePtr type = schema::PrimitiveNode::Make("c1", Repetition::REQUIRED,
-      Type::FIXED_LEN_BYTE_ARRAY, LogicalType::DECIMAL, FLBA_LENGTH, 10, 2);
+  NodePtr type =
+      schema::PrimitiveNode::Make("c1", Repetition::REQUIRED, Type::FIXED_LEN_BYTE_ARRAY,
+                                  LogicalType::DECIMAL, FLBA_LENGTH, 10, 2);
   const ColumnDescriptor d(type, 0, 0);
-  num_values_ = MakePages<FLBAType>(
-      &d, 1, 100, def_levels_, rep_levels_, values_, data_buffer_, pages_);
+  num_values_ = MakePages<FLBAType>(&d, 1, 100, def_levels_, rep_levels_, values_,
+                                    data_buffer_, pages_);
   num_levels_ = 1 * 100;
   InitScanner(&d);
   CheckResults(1, &d);
 }
 
 TEST_F(TestFLBAFlatScanner, TestDescriptorAPI) {
-  NodePtr type = schema::PrimitiveNode::Make("c1", Repetition::OPTIONAL,
-      Type::FIXED_LEN_BYTE_ARRAY, LogicalType::DECIMAL, FLBA_LENGTH, 10, 2);
+  NodePtr type =
+      schema::PrimitiveNode::Make("c1", Repetition::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY,
+                                  LogicalType::DECIMAL, FLBA_LENGTH, 10, 2);
   const ColumnDescriptor d(type, 4, 0);
-  num_values_ = MakePages<FLBAType>(
-      &d, 1, 100, def_levels_, rep_levels_, values_, data_buffer_, pages_);
+  num_values_ = MakePages<FLBAType>(&d, 1, 100, def_levels_, rep_levels_, values_,
+                                    data_buffer_, pages_);
   num_levels_ = 1 * 100;
   InitScanner(&d);
   TypedScanner<FLBAType>* scanner =
@@ -208,11 +210,12 @@ TEST_F(TestFLBAFlatScanner, TestDescriptorAPI) {
 }
 
 TEST_F(TestFLBAFlatScanner, TestFLBAPrinterNext) {
-  NodePtr type = schema::PrimitiveNode::Make("c1", Repetition::OPTIONAL,
-      Type::FIXED_LEN_BYTE_ARRAY, LogicalType::DECIMAL, FLBA_LENGTH, 10, 2);
+  NodePtr type =
+      schema::PrimitiveNode::Make("c1", Repetition::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY,
+                                  LogicalType::DECIMAL, FLBA_LENGTH, 10, 2);
   const ColumnDescriptor d(type, 4, 0);
-  num_values_ = MakePages<FLBAType>(
-      &d, 1, 100, def_levels_, rep_levels_, values_, data_buffer_, pages_);
+  num_values_ = MakePages<FLBAType>(&d, 1, 100, def_levels_, rep_levels_, values_,
+                                    data_buffer_, pages_);
   num_levels_ = 1 * 100;
   InitScanner(&d);
   TypedScanner<FLBAType>* scanner =

--- a/src/parquet/column_scanner.cc
+++ b/src/parquet/column_scanner.cc
@@ -27,8 +27,8 @@ using arrow::MemoryPool;
 
 namespace parquet {
 
-std::shared_ptr<Scanner> Scanner::Make(
-    std::shared_ptr<ColumnReader> col_reader, int64_t batch_size, MemoryPool* pool) {
+std::shared_ptr<Scanner> Scanner::Make(std::shared_ptr<ColumnReader> col_reader,
+                                       int64_t batch_size, MemoryPool* pool) {
   switch (col_reader->type()) {
     case Type::BOOLEAN:
       return std::make_shared<BoolScanner>(col_reader, batch_size, pool);
@@ -54,32 +54,33 @@ std::shared_ptr<Scanner> Scanner::Make(
 }
 
 int64_t ScanAllValues(int32_t batch_size, int16_t* def_levels, int16_t* rep_levels,
-    uint8_t* values, int64_t* values_buffered, parquet::ColumnReader* reader) {
+                      uint8_t* values, int64_t* values_buffered,
+                      parquet::ColumnReader* reader) {
   switch (reader->type()) {
     case parquet::Type::BOOLEAN:
-      return ScanAll<parquet::BoolReader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+      return ScanAll<parquet::BoolReader>(batch_size, def_levels, rep_levels, values,
+                                          values_buffered, reader);
     case parquet::Type::INT32:
-      return ScanAll<parquet::Int32Reader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+      return ScanAll<parquet::Int32Reader>(batch_size, def_levels, rep_levels, values,
+                                           values_buffered, reader);
     case parquet::Type::INT64:
-      return ScanAll<parquet::Int64Reader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+      return ScanAll<parquet::Int64Reader>(batch_size, def_levels, rep_levels, values,
+                                           values_buffered, reader);
     case parquet::Type::INT96:
-      return ScanAll<parquet::Int96Reader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+      return ScanAll<parquet::Int96Reader>(batch_size, def_levels, rep_levels, values,
+                                           values_buffered, reader);
     case parquet::Type::FLOAT:
-      return ScanAll<parquet::FloatReader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+      return ScanAll<parquet::FloatReader>(batch_size, def_levels, rep_levels, values,
+                                           values_buffered, reader);
     case parquet::Type::DOUBLE:
-      return ScanAll<parquet::DoubleReader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+      return ScanAll<parquet::DoubleReader>(batch_size, def_levels, rep_levels, values,
+                                            values_buffered, reader);
     case parquet::Type::BYTE_ARRAY:
-      return ScanAll<parquet::ByteArrayReader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+      return ScanAll<parquet::ByteArrayReader>(batch_size, def_levels, rep_levels, values,
+                                               values_buffered, reader);
     case parquet::Type::FIXED_LEN_BYTE_ARRAY:
-      return ScanAll<parquet::FixedLenByteArrayReader>(
-          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+      return ScanAll<parquet::FixedLenByteArrayReader>(batch_size, def_levels, rep_levels,
+                                                       values, values_buffered, reader);
     default:
       parquet::ParquetException::NYI("type reader not implemented");
   }

--- a/src/parquet/column_writer-test.cc
+++ b/src/parquet/column_writer-test.cc
@@ -59,8 +59,8 @@ class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
 
   Type::type type_num() { return TestType::type_num; }
 
-  void BuildReader(
-      int64_t num_rows, Compression::type compression = Compression::UNCOMPRESSED) {
+  void BuildReader(int64_t num_rows,
+                   Compression::type compression = Compression::UNCOMPRESSED) {
     auto buffer = sink_->GetBuffer();
     std::unique_ptr<InMemoryInputStream> source(new InMemoryInputStream(buffer));
     std::unique_ptr<SerializedPageReader> page_reader(
@@ -93,8 +93,8 @@ class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
   void ReadColumn(Compression::type compression = Compression::UNCOMPRESSED) {
     BuildReader(static_cast<int64_t>(this->values_out_.size()), compression);
     reader_->ReadBatch(static_cast<int>(this->values_out_.size()),
-        definition_levels_out_.data(), repetition_levels_out_.data(),
-        this->values_out_ptr_, &values_read_);
+                       definition_levels_out_.data(), repetition_levels_out_.data(),
+                       this->values_out_ptr_, &values_read_);
     this->SyncValuesOut();
   }
 
@@ -105,22 +105,24 @@ class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
   }
 
   void TestRequiredWithSettings(Encoding::type encoding, Compression::type compression,
-      bool enable_dictionary, bool enable_statistics, int64_t num_rows = SMALL_SIZE) {
+                                bool enable_dictionary, bool enable_statistics,
+                                int64_t num_rows = SMALL_SIZE) {
     this->GenerateData(num_rows);
 
-    this->WriteRequiredWithSettings(
-        encoding, compression, enable_dictionary, enable_statistics, num_rows);
+    this->WriteRequiredWithSettings(encoding, compression, enable_dictionary,
+                                    enable_statistics, num_rows);
     this->ReadAndCompare(compression, num_rows);
 
-    this->WriteRequiredWithSettingsSpaced(
-        encoding, compression, enable_dictionary, enable_statistics, num_rows);
+    this->WriteRequiredWithSettingsSpaced(encoding, compression, enable_dictionary,
+                                          enable_statistics, num_rows);
     this->ReadAndCompare(compression, num_rows);
   }
 
   void WriteRequiredWithSettings(Encoding::type encoding, Compression::type compression,
-      bool enable_dictionary, bool enable_statistics, int64_t num_rows) {
-    ColumnProperties column_properties(
-        encoding, compression, enable_dictionary, enable_statistics);
+                                 bool enable_dictionary, bool enable_statistics,
+                                 int64_t num_rows) {
+    ColumnProperties column_properties(encoding, compression, enable_dictionary,
+                                       enable_statistics);
     std::shared_ptr<TypedColumnWriter<TestType>> writer =
         this->BuildWriter(num_rows, column_properties);
     writer->WriteBatch(this->values_.size(), nullptr, nullptr, this->values_ptr_);
@@ -130,16 +132,17 @@ class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
   }
 
   void WriteRequiredWithSettingsSpaced(Encoding::type encoding,
-      Compression::type compression, bool enable_dictionary, bool enable_statistics,
-      int64_t num_rows) {
+                                       Compression::type compression,
+                                       bool enable_dictionary, bool enable_statistics,
+                                       int64_t num_rows) {
     std::vector<uint8_t> valid_bits(
         BitUtil::RoundUpNumBytes(static_cast<uint32_t>(this->values_.size())) + 1, 255);
-    ColumnProperties column_properties(
-        encoding, compression, enable_dictionary, enable_statistics);
+    ColumnProperties column_properties(encoding, compression, enable_dictionary,
+                                       enable_statistics);
     std::shared_ptr<TypedColumnWriter<TestType>> writer =
         this->BuildWriter(num_rows, column_properties);
-    writer->WriteBatchSpaced(
-        this->values_.size(), nullptr, nullptr, valid_bits.data(), 0, this->values_ptr_);
+    writer->WriteBatchSpaced(this->values_.size(), nullptr, nullptr, valid_bits.data(), 0,
+                             this->values_ptr_);
     // The behaviour should be independent from the number of Close() calls
     writer->Close();
     writer->Close();
@@ -234,7 +237,7 @@ void TestPrimitiveWriter<FLBAType>::ReadColumnFully(Compression::type compressio
     uint8_t* data_ptr = data.data();
     for (int64_t i = 0; i < values_read_recently; i++) {
       memcpy(data_ptr + this->descr_->type_length() * i,
-          this->values_out_[i + values_read_].ptr, this->descr_->type_length());
+             this->values_out_[i + values_read_].ptr, this->descr_->type_length());
       this->values_out_[i + values_read_].ptr =
           data_ptr + this->descr_->type_length() * i;
     }
@@ -246,7 +249,7 @@ void TestPrimitiveWriter<FLBAType>::ReadColumnFully(Compression::type compressio
 }
 
 typedef ::testing::Types<Int32Type, Int64Type, Int96Type, FloatType, DoubleType,
-    BooleanType, ByteArrayType, FLBAType>
+                         BooleanType, ByteArrayType, FLBAType>
     TestTypes;
 
 TYPED_TEST_CASE(TestPrimitiveWriter, TestTypes);
@@ -288,38 +291,38 @@ TYPED_TEST(TestPrimitiveWriter, RequiredRLEDictionary) {
 */
 
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithSnappyCompression) {
-  this->TestRequiredWithSettings(
-      Encoding::PLAIN, Compression::SNAPPY, false, false, LARGE_SIZE);
+  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::SNAPPY, false, false,
+                                 LARGE_SIZE);
 }
 
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithBrotliCompression) {
-  this->TestRequiredWithSettings(
-      Encoding::PLAIN, Compression::BROTLI, false, false, LARGE_SIZE);
+  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::BROTLI, false, false,
+                                 LARGE_SIZE);
 }
 
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithGzipCompression) {
-  this->TestRequiredWithSettings(
-      Encoding::PLAIN, Compression::GZIP, false, false, LARGE_SIZE);
+  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::GZIP, false, false,
+                                 LARGE_SIZE);
 }
 
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStats) {
-  this->TestRequiredWithSettings(
-      Encoding::PLAIN, Compression::UNCOMPRESSED, false, true, LARGE_SIZE);
+  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::UNCOMPRESSED, false, true,
+                                 LARGE_SIZE);
 }
 
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndSnappyCompression) {
-  this->TestRequiredWithSettings(
-      Encoding::PLAIN, Compression::SNAPPY, false, true, LARGE_SIZE);
+  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::SNAPPY, false, true,
+                                 LARGE_SIZE);
 }
 
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndBrotliCompression) {
-  this->TestRequiredWithSettings(
-      Encoding::PLAIN, Compression::BROTLI, false, true, LARGE_SIZE);
+  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::BROTLI, false, true,
+                                 LARGE_SIZE);
 }
 
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndGzipCompression) {
-  this->TestRequiredWithSettings(
-      Encoding::PLAIN, Compression::GZIP, false, true, LARGE_SIZE);
+  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::GZIP, false, true,
+                                 LARGE_SIZE);
 }
 
 TYPED_TEST(TestPrimitiveWriter, Optional) {
@@ -332,8 +335,8 @@ TYPED_TEST(TestPrimitiveWriter, Optional) {
   definition_levels[1] = 0;
 
   auto writer = this->BuildWriter();
-  writer->WriteBatch(
-      this->values_.size(), definition_levels.data(), nullptr, this->values_ptr_);
+  writer->WriteBatch(this->values_.size(), definition_levels.data(), nullptr,
+                     this->values_ptr_);
   writer->Close();
 
   // PARQUET-703
@@ -362,7 +365,7 @@ TYPED_TEST(TestPrimitiveWriter, OptionalSpaced) {
 
   auto writer = this->BuildWriter();
   writer->WriteBatchSpaced(this->values_.size(), definition_levels.data(), nullptr,
-      valid_bits.data(), 0, this->values_ptr_);
+                           valid_bits.data(), 0, this->values_ptr_);
   writer->Close();
 
   // PARQUET-703
@@ -387,7 +390,7 @@ TYPED_TEST(TestPrimitiveWriter, Repeated) {
 
   auto writer = this->BuildWriter();
   writer->WriteBatch(this->values_.size(), definition_levels.data(),
-      repetition_levels.data(), this->values_ptr_);
+                     repetition_levels.data(), this->values_ptr_);
   writer->Close();
 
   this->ReadColumn();
@@ -426,7 +429,7 @@ TYPED_TEST(TestPrimitiveWriter, RepeatedTooFewRows) {
 
   auto writer = this->BuildWriter();
   writer->WriteBatch(this->values_.size(), definition_levels.data(),
-      repetition_levels.data(), this->values_ptr_);
+                     repetition_levels.data(), this->values_ptr_);
   ASSERT_THROW(writer->Close(), ParquetException);
 }
 
@@ -485,8 +488,8 @@ TEST_F(TestNullValuesWriter, OptionalNullValueChunk) {
 
   auto writer = this->BuildWriter(LARGE_SIZE);
   // All values being written are NULL
-  writer->WriteBatch(
-      this->values_.size(), definition_levels.data(), repetition_levels.data(), NULL);
+  writer->WriteBatch(this->values_.size(), definition_levels.data(),
+                     repetition_levels.data(), NULL);
   writer->Close();
 
   // Just read the first SMALL_SIZE rows to ensure we could read it back in
@@ -512,7 +515,7 @@ TEST_F(TestBooleanValuesWriter, AlternateBooleanValues) {
 }
 
 void GenerateLevels(int min_repeat_factor, int max_repeat_factor, int max_level,
-    std::vector<int16_t>& input_levels) {
+                    std::vector<int16_t>& input_levels) {
   // for each repetition count upto max_repeat_factor
   for (int repeat = min_repeat_factor; repeat <= max_repeat_factor; repeat++) {
     // repeat count increases by a factor of 2 for every iteration
@@ -531,7 +534,7 @@ void GenerateLevels(int min_repeat_factor, int max_repeat_factor, int max_level,
 }
 
 void EncodeLevels(Encoding::type encoding, int max_level, int num_levels,
-    const int16_t* input_levels, std::vector<uint8_t>& bytes) {
+                  const int16_t* input_levels, std::vector<uint8_t>& bytes) {
   LevelEncoder encoder;
   int levels_count = 0;
   bytes.resize(2 * num_levels);
@@ -540,20 +543,21 @@ void EncodeLevels(Encoding::type encoding, int max_level, int num_levels,
   if (encoding == Encoding::RLE) {
     // leave space to write the rle length value
     encoder.Init(encoding, max_level, num_levels, bytes.data() + sizeof(int32_t),
-        static_cast<int>(bytes.size()));
+                 static_cast<int>(bytes.size()));
 
     levels_count = encoder.Encode(num_levels, input_levels);
     (reinterpret_cast<int32_t*>(bytes.data()))[0] = encoder.len();
   } else {
-    encoder.Init(
-        encoding, max_level, num_levels, bytes.data(), static_cast<int>(bytes.size()));
+    encoder.Init(encoding, max_level, num_levels, bytes.data(),
+                 static_cast<int>(bytes.size()));
     levels_count = encoder.Encode(num_levels, input_levels);
   }
   ASSERT_EQ(num_levels, levels_count);
 }
 
 void VerifyDecodingLevels(Encoding::type encoding, int max_level,
-    std::vector<int16_t>& input_levels, std::vector<uint8_t>& bytes) {
+                          std::vector<int16_t>& input_levels,
+                          std::vector<uint8_t>& bytes) {
   LevelDecoder decoder;
   int levels_count = 0;
   std::vector<int16_t> output_levels;
@@ -590,7 +594,8 @@ void VerifyDecodingLevels(Encoding::type encoding, int max_level,
 }
 
 void VerifyDecodingMultipleSetData(Encoding::type encoding, int max_level,
-    std::vector<int16_t>& input_levels, std::vector<std::vector<uint8_t>>& bytes) {
+                                   std::vector<int16_t>& input_levels,
+                                   std::vector<std::vector<uint8_t>>& bytes) {
   LevelDecoder decoder;
   int levels_count = 0;
   std::vector<int16_t> output_levels;
@@ -634,7 +639,7 @@ TEST(TestLevels, TestLevelsDecodeMultipleBitWidth) {
       // Generate levels
       GenerateLevels(min_repeat_factor, max_repeat_factor, max_level, input_levels);
       EncodeLevels(encoding, max_level, static_cast<int>(input_levels.size()),
-          input_levels.data(), bytes);
+                   input_levels.data(), bytes);
       VerifyDecodingLevels(encoding, max_level, input_levels, bytes);
       input_levels.clear();
     }
@@ -662,7 +667,7 @@ TEST(TestLevels, TestLevelsDecodeMultipleSetData) {
     for (int rf = 0; rf < setdata_factor; rf++) {
       int offset = rf * split_level_size;
       EncodeLevels(encoding, max_level, split_level_size,
-          reinterpret_cast<int16_t*>(input_levels.data()) + offset, bytes[rf]);
+                   reinterpret_cast<int16_t*>(input_levels.data()) + offset, bytes[rf]);
     }
     VerifyDecodingMultipleSetData(encoding, max_level, input_levels, bytes);
   }
@@ -685,8 +690,8 @@ TEST(TestLevelEncoder, MinimumBufferSize) {
       LevelEncoder::MaxBufferSize(Encoding::RLE, 1, kNumToEncode));
 
   LevelEncoder encoder;
-  encoder.Init(
-      Encoding::RLE, 1, kNumToEncode, output.data(), static_cast<int>(output.size()));
+  encoder.Init(Encoding::RLE, 1, kNumToEncode, output.data(),
+               static_cast<int>(output.size()));
   int encode_count = encoder.Encode(kNumToEncode, levels.data());
 
   ASSERT_EQ(kNumToEncode, encode_count);
@@ -718,7 +723,7 @@ TEST(TestLevelEncoder, MinimumBufferSize2) {
 
     LevelEncoder encoder;
     encoder.Init(Encoding::RLE, bit_width, kNumToEncode, output.data(),
-        static_cast<int>(output.size()));
+                 static_cast<int>(output.size()));
     int encode_count = encoder.Encode(kNumToEncode, levels.data());
 
     ASSERT_EQ(kNumToEncode, encode_count);

--- a/src/parquet/column_writer.h
+++ b/src/parquet/column_writer.h
@@ -44,12 +44,12 @@ class PARQUET_EXPORT LevelEncoder {
   LevelEncoder();
   ~LevelEncoder();
 
-  static int MaxBufferSize(
-      Encoding::type encoding, int16_t max_level, int num_buffered_values);
+  static int MaxBufferSize(Encoding::type encoding, int16_t max_level,
+                           int num_buffered_values);
 
   // Initialize the LevelEncoder.
   void Init(Encoding::type encoding, int16_t max_level, int num_buffered_values,
-      uint8_t* data, int data_size);
+            uint8_t* data, int data_size);
 
   // Encodes a batch of levels from an array and returns the number of levels encoded
   int Encode(int batch_size, const int16_t* levels);
@@ -73,12 +73,13 @@ static constexpr int WRITE_BATCH_SIZE = 1000;
 class PARQUET_EXPORT ColumnWriter {
  public:
   ColumnWriter(ColumnChunkMetaDataBuilder*, std::unique_ptr<PageWriter>,
-      int64_t expected_rows, bool has_dictionary, Encoding::type encoding,
-      const WriterProperties* properties);
+               int64_t expected_rows, bool has_dictionary, Encoding::type encoding,
+               const WriterProperties* properties);
 
   static std::shared_ptr<ColumnWriter> Make(ColumnChunkMetaDataBuilder*,
-      std::unique_ptr<PageWriter>, int64_t expected_rows,
-      const WriterProperties* properties);
+                                            std::unique_ptr<PageWriter>,
+                                            int64_t expected_rows,
+                                            const WriterProperties* properties);
 
   Type::type type() const { return descr_->physical_type(); }
 
@@ -126,8 +127,8 @@ class PARQUET_EXPORT ColumnWriter {
   void WriteRepetitionLevels(int64_t num_levels, const int16_t* levels);
 
   // RLE encode the src_buffer into dest_buffer and return the encoded size
-  int64_t RleEncodeLevels(
-      const Buffer& src_buffer, ResizableBuffer* dest_buffer, int16_t max_level);
+  int64_t RleEncodeLevels(const Buffer& src_buffer, ResizableBuffer* dest_buffer,
+                          int16_t max_level);
 
   // Serialize the buffered Data Pages
   void FlushBufferedDataPages();
@@ -194,13 +195,13 @@ class PARQUET_EXPORT TypedColumnWriter : public ColumnWriter {
   typedef typename DType::c_type T;
 
   TypedColumnWriter(ColumnChunkMetaDataBuilder* metadata,
-      std::unique_ptr<PageWriter> pager, int64_t expected_rows, Encoding::type encoding,
-      const WriterProperties* properties);
+                    std::unique_ptr<PageWriter> pager, int64_t expected_rows,
+                    Encoding::type encoding, const WriterProperties* properties);
 
   // Write a batch of repetition levels, definition levels, and values to the
   // column.
   void WriteBatch(int64_t num_values, const int16_t* def_levels,
-      const int16_t* rep_levels, const T* values);
+                  const int16_t* rep_levels, const T* values);
 
   /// Write a batch of repetition levels, definition levels, and values to the
   /// column.
@@ -229,8 +230,8 @@ class PARQUET_EXPORT TypedColumnWriter : public ColumnWriter {
   ///   spacing for nulls on the lowest levels; input has the length
   ///   of the number of rows on the lowest nesting level.
   void WriteBatchSpaced(int64_t num_values, const int16_t* def_levels,
-      const int16_t* rep_levels, const uint8_t* valid_bits, int64_t valid_bits_offset,
-      const T* values);
+                        const int16_t* rep_levels, const uint8_t* valid_bits,
+                        int64_t valid_bits_offset, const T* values);
 
  protected:
   std::shared_ptr<Buffer> GetValuesBuffer() override {
@@ -244,18 +245,19 @@ class PARQUET_EXPORT TypedColumnWriter : public ColumnWriter {
 
  private:
   int64_t WriteMiniBatch(int64_t num_values, const int16_t* def_levels,
-      const int16_t* rep_levels, const T* values);
+                         const int16_t* rep_levels, const T* values);
 
   int64_t WriteMiniBatchSpaced(int64_t num_values, const int16_t* def_levels,
-      const int16_t* rep_levels, const uint8_t* valid_bits, int64_t valid_bits_offset,
-      const T* values, int64_t* num_spaced_written);
+                               const int16_t* rep_levels, const uint8_t* valid_bits,
+                               int64_t valid_bits_offset, const T* values,
+                               int64_t* num_spaced_written);
 
   typedef Encoder<DType> EncoderType;
 
   // Write values to a temporary buffer before they are encoded into pages
   void WriteValues(int64_t num_values, const T* values);
   void WriteValuesSpaced(int64_t num_values, const uint8_t* valid_bits,
-      int64_t valid_bits_offset, const T* values);
+                         int64_t valid_bits_offset, const T* values);
   std::unique_ptr<EncoderType> current_encoder_;
 
   typedef TypedRowGroupStatistics<DType> TypedStats;

--- a/src/parquet/encoding-benchmark.cc
+++ b/src/parquet/encoding-benchmark.cc
@@ -33,8 +33,8 @@ namespace benchmark {
 
 std::shared_ptr<ColumnDescriptor> Int64Schema(Repetition::type repetition) {
   auto node = PrimitiveNode::Make("int64", repetition, Type::INT64);
-  return std::make_shared<ColumnDescriptor>(
-      node, repetition != Repetition::REQUIRED, repetition == Repetition::REPEATED);
+  return std::make_shared<ColumnDescriptor>(node, repetition != Repetition::REQUIRED,
+                                            repetition == Repetition::REPEATED);
 }
 
 static void BM_PlainEncodingBoolean(::benchmark::State& state) {
@@ -99,8 +99,8 @@ static void BM_PlainDecodingInt64(::benchmark::State& state) {
 BENCHMARK(BM_PlainDecodingInt64)->Range(1024, 65536);
 
 template <typename Type>
-static void DecodeDict(
-    std::vector<typename Type::c_type>& values, ::benchmark::State& state) {
+static void DecodeDict(std::vector<typename Type::c_type>& values,
+                       ::benchmark::State& state) {
   typedef typename Type::c_type T;
   int num_values = values.size();
 

--- a/src/parquet/encoding-test.cc
+++ b/src/parquet/encoding-test.cc
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <gtest/gtest.h>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <gtest/gtest.h>
 #include <string>
 #include <vector>
 
@@ -59,8 +59,8 @@ TEST(VectorBooleanTest, TestEncodeDecode) {
   vector<uint8_t> decode_buffer(nbytes);
   const uint8_t* decode_data = &decode_buffer[0];
 
-  decoder.SetData(
-      nvalues, encode_buffer->data(), static_cast<int>(encode_buffer->size()));
+  decoder.SetData(nvalues, encode_buffer->data(),
+                  static_cast<int>(encode_buffer->size()));
   int values_decoded = decoder.Decode(&decode_buffer[0], nvalues);
   ASSERT_EQ(nvalues, values_decoded);
 
@@ -75,8 +75,8 @@ TEST(VectorBooleanTest, TestEncodeDecode) {
 template <typename T>
 void GenerateData(int num_values, T* out, vector<uint8_t>* heap) {
   // seed the prng so failure is deterministic
-  random_numbers(
-      num_values, 0, std::numeric_limits<T>::min(), std::numeric_limits<T>::max(), out);
+  random_numbers(num_values, 0, std::numeric_limits<T>::min(),
+                 std::numeric_limits<T>::max(), out);
 }
 
 template <>
@@ -89,7 +89,7 @@ template <>
 void GenerateData<Int96>(int num_values, Int96* out, vector<uint8_t>* heap) {
   // seed the prng so failure is deterministic
   random_Int96_numbers(num_values, 0, std::numeric_limits<int32_t>::min(),
-      std::numeric_limits<int32_t>::max(), out);
+                       std::numeric_limits<int32_t>::max(), out);
 }
 
 template <>
@@ -135,7 +135,8 @@ std::shared_ptr<ColumnDescriptor> ExampleDescr() {
 template <>
 std::shared_ptr<ColumnDescriptor> ExampleDescr<FLBAType>() {
   auto node = schema::PrimitiveNode::Make("name", Repetition::OPTIONAL,
-      Type::FIXED_LEN_BYTE_ARRAY, LogicalType::DECIMAL, flba_length, 10, 2);
+                                          Type::FIXED_LEN_BYTE_ARRAY,
+                                          LogicalType::DECIMAL, flba_length, 10, 2);
   return std::make_shared<ColumnDescriptor>(node, 0, 0);
 }
 
@@ -220,8 +221,8 @@ class TestPlainEncoding : public TestEncodingBase<Type> {
     encoder.Put(draws_, num_values_);
     encode_buffer_ = encoder.FlushValues();
 
-    decoder.SetData(
-        num_values_, encode_buffer_->data(), static_cast<int>(encode_buffer_->size()));
+    decoder.SetData(num_values_, encode_buffer_->data(),
+                    static_cast<int>(encode_buffer_->size()));
     int values_decoded = decoder.Decode(decode_buf_, num_values_);
     ASSERT_EQ(num_values_, values_decoded);
     VerifyResults<T>(decode_buf_, draws_, num_values_);
@@ -233,15 +234,13 @@ class TestPlainEncoding : public TestEncodingBase<Type> {
 
 TYPED_TEST_CASE(TestPlainEncoding, ParquetTypes);
 
-TYPED_TEST(TestPlainEncoding, BasicRoundTrip) {
-  this->Execute(10000, 1);
-}
+TYPED_TEST(TestPlainEncoding, BasicRoundTrip) { this->Execute(10000, 1); }
 
 // ----------------------------------------------------------------------
 // Dictionary encoding tests
 
 typedef ::testing::Types<Int32Type, Int64Type, Int96Type, FloatType, DoubleType,
-    ByteArrayType, FLBAType>
+                         ByteArrayType, FLBAType>
     DictEncodedTypes;
 
 template <typename Type>
@@ -267,7 +266,7 @@ class TestDictionaryEncoding : public TestEncodingBase<Type> {
 
     PlainDecoder<Type> dict_decoder(descr_.get());
     dict_decoder.SetData(encoder.num_entries(), dict_buffer_->data(),
-        static_cast<int>(dict_buffer_->size()));
+                         static_cast<int>(dict_buffer_->size()));
 
     DictionaryDecoder<Type> decoder(descr_.get());
     decoder.SetDict(&dict_decoder);
@@ -296,9 +295,7 @@ class TestDictionaryEncoding : public TestEncodingBase<Type> {
 
 TYPED_TEST_CASE(TestDictionaryEncoding, DictEncodedTypes);
 
-TYPED_TEST(TestDictionaryEncoding, BasicRoundTrip) {
-  this->Execute(2500, 2);
-}
+TYPED_TEST(TestDictionaryEncoding, BasicRoundTrip) { this->Execute(2500, 2); }
 
 TEST(TestDictionaryEncoding, CannotDictDecodeBoolean) {
   PlainDecoder<BooleanType> dict_decoder(nullptr);

--- a/src/parquet/encoding.h
+++ b/src/parquet/encoding.h
@@ -22,8 +22,8 @@
 #include <memory>
 #include <sstream>
 
-#include "arrow/util/bit-util.h"
 #include "arrow/status.h"
+#include "arrow/util/bit-util.h"
 
 #include "parquet/exception.h"
 #include "parquet/schema.h"
@@ -49,13 +49,13 @@ class Encoder {
   virtual std::shared_ptr<Buffer> FlushValues() = 0;
   virtual void Put(const T* src, int num_values) = 0;
   virtual void PutSpaced(const T* src, int num_values, const uint8_t* valid_bits,
-      int64_t valid_bits_offset) {
+                         int64_t valid_bits_offset) {
     PoolBuffer buffer(pool_);
     ::arrow::Status status = buffer.Resize(num_values * sizeof(T));
     if (!status.ok()) {
       std::ostringstream ss;
-      ss << "buffer.Resize failed in Encoder.PutSpaced in " <<
-         __FILE__ << ", on line " << __LINE__;
+      ss << "buffer.Resize failed in Encoder.PutSpaced in " << __FILE__ << ", on line "
+         << __LINE__;
       throw ParquetException(ss.str());
     }
     int32_t num_valid_values = 0;
@@ -73,8 +73,8 @@ class Encoder {
   Encoding::type encoding() const { return encoding_; }
 
  protected:
-  explicit Encoder(
-      const ColumnDescriptor* descr, Encoding::type encoding, ::arrow::MemoryPool* pool)
+  explicit Encoder(const ColumnDescriptor* descr, Encoding::type encoding,
+                   ::arrow::MemoryPool* pool)
       : descr_(descr), encoding_(encoding), pool_(pool) {}
 
   // For accessing type-specific metadata, like FIXED_LEN_BYTE_ARRAY
@@ -106,7 +106,7 @@ class Decoder {
   // num_values is the size of the def_levels and buffer arrays including the number of
   // null values.
   virtual int DecodeSpaced(T* buffer, int num_values, int null_count,
-      const uint8_t* valid_bits, int64_t valid_bits_offset) {
+                           const uint8_t* valid_bits, int64_t valid_bits_offset) {
     int values_to_read = num_values - null_count;
     int values_read = Decode(buffer, values_to_read);
     if (values_read != values_to_read) {

--- a/src/parquet/exception.cc
+++ b/src/parquet/exception.cc
@@ -33,9 +33,7 @@ void ParquetException::NYI(const std::string& msg) {
   throw ParquetException(ss.str());
 }
 
-void ParquetException::Throw(const std::string& msg) {
-  throw ParquetException(msg);
-}
+void ParquetException::Throw(const std::string& msg) { throw ParquetException(msg); }
 
 ParquetException::ParquetException(const char* msg) : msg_(msg) {}
 
@@ -45,8 +43,6 @@ ParquetException::ParquetException(const char* msg, std::exception& e) : msg_(ms
 
 ParquetException::~ParquetException() throw() {}
 
-const char* ParquetException::what() const throw() {
-  return msg_.c_str();
-}
+const char* ParquetException::what() const throw() { return msg_.c_str(); }
 
 }  // namespace parquet

--- a/src/parquet/file/file-deserialize-test.cc
+++ b/src/parquet/file/file-deserialize-test.cc
@@ -37,10 +37,12 @@
 
 namespace parquet {
 
-#define ASSERT_OK(expr)                      \
-  do {                                       \
-    ::arrow::Status s = (expr);              \
-    if (!s.ok()) { FAIL() << s.ToString(); } \
+#define ASSERT_OK(expr)         \
+  do {                          \
+    ::arrow::Status s = (expr); \
+    if (!s.ok()) {              \
+      FAIL() << s.ToString();   \
+    }                           \
   } while (0)
 
 using ::arrow::io::BufferReader;
@@ -66,8 +68,8 @@ class TestPageSerde : public ::testing::Test {
     ResetStream();
   }
 
-  void InitSerializedPageReader(
-      int64_t num_rows, Compression::type codec = Compression::UNCOMPRESSED) {
+  void InitSerializedPageReader(int64_t num_rows,
+                                Compression::type codec = Compression::UNCOMPRESSED) {
     EndStream();
     std::unique_ptr<InputStream> stream;
     stream.reset(new InMemoryInputStream(out_buffer_));
@@ -75,7 +77,7 @@ class TestPageSerde : public ::testing::Test {
   }
 
   void WriteDataPageHeader(int max_serialized_len = 1024, int32_t uncompressed_size = 0,
-      int32_t compressed_size = 0) {
+                           int32_t compressed_size = 0) {
     // Simplifying writing serialized data page headers which may or may not
     // have meaningful data associated with them
 
@@ -176,8 +178,8 @@ TEST_F(TestPageSerde, TestFailLargePageHeaders) {
 }
 
 TEST_F(TestPageSerde, Compression) {
-  Compression::type codec_types[3] = {
-      Compression::GZIP, Compression::SNAPPY, Compression::BROTLI};
+  Compression::type codec_types[3] = {Compression::GZIP, Compression::SNAPPY,
+                                      Compression::BROTLI};
 
   const int32_t num_rows = 32;  // dummy value
   data_page_header_.num_values = num_rows;
@@ -203,8 +205,8 @@ TEST_F(TestPageSerde, Compression) {
       buffer.resize(max_compressed_size);
 
       int64_t actual_size;
-      ASSERT_OK(codec->Compress(
-          data_size, data, max_compressed_size, &buffer[0], &actual_size));
+      ASSERT_OK(codec->Compress(data_size, data, max_compressed_size, &buffer[0],
+                                &actual_size));
 
       WriteDataPageHeader(1024, data_size, static_cast<int32_t>(actual_size));
       out_stream_->Write(buffer.data(), actual_size);
@@ -246,8 +248,8 @@ class TestParquetFileReader : public ::testing::Test {
     auto reader = std::make_shared<BufferReader>(buffer);
     auto wrapper = std::unique_ptr<ArrowInputFile>(new ArrowInputFile(reader));
 
-    ASSERT_THROW(
-        reader_->Open(SerializedFile::Open(std::move(wrapper))), ParquetException);
+    ASSERT_THROW(reader_->Open(SerializedFile::Open(std::move(wrapper))),
+                 ParquetException);
   }
 
  protected:
@@ -257,22 +259,22 @@ class TestParquetFileReader : public ::testing::Test {
 TEST_F(TestParquetFileReader, InvalidHeader) {
   const char* bad_header = "PAR2";
 
-  auto buffer = std::make_shared<Buffer>(
-      reinterpret_cast<const uint8_t*>(bad_header), strlen(bad_header));
+  auto buffer = std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(bad_header),
+                                         strlen(bad_header));
   AssertInvalidFileThrows(buffer);
 }
 
 TEST_F(TestParquetFileReader, InvalidFooter) {
   // File is smaller than FOOTER_SIZE
   const char* bad_file = "PAR1PAR";
-  auto buffer = std::make_shared<Buffer>(
-      reinterpret_cast<const uint8_t*>(bad_file), strlen(bad_file));
+  auto buffer = std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(bad_file),
+                                         strlen(bad_file));
   AssertInvalidFileThrows(buffer);
 
   // Magic number incorrect
   const char* bad_file2 = "PAR1PAR2";
-  buffer = std::make_shared<Buffer>(
-      reinterpret_cast<const uint8_t*>(bad_file2), strlen(bad_file2));
+  buffer = std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(bad_file2),
+                                    strlen(bad_file2));
   AssertInvalidFileThrows(buffer);
 }
 

--- a/src/parquet/file/file-metadata-test.cc
+++ b/src/parquet/file/file-metadata-test.cc
@@ -15,11 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <gtest/gtest.h>
 #include "parquet/file/metadata.h"
 #include "parquet/schema.h"
 #include "parquet/statistics.h"
 #include "parquet/types.h"
-#include <gtest/gtest.h>
 
 namespace parquet {
 

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -65,8 +65,8 @@ class TestSerialize : public PrimitiveTypedTest<TestType> {
     for (int i = 0; i < num_columns_; ++i) {
       auto column_writer =
           static_cast<TypedColumnWriter<TestType>*>(row_group_writer->NextColumn());
-      column_writer->WriteBatch(
-          100, this->def_levels_.data(), nullptr, this->values_ptr_);
+      column_writer->WriteBatch(100, this->def_levels_.data(), nullptr,
+                                this->values_ptr_);
       column_writer->Close();
     }
 
@@ -96,7 +96,7 @@ class TestSerialize : public PrimitiveTypedTest<TestType> {
           std::static_pointer_cast<TypedColumnReader<TestType>>(rg_reader->Column(i));
       this->SetupValuesOut(100);
       col_reader->ReadBatch(100, def_levels_out.data(), rep_levels_out.data(),
-          this->values_out_ptr_, &values_read);
+                            this->values_out_ptr_, &values_read);
       this->SyncValuesOut();
       ASSERT_EQ(100, values_read);
       ASSERT_EQ(this->values_, this->values_out_);
@@ -106,7 +106,7 @@ class TestSerialize : public PrimitiveTypedTest<TestType> {
 };
 
 typedef ::testing::Types<Int32Type, Int64Type, Int96Type, FloatType, DoubleType,
-    BooleanType, ByteArrayType, FLBAType>
+                         BooleanType, ByteArrayType, FLBAType>
     TestTypes;
 
 TYPED_TEST_CASE(TestSerialize, TestTypes);
@@ -123,9 +123,7 @@ TYPED_TEST(TestSerialize, SmallFileBrotli) {
   this->FileSerializeTest(Compression::BROTLI);
 }
 
-TYPED_TEST(TestSerialize, SmallFileGzip) {
-  this->FileSerializeTest(Compression::GZIP);
-}
+TYPED_TEST(TestSerialize, SmallFileGzip) { this->FileSerializeTest(Compression::GZIP); }
 
 }  // namespace test
 

--- a/src/parquet/file/metadata.cc
+++ b/src/parquet/file/metadata.cc
@@ -91,8 +91,9 @@ SortOrder get_sort_order(LogicalType::type converted, Type::type primitive) {
 template <typename DType>
 static std::shared_ptr<RowGroupStatistics> MakeTypedColumnStats(
     const format::ColumnMetaData& metadata, const ColumnDescriptor* descr) {
-  return std::make_shared<TypedRowGroupStatistics<DType>>(descr, metadata.statistics.min,
-      metadata.statistics.max, metadata.num_values - metadata.statistics.null_count,
+  return std::make_shared<TypedRowGroupStatistics<DType>>(
+      descr, metadata.statistics.min, metadata.statistics.max,
+      metadata.num_values - metadata.statistics.null_count,
       metadata.statistics.null_count, metadata.statistics.distinct_count,
       metadata.statistics.__isset.max || metadata.statistics.__isset.min);
 }
@@ -125,7 +126,8 @@ std::shared_ptr<RowGroupStatistics> MakeColumnStats(
 class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
  public:
   explicit ColumnChunkMetaDataImpl(const format::ColumnChunk* column,
-      const ColumnDescriptor* descr, const ApplicationVersion* writer_version)
+                                   const ColumnDescriptor* descr,
+                                   const ApplicationVersion* writer_version)
       : column_(column), descr_(descr), writer_version_(writer_version) {
     const format::ColumnMetaData& meta_data = column->meta_data;
     for (auto encoding : meta_data.encodings) {
@@ -205,36 +207,30 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
   const ApplicationVersion* writer_version_;
 };
 
-std::unique_ptr<ColumnChunkMetaData> ColumnChunkMetaData::Make(const uint8_t* metadata,
-    const ColumnDescriptor* descr, const ApplicationVersion* writer_version) {
+std::unique_ptr<ColumnChunkMetaData> ColumnChunkMetaData::Make(
+    const uint8_t* metadata, const ColumnDescriptor* descr,
+    const ApplicationVersion* writer_version) {
   return std::unique_ptr<ColumnChunkMetaData>(
       new ColumnChunkMetaData(metadata, descr, writer_version));
 }
 
 ColumnChunkMetaData::ColumnChunkMetaData(const uint8_t* metadata,
-    const ColumnDescriptor* descr, const ApplicationVersion* writer_version)
+                                         const ColumnDescriptor* descr,
+                                         const ApplicationVersion* writer_version)
     : impl_{std::unique_ptr<ColumnChunkMetaDataImpl>(new ColumnChunkMetaDataImpl(
           reinterpret_cast<const format::ColumnChunk*>(metadata), descr,
           writer_version))} {}
 ColumnChunkMetaData::~ColumnChunkMetaData() {}
 
 // column chunk
-int64_t ColumnChunkMetaData::file_offset() const {
-  return impl_->file_offset();
-}
+int64_t ColumnChunkMetaData::file_offset() const { return impl_->file_offset(); }
 
-const std::string& ColumnChunkMetaData::file_path() const {
-  return impl_->file_path();
-}
+const std::string& ColumnChunkMetaData::file_path() const { return impl_->file_path(); }
 
 // column metadata
-Type::type ColumnChunkMetaData::type() const {
-  return impl_->type();
-}
+Type::type ColumnChunkMetaData::type() const { return impl_->type(); }
 
-int64_t ColumnChunkMetaData::num_values() const {
-  return impl_->num_values();
-}
+int64_t ColumnChunkMetaData::num_values() const { return impl_->num_values(); }
 
 std::shared_ptr<schema::ColumnPath> ColumnChunkMetaData::path_in_schema() const {
   return impl_->path_in_schema();
@@ -244,9 +240,7 @@ std::shared_ptr<RowGroupStatistics> ColumnChunkMetaData::statistics() const {
   return impl_->statistics();
 }
 
-bool ColumnChunkMetaData::is_stats_set() const {
-  return impl_->is_stats_set();
-}
+bool ColumnChunkMetaData::is_stats_set() const { return impl_->is_stats_set(); }
 
 int64_t ColumnChunkMetaData::has_dictionary_page() const {
   return impl_->has_dictionary_page();
@@ -284,7 +278,8 @@ int64_t ColumnChunkMetaData::total_compressed_size() const {
 class RowGroupMetaData::RowGroupMetaDataImpl {
  public:
   explicit RowGroupMetaDataImpl(const format::RowGroup* row_group,
-      const SchemaDescriptor* schema, const ApplicationVersion* writer_version)
+                                const SchemaDescriptor* schema,
+                                const ApplicationVersion* writer_version)
       : row_group_(row_group), schema_(schema), writer_version_(writer_version) {}
   ~RowGroupMetaDataImpl() {}
 
@@ -314,34 +309,28 @@ class RowGroupMetaData::RowGroupMetaDataImpl {
   const ApplicationVersion* writer_version_;
 };
 
-std::unique_ptr<RowGroupMetaData> RowGroupMetaData::Make(const uint8_t* metadata,
-    const SchemaDescriptor* schema, const ApplicationVersion* writer_version) {
+std::unique_ptr<RowGroupMetaData> RowGroupMetaData::Make(
+    const uint8_t* metadata, const SchemaDescriptor* schema,
+    const ApplicationVersion* writer_version) {
   return std::unique_ptr<RowGroupMetaData>(
       new RowGroupMetaData(metadata, schema, writer_version));
 }
 
 RowGroupMetaData::RowGroupMetaData(const uint8_t* metadata,
-    const SchemaDescriptor* schema, const ApplicationVersion* writer_version)
+                                   const SchemaDescriptor* schema,
+                                   const ApplicationVersion* writer_version)
     : impl_{std::unique_ptr<RowGroupMetaDataImpl>(new RowGroupMetaDataImpl(
           reinterpret_cast<const format::RowGroup*>(metadata), schema, writer_version))} {
 }
 RowGroupMetaData::~RowGroupMetaData() {}
 
-int RowGroupMetaData::num_columns() const {
-  return impl_->num_columns();
-}
+int RowGroupMetaData::num_columns() const { return impl_->num_columns(); }
 
-int64_t RowGroupMetaData::num_rows() const {
-  return impl_->num_rows();
-}
+int64_t RowGroupMetaData::num_rows() const { return impl_->num_rows(); }
 
-int64_t RowGroupMetaData::total_byte_size() const {
-  return impl_->total_byte_size();
-}
+int64_t RowGroupMetaData::total_byte_size() const { return impl_->total_byte_size(); }
 
-const SchemaDescriptor* RowGroupMetaData::schema() const {
-  return impl_->schema();
-}
+const SchemaDescriptor* RowGroupMetaData::schema() const { return impl_->schema(); }
 
 std::unique_ptr<ColumnChunkMetaData> RowGroupMetaData::ColumnChunk(int i) const {
   return impl_->ColumnChunk(i);
@@ -408,8 +397,8 @@ class FileMetaData::FileMetaDataImpl {
   uint32_t metadata_len_;
   std::unique_ptr<format::FileMetaData> metadata_;
   void InitSchema() {
-    schema::FlatSchemaConverter converter(
-        &metadata_->schema[0], static_cast<int>(metadata_->schema.size()));
+    schema::FlatSchemaConverter converter(&metadata_->schema[0],
+                                          static_cast<int>(metadata_->schema.size()));
     schema_.Init(converter.Convert());
   }
   SchemaDescriptor schema_;
@@ -429,8 +418,8 @@ class FileMetaData::FileMetaDataImpl {
   std::shared_ptr<const KeyValueMetadata> key_value_metadata_;
 };
 
-std::shared_ptr<FileMetaData> FileMetaData::Make(
-    const uint8_t* metadata, uint32_t* metadata_len) {
+std::shared_ptr<FileMetaData> FileMetaData::Make(const uint8_t* metadata,
+                                                 uint32_t* metadata_len) {
   // This FileMetaData ctor is private, not compatible with std::make_shared
   return std::shared_ptr<FileMetaData>(new FileMetaData(metadata, metadata_len));
 }
@@ -448,21 +437,13 @@ std::unique_ptr<RowGroupMetaData> FileMetaData::RowGroup(int i) const {
   return impl_->RowGroup(i);
 }
 
-uint32_t FileMetaData::size() const {
-  return impl_->size();
-}
+uint32_t FileMetaData::size() const { return impl_->size(); }
 
-int FileMetaData::num_columns() const {
-  return impl_->num_columns();
-}
+int FileMetaData::num_columns() const { return impl_->num_columns(); }
 
-int64_t FileMetaData::num_rows() const {
-  return impl_->num_rows();
-}
+int64_t FileMetaData::num_rows() const { return impl_->num_rows(); }
 
-int FileMetaData::num_row_groups() const {
-  return impl_->num_row_groups();
-}
+int FileMetaData::num_row_groups() const { return impl_->num_row_groups(); }
 
 ParquetVersion::type FileMetaData::version() const {
   switch (impl_->version()) {
@@ -481,25 +462,17 @@ const ApplicationVersion& FileMetaData::writer_version() const {
   return impl_->writer_version();
 }
 
-const std::string& FileMetaData::created_by() const {
-  return impl_->created_by();
-}
+const std::string& FileMetaData::created_by() const { return impl_->created_by(); }
 
-int FileMetaData::num_schema_elements() const {
-  return impl_->num_schema_elements();
-}
+int FileMetaData::num_schema_elements() const { return impl_->num_schema_elements(); }
 
-const SchemaDescriptor* FileMetaData::schema() const {
-  return impl_->schema();
-}
+const SchemaDescriptor* FileMetaData::schema() const { return impl_->schema(); }
 
 std::shared_ptr<const KeyValueMetadata> FileMetaData::key_value_metadata() const {
   return impl_->key_value_metadata();
 }
 
-void FileMetaData::WriteTo(OutputStream* dst) {
-  return impl_->WriteTo(dst);
-}
+void FileMetaData::WriteTo(OutputStream* dst) { return impl_->WriteTo(dst); }
 
 ApplicationVersion::ApplicationVersion(const std::string& created_by) {
   boost::regex app_regex{ApplicationVersion::APPLICATION_FORMAT};
@@ -509,7 +482,7 @@ ApplicationVersion::ApplicationVersion(const std::string& created_by) {
 
   std::string created_by_lower = created_by;
   std::transform(created_by_lower.begin(), created_by_lower.end(),
-      created_by_lower.begin(), ::tolower);
+                 created_by_lower.begin(), ::tolower);
 
   bool app_success = boost::regex_match(created_by_lower, app_matches, app_regex);
   bool ver_success = false;
@@ -572,10 +545,14 @@ bool ApplicationVersion::HasCorrectStatistics(Type::type col_type) const {
 
   // created_by is not populated, which could have been caused by
   // parquet-mr during the same time as PARQUET-251, see PARQUET-297
-  if (application_ == "unknown") { return true; }
+  if (application_ == "unknown") {
+    return true;
+  }
 
   // PARQUET-251
-  if (VersionLt(PARQUET_251_FIXED_VERSION)) { return false; }
+  if (VersionLt(PARQUET_251_FIXED_VERSION)) {
+    return false;
+  }
 
   return true;
 }
@@ -585,7 +562,8 @@ bool ApplicationVersion::HasCorrectStatistics(Type::type col_type) const {
 class ColumnChunkMetaDataBuilder::ColumnChunkMetaDataBuilderImpl {
  public:
   explicit ColumnChunkMetaDataBuilderImpl(const std::shared_ptr<WriterProperties>& props,
-      const ColumnDescriptor* column, uint8_t* contents)
+                                          const ColumnDescriptor* column,
+                                          uint8_t* contents)
       : properties_(props), column_(column) {
     column_chunk_ = reinterpret_cast<format::ColumnChunk*>(contents);
     column_chunk_->meta_data.__set_type(ToThrift(column->physical_type()));
@@ -614,8 +592,9 @@ class ColumnChunkMetaDataBuilder::ColumnChunkMetaDataBuilderImpl {
   }
 
   void Finish(int64_t num_values, int64_t dictionary_page_offset,
-      int64_t index_page_offset, int64_t data_page_offset, int64_t compressed_size,
-      int64_t uncompressed_size, bool has_dictionary, bool dictionary_fallback) {
+              int64_t index_page_offset, int64_t data_page_offset,
+              int64_t compressed_size, int64_t uncompressed_size, bool has_dictionary,
+              bool dictionary_fallback) {
     if (dictionary_page_offset > 0) {
       column_chunk_->meta_data.__set_dictionary_page_offset(dictionary_page_offset);
       column_chunk_->__set_file_offset(dictionary_page_offset + compressed_size);
@@ -642,7 +621,9 @@ class ColumnChunkMetaDataBuilder::ColumnChunkMetaDataBuilderImpl {
     thrift_encodings.push_back(ToThrift(Encoding::RLE));
     // Only PLAIN encoding is supported for fallback in V1
     // TODO(majetideepak): Use user specified encoding for V2
-    if (dictionary_fallback) { thrift_encodings.push_back(ToThrift(Encoding::PLAIN)); }
+    if (dictionary_fallback) {
+      thrift_encodings.push_back(ToThrift(Encoding::PLAIN));
+    }
     column_chunk_->meta_data.__set_encodings(thrift_encodings);
   }
 
@@ -678,16 +659,16 @@ void ColumnChunkMetaDataBuilder::set_file_path(const std::string& path) {
 }
 
 void ColumnChunkMetaDataBuilder::Finish(int64_t num_values,
-    int64_t dictionary_page_offset, int64_t index_page_offset, int64_t data_page_offset,
-    int64_t compressed_size, int64_t uncompressed_size, bool has_dictionary,
-    bool dictionary_fallback) {
+                                        int64_t dictionary_page_offset,
+                                        int64_t index_page_offset,
+                                        int64_t data_page_offset, int64_t compressed_size,
+                                        int64_t uncompressed_size, bool has_dictionary,
+                                        bool dictionary_fallback) {
   impl_->Finish(num_values, dictionary_page_offset, index_page_offset, data_page_offset,
-      compressed_size, uncompressed_size, has_dictionary, dictionary_fallback);
+                compressed_size, uncompressed_size, has_dictionary, dictionary_fallback);
 }
 
-void ColumnChunkMetaDataBuilder::WriteTo(OutputStream* sink) {
-  impl_->WriteTo(sink);
-}
+void ColumnChunkMetaDataBuilder::WriteTo(OutputStream* sink) { impl_->WriteTo(sink); }
 
 const ColumnDescriptor* ColumnChunkMetaDataBuilder::descr() const {
   return impl_->descr();
@@ -700,8 +681,8 @@ void ColumnChunkMetaDataBuilder::SetStatistics(const EncodedStatistics& result) 
 class RowGroupMetaDataBuilder::RowGroupMetaDataBuilderImpl {
  public:
   explicit RowGroupMetaDataBuilderImpl(int64_t num_rows,
-      const std::shared_ptr<WriterProperties>& props, const SchemaDescriptor* schema,
-      uint8_t* contents)
+                                       const std::shared_ptr<WriterProperties>& props,
+                                       const SchemaDescriptor* schema, uint8_t* contents)
       : properties_(props), schema_(schema), current_column_(0) {
     row_group_ = reinterpret_cast<format::RowGroup*>(contents);
     InitializeColumns(schema->num_columns());
@@ -717,7 +698,8 @@ class RowGroupMetaDataBuilder::RowGroupMetaDataBuilderImpl {
       throw ParquetException(ss.str());
     }
     auto column = schema_->Column(current_column_);
-    auto column_builder = ColumnChunkMetaDataBuilder::Make(properties_, column,
+    auto column_builder = ColumnChunkMetaDataBuilder::Make(
+        properties_, column,
         reinterpret_cast<uint8_t*>(&row_group_->columns[current_column_++]));
     auto column_builder_ptr = column_builder.get();
     column_builders_.push_back(std::move(column_builder));
@@ -761,16 +743,16 @@ class RowGroupMetaDataBuilder::RowGroupMetaDataBuilderImpl {
   int current_column_;
 };
 
-std::unique_ptr<RowGroupMetaDataBuilder> RowGroupMetaDataBuilder::Make(int64_t num_rows,
-    const std::shared_ptr<WriterProperties>& props, const SchemaDescriptor* schema_,
-    uint8_t* contents) {
+std::unique_ptr<RowGroupMetaDataBuilder> RowGroupMetaDataBuilder::Make(
+    int64_t num_rows, const std::shared_ptr<WriterProperties>& props,
+    const SchemaDescriptor* schema_, uint8_t* contents) {
   return std::unique_ptr<RowGroupMetaDataBuilder>(
       new RowGroupMetaDataBuilder(num_rows, props, schema_, contents));
 }
 
-RowGroupMetaDataBuilder::RowGroupMetaDataBuilder(int64_t num_rows,
-    const std::shared_ptr<WriterProperties>& props, const SchemaDescriptor* schema_,
-    uint8_t* contents)
+RowGroupMetaDataBuilder::RowGroupMetaDataBuilder(
+    int64_t num_rows, const std::shared_ptr<WriterProperties>& props,
+    const SchemaDescriptor* schema_, uint8_t* contents)
     : impl_{std::unique_ptr<RowGroupMetaDataBuilderImpl>(
           new RowGroupMetaDataBuilderImpl(num_rows, props, schema_, contents))} {}
 
@@ -780,13 +762,9 @@ ColumnChunkMetaDataBuilder* RowGroupMetaDataBuilder::NextColumnChunk() {
   return impl_->NextColumnChunk();
 }
 
-int RowGroupMetaDataBuilder::current_column() const {
-  return impl_->current_column();
-}
+int RowGroupMetaDataBuilder::current_column() const { return impl_->current_column(); }
 
-int RowGroupMetaDataBuilder::num_columns() {
-  return impl_->num_columns();
-}
+int RowGroupMetaDataBuilder::num_columns() { return impl_->num_columns(); }
 
 void RowGroupMetaDataBuilder::Finish(int64_t total_bytes_written) {
   impl_->Finish(total_bytes_written);
@@ -796,8 +774,8 @@ void RowGroupMetaDataBuilder::Finish(int64_t total_bytes_written) {
 // TODO(PARQUET-595) Support key_value_metadata
 class FileMetaDataBuilder::FileMetaDataBuilderImpl {
  public:
-  explicit FileMetaDataBuilderImpl(const SchemaDescriptor* schema,
-      const std::shared_ptr<WriterProperties>& props,
+  explicit FileMetaDataBuilderImpl(
+      const SchemaDescriptor* schema, const std::shared_ptr<WriterProperties>& props,
       const std::shared_ptr<const KeyValueMetadata>& key_value_metadata)
       : properties_(props), schema_(schema), key_value_metadata_(key_value_metadata) {
     metadata_.reset(new format::FileMetaData());
@@ -879,8 +857,8 @@ std::unique_ptr<FileMetaDataBuilder> FileMetaDataBuilder::Make(
       new FileMetaDataBuilder(schema, props, key_value_metadata));
 }
 
-FileMetaDataBuilder::FileMetaDataBuilder(const SchemaDescriptor* schema,
-    const std::shared_ptr<WriterProperties>& props,
+FileMetaDataBuilder::FileMetaDataBuilder(
+    const SchemaDescriptor* schema, const std::shared_ptr<WriterProperties>& props,
     const std::shared_ptr<const KeyValueMetadata>& key_value_metadata)
     : impl_{std::unique_ptr<FileMetaDataBuilderImpl>(
           new FileMetaDataBuilderImpl(schema, props, key_value_metadata))} {}
@@ -891,8 +869,6 @@ RowGroupMetaDataBuilder* FileMetaDataBuilder::AppendRowGroup(int64_t num_rows) {
   return impl_->AppendRowGroup(num_rows);
 }
 
-std::unique_ptr<FileMetaData> FileMetaDataBuilder::Finish() {
-  return impl_->Finish();
-}
+std::unique_ptr<FileMetaData> FileMetaDataBuilder::Finish() { return impl_->Finish(); }
 
 }  // namespace parquet

--- a/src/parquet/file/metadata.h
+++ b/src/parquet/file/metadata.h
@@ -98,8 +98,9 @@ class ApplicationVersion {
 class PARQUET_EXPORT ColumnChunkMetaData {
  public:
   // API convenience to get a MetaData accessor
-  static std::unique_ptr<ColumnChunkMetaData> Make(const uint8_t* metadata,
-      const ColumnDescriptor* descr, const ApplicationVersion* writer_version = NULL);
+  static std::unique_ptr<ColumnChunkMetaData> Make(
+      const uint8_t* metadata, const ColumnDescriptor* descr,
+      const ApplicationVersion* writer_version = NULL);
 
   ~ColumnChunkMetaData();
 
@@ -124,7 +125,7 @@ class PARQUET_EXPORT ColumnChunkMetaData {
 
  private:
   explicit ColumnChunkMetaData(const uint8_t* metadata, const ColumnDescriptor* descr,
-      const ApplicationVersion* writer_version = NULL);
+                               const ApplicationVersion* writer_version = NULL);
   // PIMPL Idiom
   class ColumnChunkMetaDataImpl;
   std::unique_ptr<ColumnChunkMetaDataImpl> impl_;
@@ -133,8 +134,9 @@ class PARQUET_EXPORT ColumnChunkMetaData {
 class PARQUET_EXPORT RowGroupMetaData {
  public:
   // API convenience to get a MetaData accessor
-  static std::unique_ptr<RowGroupMetaData> Make(const uint8_t* metadata,
-      const SchemaDescriptor* schema, const ApplicationVersion* writer_version = NULL);
+  static std::unique_ptr<RowGroupMetaData> Make(
+      const uint8_t* metadata, const SchemaDescriptor* schema,
+      const ApplicationVersion* writer_version = NULL);
 
   ~RowGroupMetaData();
 
@@ -148,7 +150,7 @@ class PARQUET_EXPORT RowGroupMetaData {
 
  private:
   explicit RowGroupMetaData(const uint8_t* metadata, const SchemaDescriptor* schema,
-      const ApplicationVersion* writer_version = NULL);
+                            const ApplicationVersion* writer_version = NULL);
   // PIMPL Idiom
   class RowGroupMetaDataImpl;
   std::unique_ptr<RowGroupMetaDataImpl> impl_;
@@ -159,8 +161,8 @@ class FileMetaDataBuilder;
 class PARQUET_EXPORT FileMetaData {
  public:
   // API convenience to get a MetaData accessor
-  static std::shared_ptr<FileMetaData> Make(
-      const uint8_t* serialized_metadata, uint32_t* metadata_len);
+  static std::shared_ptr<FileMetaData> Make(const uint8_t* serialized_metadata,
+                                            uint32_t* metadata_len);
 
   ~FileMetaData();
 
@@ -212,15 +214,16 @@ class PARQUET_EXPORT ColumnChunkMetaDataBuilder {
   const ColumnDescriptor* descr() const;
   // commit the metadata
   void Finish(int64_t num_values, int64_t dictonary_page_offset,
-      int64_t index_page_offset, int64_t data_page_offset, int64_t compressed_size,
-      int64_t uncompressed_size, bool has_dictionary, bool dictionary_fallback);
+              int64_t index_page_offset, int64_t data_page_offset,
+              int64_t compressed_size, int64_t uncompressed_size, bool has_dictionary,
+              bool dictionary_fallback);
 
   // For writing metadata at end of column chunk
   void WriteTo(OutputStream* sink);
 
  private:
   explicit ColumnChunkMetaDataBuilder(const std::shared_ptr<WriterProperties>& props,
-      const ColumnDescriptor* column, uint8_t* contents);
+                                      const ColumnDescriptor* column, uint8_t* contents);
   // PIMPL Idiom
   class ColumnChunkMetaDataBuilderImpl;
   std::unique_ptr<ColumnChunkMetaDataBuilderImpl> impl_;
@@ -229,9 +232,9 @@ class PARQUET_EXPORT ColumnChunkMetaDataBuilder {
 class PARQUET_EXPORT RowGroupMetaDataBuilder {
  public:
   // API convenience to get a MetaData reader
-  static std::unique_ptr<RowGroupMetaDataBuilder> Make(int64_t num_rows,
-      const std::shared_ptr<WriterProperties>& props, const SchemaDescriptor* schema_,
-      uint8_t* contents);
+  static std::unique_ptr<RowGroupMetaDataBuilder> Make(
+      int64_t num_rows, const std::shared_ptr<WriterProperties>& props,
+      const SchemaDescriptor* schema_, uint8_t* contents);
 
   ~RowGroupMetaDataBuilder();
 
@@ -244,8 +247,8 @@ class PARQUET_EXPORT RowGroupMetaDataBuilder {
 
  private:
   explicit RowGroupMetaDataBuilder(int64_t num_rows,
-      const std::shared_ptr<WriterProperties>& props, const SchemaDescriptor* schema_,
-      uint8_t* contents);
+                                   const std::shared_ptr<WriterProperties>& props,
+                                   const SchemaDescriptor* schema_, uint8_t* contents);
   // PIMPL Idiom
   class RowGroupMetaDataBuilderImpl;
   std::unique_ptr<RowGroupMetaDataBuilderImpl> impl_;
@@ -254,8 +257,8 @@ class PARQUET_EXPORT RowGroupMetaDataBuilder {
 class PARQUET_EXPORT FileMetaDataBuilder {
  public:
   // API convenience to get a MetaData reader
-  static std::unique_ptr<FileMetaDataBuilder> Make(const SchemaDescriptor* schema,
-      const std::shared_ptr<WriterProperties>& props,
+  static std::unique_ptr<FileMetaDataBuilder> Make(
+      const SchemaDescriptor* schema, const std::shared_ptr<WriterProperties>& props,
       const std::shared_ptr<const KeyValueMetadata>& key_value_metadata = nullptr);
 
   ~FileMetaDataBuilder();
@@ -266,8 +269,8 @@ class PARQUET_EXPORT FileMetaDataBuilder {
   std::unique_ptr<FileMetaData> Finish();
 
  private:
-  explicit FileMetaDataBuilder(const SchemaDescriptor* schema,
-      const std::shared_ptr<WriterProperties>& props,
+  explicit FileMetaDataBuilder(
+      const SchemaDescriptor* schema, const std::shared_ptr<WriterProperties>& props,
       const std::shared_ptr<const KeyValueMetadata>& key_value_metadata = nullptr);
   // PIMPL Idiom
   class FileMetaDataBuilderImpl;

--- a/src/parquet/file/printer.cc
+++ b/src/parquet/file/printer.cc
@@ -33,7 +33,7 @@ namespace parquet {
 #define COL_WIDTH "30"
 
 void ParquetFilePrinter::DebugPrint(std::ostream& stream, std::list<int> selected_columns,
-    bool print_values, const char* filename) {
+                                    bool print_values, const char* filename) {
   const FileMetaData* file_metadata = fileReader->metadata().get();
 
   stream << "File Name: " << filename << "\n";
@@ -101,7 +101,9 @@ void ParquetFilePrinter::DebugPrint(std::ostream& stream, std::list<int> selecte
              << std::endl;
     }
 
-    if (!print_values) { continue; }
+    if (!print_values) {
+      continue;
+    }
 
     static constexpr int bufsize = 25;
     char buffer[bufsize];
@@ -117,7 +119,7 @@ void ParquetFilePrinter::DebugPrint(std::ostream& stream, std::list<int> selecte
       std::string fmt = ss.str();
 
       snprintf(buffer, bufsize, fmt.c_str(),
-          file_metadata->schema()->Column(i)->name().c_str());
+               file_metadata->schema()->Column(i)->name().c_str());
       stream << buffer;
 
       // This is OK in this method as long as the RowGroupReader does not get
@@ -140,8 +142,8 @@ void ParquetFilePrinter::DebugPrint(std::ostream& stream, std::list<int> selecte
   }
 }
 
-void ParquetFilePrinter::JSONPrint(
-    std::ostream& stream, std::list<int> selected_columns, const char* filename) {
+void ParquetFilePrinter::JSONPrint(std::ostream& stream, std::list<int> selected_columns,
+                                   const char* filename) {
   const FileMetaData* file_metadata = fileReader->metadata().get();
   stream << "{\n";
   stream << "  \"FileName\": \"" << filename << "\",\n";
@@ -174,7 +176,9 @@ void ParquetFilePrinter::JSONPrint(
            << " \"LogicalType\": \"" << LogicalTypeToString(descr->logical_type())
            << "\" }";
     c++;
-    if (c != static_cast<int>(selected_columns.size())) { stream << ",\n"; }
+    if (c != static_cast<int>(selected_columns.size())) {
+      stream << ",\n";
+    }
   }
 
   stream << "\n  ],\n  \"RowGroups\": [\n";
@@ -223,11 +227,15 @@ void ParquetFilePrinter::JSONPrint(
       // end of a ColumnChunk
       stream << "\" }";
       c1++;
-      if (c1 != static_cast<int>(selected_columns.size())) { stream << ",\n"; }
+      if (c1 != static_cast<int>(selected_columns.size())) {
+        stream << ",\n";
+      }
     }
 
     stream << "\n        ]\n     }";
-    if ((r + 1) != static_cast<int>(file_metadata->num_row_groups())) { stream << ",\n"; }
+    if ((r + 1) != static_cast<int>(file_metadata->num_row_groups())) {
+      stream << ",\n";
+    }
   }
   stream << "\n  ]\n}\n";
 }

--- a/src/parquet/file/printer.h
+++ b/src/parquet/file/printer.h
@@ -38,10 +38,10 @@ class PARQUET_EXPORT ParquetFilePrinter {
   ~ParquetFilePrinter() {}
 
   void DebugPrint(std::ostream& stream, std::list<int> selected_columns,
-      bool print_values = true, const char* fileame = "No Name");
+                  bool print_values = true, const char* fileame = "No Name");
 
   void JSONPrint(std::ostream& stream, std::list<int> selected_columns,
-      const char* filename = "No Name");
+                 const char* filename = "No Name");
 };
 
 }  // namespace parquet

--- a/src/parquet/file/reader-internal.h
+++ b/src/parquet/file/reader-internal.h
@@ -50,8 +50,8 @@ static constexpr uint32_t DEFAULT_PAGE_HEADER_SIZE = 16 * 1024;
 class PARQUET_EXPORT SerializedPageReader : public PageReader {
  public:
   SerializedPageReader(std::unique_ptr<InputStream> stream, int64_t num_rows,
-      Compression::type codec,
-      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+                       Compression::type codec,
+                       ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
 
   virtual ~SerializedPageReader() {}
 
@@ -84,7 +84,7 @@ class PARQUET_EXPORT SerializedPageReader : public PageReader {
 class PARQUET_EXPORT SerializedRowGroup : public RowGroupReader::Contents {
  public:
   SerializedRowGroup(RandomAccessSource* source, FileMetaData* file_metadata,
-      int row_group_number, const ReaderProperties& props);
+                     int row_group_number, const ReaderProperties& props);
 
   virtual const RowGroupMetaData* metadata() const;
 
@@ -118,8 +118,8 @@ class PARQUET_EXPORT SerializedFile : public ParquetFileReader::Contents {
 
  private:
   // This class takes ownership of the provided data source
-  explicit SerializedFile(
-      std::unique_ptr<RandomAccessSource> source, const ReaderProperties& props);
+  explicit SerializedFile(std::unique_ptr<RandomAccessSource> source,
+                          const ReaderProperties& props);
 
   std::unique_ptr<RandomAccessSource> source_;
   std::shared_ptr<FileMetaData> file_metadata_;

--- a/src/parquet/file/reader.cc
+++ b/src/parquet/file/reader.cc
@@ -51,14 +51,13 @@ std::shared_ptr<ColumnReader> RowGroupReader::Column(int i) {
   const ColumnDescriptor* descr = metadata()->schema()->Column(i);
 
   std::unique_ptr<PageReader> page_reader = contents_->GetColumnPageReader(i);
-  return ColumnReader::Make(descr, std::move(page_reader),
+  return ColumnReader::Make(
+      descr, std::move(page_reader),
       const_cast<ReaderProperties*>(contents_->properties())->memory_pool());
 }
 
 // Returns the rowgroup metadata
-const RowGroupMetaData* RowGroupReader::metadata() const {
-  return contents_->metadata();
-}
+const RowGroupMetaData* RowGroupReader::metadata() const { return contents_->metadata(); }
 
 // ----------------------------------------------------------------------
 // ParquetFileReader public API
@@ -67,7 +66,8 @@ ParquetFileReader::ParquetFileReader() {}
 ParquetFileReader::~ParquetFileReader() {
   try {
     Close();
-  } catch (...) {}
+  } catch (...) {
+  }
 }
 
 std::unique_ptr<ParquetFileReader> ParquetFileReader::Open(
@@ -86,8 +86,8 @@ std::unique_ptr<ParquetFileReader> ParquetFileReader::Open(
   return result;
 }
 
-std::unique_ptr<ParquetFileReader> ParquetFileReader::OpenFile(const std::string& path,
-    bool memory_map, const ReaderProperties& props,
+std::unique_ptr<ParquetFileReader> ParquetFileReader::OpenFile(
+    const std::string& path, bool memory_map, const ReaderProperties& props,
     const std::shared_ptr<FileMetaData>& metadata) {
   std::shared_ptr<::arrow::io::ReadableFileInterface> source;
   if (memory_map) {
@@ -110,7 +110,9 @@ void ParquetFileReader::Open(std::unique_ptr<ParquetFileReader::Contents> conten
 }
 
 void ParquetFileReader::Close() {
-  if (contents_) { contents_->Close(); }
+  if (contents_) {
+    contents_->Close();
+  }
 }
 
 std::shared_ptr<FileMetaData> ParquetFileReader::metadata() const {

--- a/src/parquet/file/reader.h
+++ b/src/parquet/file/reader.h
@@ -98,8 +98,9 @@ class PARQUET_EXPORT ParquetFileReader {
 
   // API Convenience to open a serialized Parquet file on disk, using Arrow IO
   // interfaces.
-  static std::unique_ptr<ParquetFileReader> OpenFile(const std::string& path,
-      bool memory_map = true, const ReaderProperties& props = default_reader_properties(),
+  static std::unique_ptr<ParquetFileReader> OpenFile(
+      const std::string& path, bool memory_map = true,
+      const ReaderProperties& props = default_reader_properties(),
       const std::shared_ptr<FileMetaData>& metadata = nullptr);
 
   void Open(std::unique_ptr<Contents> contents);
@@ -117,8 +118,8 @@ class PARQUET_EXPORT ParquetFileReader {
 };
 
 // Read only Parquet file metadata
-std::shared_ptr<FileMetaData> PARQUET_EXPORT ReadMetaData(
-    const std::shared_ptr<::arrow::io::ReadableFileInterface>& source);
+std::shared_ptr<FileMetaData> PARQUET_EXPORT
+ReadMetaData(const std::shared_ptr<::arrow::io::ReadableFileInterface>& source);
 
 }  // namespace parquet
 

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -40,8 +40,8 @@ namespace parquet {
 class SerializedPageWriter : public PageWriter {
  public:
   SerializedPageWriter(OutputStream* sink, Compression::type codec,
-      ColumnChunkMetaDataBuilder* metadata,
-      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+                       ColumnChunkMetaDataBuilder* metadata,
+                       ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
 
   virtual ~SerializedPageWriter() {}
 
@@ -76,7 +76,8 @@ class SerializedPageWriter : public PageWriter {
 class RowGroupSerializer : public RowGroupWriter::Contents {
  public:
   RowGroupSerializer(int64_t num_rows, OutputStream* sink,
-      RowGroupMetaDataBuilder* metadata, const WriterProperties* properties)
+                     RowGroupMetaDataBuilder* metadata,
+                     const WriterProperties* properties)
       : num_rows_(num_rows),
         sink_(sink),
         metadata_(metadata),
@@ -126,7 +127,8 @@ class FileSerializer : public ParquetFileWriter::Contents {
   virtual ~FileSerializer();
 
  private:
-  explicit FileSerializer(const std::shared_ptr<OutputStream>& sink,
+  explicit FileSerializer(
+      const std::shared_ptr<OutputStream>& sink,
       const std::shared_ptr<schema::GroupNode>& schema,
       const std::shared_ptr<WriterProperties>& properties,
       const std::shared_ptr<const KeyValueMetadata>& key_value_metadata);

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -37,21 +37,13 @@ void RowGroupWriter::Close() {
   }
 }
 
-ColumnWriter* RowGroupWriter::NextColumn() {
-  return contents_->NextColumn();
-}
+ColumnWriter* RowGroupWriter::NextColumn() { return contents_->NextColumn(); }
 
-int RowGroupWriter::current_column() {
-  return contents_->current_column();
-}
+int RowGroupWriter::current_column() { return contents_->current_column(); }
 
-int RowGroupWriter::num_columns() const {
-  return contents_->num_columns();
-}
+int RowGroupWriter::num_columns() const { return contents_->num_columns(); }
 
-int64_t RowGroupWriter::num_rows() const {
-  return contents_->num_rows();
-}
+int64_t RowGroupWriter::num_rows() const { return contents_->num_rows(); }
 
 // ----------------------------------------------------------------------
 // ParquetFileWriter public API
@@ -61,7 +53,8 @@ ParquetFileWriter::ParquetFileWriter() {}
 ParquetFileWriter::~ParquetFileWriter() {
   try {
     Close();
-  } catch (...) {}
+  } catch (...) {
+  }
 }
 
 std::unique_ptr<ParquetFileWriter> ParquetFileWriter::Open(
@@ -69,8 +62,8 @@ std::unique_ptr<ParquetFileWriter> ParquetFileWriter::Open(
     const std::shared_ptr<GroupNode>& schema,
     const std::shared_ptr<WriterProperties>& properties,
     const std::shared_ptr<const KeyValueMetadata>& key_value_metadata) {
-  return Open(
-      std::make_shared<ArrowOutputStream>(sink), schema, properties, key_value_metadata);
+  return Open(std::make_shared<ArrowOutputStream>(sink), schema, properties,
+              key_value_metadata);
 }
 
 std::unique_ptr<ParquetFileWriter> ParquetFileWriter::Open(
@@ -84,25 +77,17 @@ std::unique_ptr<ParquetFileWriter> ParquetFileWriter::Open(
   return result;
 }
 
-const SchemaDescriptor* ParquetFileWriter::schema() const {
-  return contents_->schema();
-}
+const SchemaDescriptor* ParquetFileWriter::schema() const { return contents_->schema(); }
 
 const ColumnDescriptor* ParquetFileWriter::descr(int i) const {
   return contents_->schema()->Column(i);
 }
 
-int ParquetFileWriter::num_columns() const {
-  return contents_->num_columns();
-}
+int ParquetFileWriter::num_columns() const { return contents_->num_columns(); }
 
-int64_t ParquetFileWriter::num_rows() const {
-  return contents_->num_rows();
-}
+int64_t ParquetFileWriter::num_rows() const { return contents_->num_rows(); }
 
-int ParquetFileWriter::num_row_groups() const {
-  return contents_->num_row_groups();
-}
+int ParquetFileWriter::num_row_groups() const { return contents_->num_row_groups(); }
 
 const std::shared_ptr<const KeyValueMetadata>& ParquetFileWriter::key_value_metadata()
     const {

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -88,7 +88,7 @@ class PARQUET_EXPORT ParquetFileWriter {
   // An implementation of the Contents class is defined in the .cc file
   struct Contents {
     Contents(const std::shared_ptr<::parquet::schema::GroupNode>& schema,
-        const std::shared_ptr<const KeyValueMetadata>& key_value_metadata)
+             const std::shared_ptr<const KeyValueMetadata>& key_value_metadata)
         : schema_(), key_value_metadata_(key_value_metadata) {
       schema_.Init(schema);
     }

--- a/src/parquet/properties-test.cc
+++ b/src/parquet/properties-test.cc
@@ -52,12 +52,12 @@ TEST(TestWriterProperties, AdvancedHandling) {
   std::shared_ptr<WriterProperties> props = builder.build();
 
   ASSERT_EQ(Compression::GZIP, props->compression(ColumnPath::FromDotString("gzip")));
-  ASSERT_EQ(
-      Compression::SNAPPY, props->compression(ColumnPath::FromDotString("delta-length")));
-  ASSERT_EQ(
-      Encoding::DELTA_BINARY_PACKED, props->encoding(ColumnPath::FromDotString("gzip")));
+  ASSERT_EQ(Compression::SNAPPY,
+            props->compression(ColumnPath::FromDotString("delta-length")));
+  ASSERT_EQ(Encoding::DELTA_BINARY_PACKED,
+            props->encoding(ColumnPath::FromDotString("gzip")));
   ASSERT_EQ(Encoding::DELTA_LENGTH_BYTE_ARRAY,
-      props->encoding(ColumnPath::FromDotString("delta-length")));
+            props->encoding(ColumnPath::FromDotString("delta-length")));
 }
 
 }  // namespace test

--- a/src/parquet/properties.h
+++ b/src/parquet/properties.h
@@ -48,8 +48,8 @@ class PARQUET_EXPORT ReaderProperties {
 
   ::arrow::MemoryPool* memory_pool() const { return pool_; }
 
-  std::unique_ptr<InputStream> GetStream(
-      RandomAccessSource* source, int64_t start, int64_t num_bytes) {
+  std::unique_ptr<InputStream> GetStream(RandomAccessSource* source, int64_t start,
+                                         int64_t num_bytes) {
     std::unique_ptr<InputStream> stream;
     if (buffered_stream_enabled_) {
       stream.reset(
@@ -92,9 +92,9 @@ static constexpr Compression::type DEFAULT_COMPRESSION_TYPE = Compression::UNCOM
 class PARQUET_EXPORT ColumnProperties {
  public:
   ColumnProperties(Encoding::type encoding = DEFAULT_ENCODING,
-      Compression::type codec = DEFAULT_COMPRESSION_TYPE,
-      bool dictionary_enabled = DEFAULT_IS_DICTIONARY_ENABLED,
-      bool statistics_enabled = DEFAULT_ARE_STATISTICS_ENABLED)
+                   Compression::type codec = DEFAULT_COMPRESSION_TYPE,
+                   bool dictionary_enabled = DEFAULT_IS_DICTIONARY_ENABLED,
+                   bool statistics_enabled = DEFAULT_ARE_STATISTICS_ENABLED)
       : encoding(encoding),
         codec(codec),
         dictionary_enabled(dictionary_enabled),
@@ -215,8 +215,8 @@ class PARQUET_EXPORT WriterProperties {
      * This either apply if dictionary encoding is disabled or if we fallback
      * as the dictionary grew too large.
      */
-    Builder* encoding(
-        const std::shared_ptr<schema::ColumnPath>& path, Encoding::type encoding_type) {
+    Builder* encoding(const std::shared_ptr<schema::ColumnPath>& path,
+                      Encoding::type encoding_type) {
       return this->encoding(path->ToDotString(), encoding_type);
     }
 
@@ -230,8 +230,8 @@ class PARQUET_EXPORT WriterProperties {
       return this;
     }
 
-    Builder* compression(
-        const std::shared_ptr<schema::ColumnPath>& path, Compression::type codec) {
+    Builder* compression(const std::shared_ptr<schema::ColumnPath>& path,
+                         Compression::type codec) {
       return this->compression(path->ToDotString(), codec);
     }
 
@@ -273,18 +273,16 @@ class PARQUET_EXPORT WriterProperties {
           return it->second;
       };
 
-      for (const auto& item : encodings_)
-        get(item.first).encoding = item.second;
-      for (const auto& item : codecs_)
-        get(item.first).codec = item.second;
+      for (const auto& item : encodings_) get(item.first).encoding = item.second;
+      for (const auto& item : codecs_) get(item.first).codec = item.second;
       for (const auto& item : dictionary_enabled_)
         get(item.first).dictionary_enabled = item.second;
       for (const auto& item : statistics_enabled_)
         get(item.first).statistics_enabled = item.second;
 
-      return std::shared_ptr<WriterProperties>(new WriterProperties(pool_,
-          dictionary_pagesize_limit_, write_batch_size_, pagesize_, version_, created_by_,
-          default_column_properties_, column_properties));
+      return std::shared_ptr<WriterProperties>(new WriterProperties(
+          pool_, dictionary_pagesize_limit_, write_batch_size_, pagesize_, version_,
+          created_by_, default_column_properties_, column_properties));
     }
 
    private:
@@ -355,7 +353,8 @@ class PARQUET_EXPORT WriterProperties {
   }
 
  private:
-  explicit WriterProperties(::arrow::MemoryPool* pool, int64_t dictionary_pagesize_limit,
+  explicit WriterProperties(
+      ::arrow::MemoryPool* pool, int64_t dictionary_pagesize_limit,
       int64_t write_batch_size, int64_t pagesize, ParquetVersion::type version,
       const std::string& created_by, const ColumnProperties& default_column_properties,
       const std::unordered_map<std::string, ColumnProperties>& column_properties)

--- a/src/parquet/public-api-test.cc
+++ b/src/parquet/public-api-test.cc
@@ -40,9 +40,7 @@ TEST(TestPublicAPI, DoesNotIncludeZlib) {
 #endif
 }
 
-void ThrowsParquetException() {
-  throw parquet::ParquetException("This function throws");
-}
+void ThrowsParquetException() { throw parquet::ParquetException("This function throws"); }
 
 TEST(TestPublicAPI, CanThrowParquetException) {
   ASSERT_THROW(ThrowsParquetException(), parquet::ParquetException);

--- a/src/parquet/reader-test.cc
+++ b/src/parquet/reader-test.cc
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <cstdint>
-#include <cstdlib>
 #include <fcntl.h>
 #include <gtest/gtest.h>
+#include <cstdint>
+#include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -227,8 +227,8 @@ TEST_F(TestLocalFile, OpenWithMetadata) {
   printer.DebugPrint(ss, columns, true);
 
   // Make sure OpenFile passes on the external metadata, too
-  auto reader2 = ParquetFileReader::OpenFile(
-      alltypes_plain(), false, default_reader_properties(), metadata);
+  auto reader2 = ParquetFileReader::OpenFile(alltypes_plain(), false,
+                                             default_reader_properties(), metadata);
 
   // Compare pointers
   ASSERT_EQ(metadata.get(), reader2->metadata().get());

--- a/src/parquet/schema-test.cc
+++ b/src/parquet/schema-test.cc
@@ -41,7 +41,8 @@ using format::SchemaElement;
 namespace schema {
 
 static inline SchemaElement NewPrimitive(const std::string& name,
-    FieldRepetitionType::type repetition, format::Type::type type, int id = 0) {
+                                         FieldRepetitionType::type repetition,
+                                         format::Type::type type, int id = 0) {
   SchemaElement result;
   result.__set_name(name);
   result.__set_repetition_type(repetition);
@@ -52,7 +53,8 @@ static inline SchemaElement NewPrimitive(const std::string& name,
 }
 
 static inline SchemaElement NewGroup(const std::string& name,
-    FieldRepetitionType::type repetition, int num_children, int id = 0) {
+                                     FieldRepetitionType::type repetition,
+                                     int num_children, int id = 0) {
   SchemaElement result;
   result.__set_name(name);
   result.__set_repetition_type(repetition);
@@ -156,8 +158,8 @@ TEST_F(TestPrimitiveNode, FromParquet) {
   ASSERT_EQ(LogicalType::UTF8, prim_node_->logical_type());
 
   // FIXED_LEN_BYTE_ARRAY
-  elt = NewPrimitive(
-      name_, FieldRepetitionType::OPTIONAL, format::Type::FIXED_LEN_BYTE_ARRAY, 0);
+  elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL,
+                     format::Type::FIXED_LEN_BYTE_ARRAY, 0);
   elt.__set_type_length(16);
 
   Convert(&elt);
@@ -168,8 +170,8 @@ TEST_F(TestPrimitiveNode, FromParquet) {
   ASSERT_EQ(16, prim_node_->type_length());
 
   // ConvertedType::Decimal
-  elt = NewPrimitive(
-      name_, FieldRepetitionType::OPTIONAL, format::Type::FIXED_LEN_BYTE_ARRAY, 0);
+  elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL,
+                     format::Type::FIXED_LEN_BYTE_ARRAY, 0);
   elt.__set_converted_type(ConvertedType::DECIMAL);
   elt.__set_type_length(6);
   elt.__set_scale(2);
@@ -197,21 +199,21 @@ TEST_F(TestPrimitiveNode, Equals) {
   ASSERT_TRUE(node1.Equals(&node5));
 
   PrimitiveNode flba1("foo", Repetition::REQUIRED, Type::FIXED_LEN_BYTE_ARRAY,
-      LogicalType::DECIMAL, 12, 4, 2);
+                      LogicalType::DECIMAL, 12, 4, 2);
 
   PrimitiveNode flba2("foo", Repetition::REQUIRED, Type::FIXED_LEN_BYTE_ARRAY,
-      LogicalType::DECIMAL, 1, 4, 2);
+                      LogicalType::DECIMAL, 1, 4, 2);
   flba2.SetTypeLength(12);
 
   PrimitiveNode flba3("foo", Repetition::REQUIRED, Type::FIXED_LEN_BYTE_ARRAY,
-      LogicalType::DECIMAL, 1, 4, 2);
+                      LogicalType::DECIMAL, 1, 4, 2);
   flba3.SetTypeLength(16);
 
   PrimitiveNode flba4("foo", Repetition::REQUIRED, Type::FIXED_LEN_BYTE_ARRAY,
-      LogicalType::DECIMAL, 12, 4, 0);
+                      LogicalType::DECIMAL, 12, 4, 0);
 
   PrimitiveNode flba5("foo", Repetition::REQUIRED, Type::FIXED_LEN_BYTE_ARRAY,
-      LogicalType::NONE, 12, 4, 0);
+                      LogicalType::NONE, 12, 4, 0);
 
   ASSERT_TRUE(flba1.Equals(&flba2));
   ASSERT_FALSE(flba1.Equals(&flba3));
@@ -222,52 +224,59 @@ TEST_F(TestPrimitiveNode, Equals) {
 TEST_F(TestPrimitiveNode, PhysicalLogicalMapping) {
   ASSERT_NO_THROW(
       PrimitiveNode::Make("foo", Repetition::REQUIRED, Type::INT32, LogicalType::INT_32));
-  ASSERT_NO_THROW(PrimitiveNode::Make(
-      "foo", Repetition::REQUIRED, Type::BYTE_ARRAY, LogicalType::JSON));
+  ASSERT_NO_THROW(PrimitiveNode::Make("foo", Repetition::REQUIRED, Type::BYTE_ARRAY,
+                                      LogicalType::JSON));
   ASSERT_THROW(
       PrimitiveNode::Make("foo", Repetition::REQUIRED, Type::INT32, LogicalType::JSON),
       ParquetException);
-  ASSERT_NO_THROW(PrimitiveNode::Make(
-      "foo", Repetition::REQUIRED, Type::INT64, LogicalType::TIMESTAMP_MILLIS));
+  ASSERT_NO_THROW(PrimitiveNode::Make("foo", Repetition::REQUIRED, Type::INT64,
+                                      LogicalType::TIMESTAMP_MILLIS));
   ASSERT_THROW(
       PrimitiveNode::Make("foo", Repetition::REQUIRED, Type::INT32, LogicalType::INT_64),
       ParquetException);
-  ASSERT_THROW(PrimitiveNode::Make(
-                   "foo", Repetition::REQUIRED, Type::BYTE_ARRAY, LogicalType::INT_8),
-      ParquetException);
-  ASSERT_THROW(PrimitiveNode::Make(
-                   "foo", Repetition::REQUIRED, Type::BYTE_ARRAY, LogicalType::INTERVAL),
-      ParquetException);
+  ASSERT_THROW(PrimitiveNode::Make("foo", Repetition::REQUIRED, Type::BYTE_ARRAY,
+                                   LogicalType::INT_8),
+               ParquetException);
+  ASSERT_THROW(PrimitiveNode::Make("foo", Repetition::REQUIRED, Type::BYTE_ARRAY,
+                                   LogicalType::INTERVAL),
+               ParquetException);
   ASSERT_THROW(PrimitiveNode::Make("foo", Repetition::REQUIRED,
-                   Type::FIXED_LEN_BYTE_ARRAY, LogicalType::ENUM),
-      ParquetException);
-  ASSERT_NO_THROW(PrimitiveNode::Make(
-      "foo", Repetition::REQUIRED, Type::BYTE_ARRAY, LogicalType::ENUM));
-  ASSERT_THROW(PrimitiveNode::Make("foo", Repetition::REQUIRED,
-                   Type::FIXED_LEN_BYTE_ARRAY, LogicalType::DECIMAL, 0, 2, 4),
+                                   Type::FIXED_LEN_BYTE_ARRAY, LogicalType::ENUM),
+               ParquetException);
+  ASSERT_NO_THROW(PrimitiveNode::Make("foo", Repetition::REQUIRED, Type::BYTE_ARRAY,
+                                      LogicalType::ENUM));
+  ASSERT_THROW(
+      PrimitiveNode::Make("foo", Repetition::REQUIRED, Type::FIXED_LEN_BYTE_ARRAY,
+                          LogicalType::DECIMAL, 0, 2, 4),
       ParquetException);
   ASSERT_THROW(PrimitiveNode::Make("foo", Repetition::REQUIRED, Type::FLOAT,
-                   LogicalType::DECIMAL, 0, 2, 4),
+                                   LogicalType::DECIMAL, 0, 2, 4),
+               ParquetException);
+  ASSERT_THROW(
+      PrimitiveNode::Make("foo", Repetition::REQUIRED, Type::FIXED_LEN_BYTE_ARRAY,
+                          LogicalType::DECIMAL, 0, 4, 0),
       ParquetException);
-  ASSERT_THROW(PrimitiveNode::Make("foo", Repetition::REQUIRED,
-                   Type::FIXED_LEN_BYTE_ARRAY, LogicalType::DECIMAL, 0, 4, 0),
+  ASSERT_THROW(
+      PrimitiveNode::Make("foo", Repetition::REQUIRED, Type::FIXED_LEN_BYTE_ARRAY,
+                          LogicalType::DECIMAL, 10, 0, 4),
       ParquetException);
-  ASSERT_THROW(PrimitiveNode::Make("foo", Repetition::REQUIRED,
-                   Type::FIXED_LEN_BYTE_ARRAY, LogicalType::DECIMAL, 10, 0, 4),
+  ASSERT_THROW(
+      PrimitiveNode::Make("foo", Repetition::REQUIRED, Type::FIXED_LEN_BYTE_ARRAY,
+                          LogicalType::DECIMAL, 10, 4, -1),
       ParquetException);
-  ASSERT_THROW(PrimitiveNode::Make("foo", Repetition::REQUIRED,
-                   Type::FIXED_LEN_BYTE_ARRAY, LogicalType::DECIMAL, 10, 4, -1),
-      ParquetException);
-  ASSERT_THROW(PrimitiveNode::Make("foo", Repetition::REQUIRED,
-                   Type::FIXED_LEN_BYTE_ARRAY, LogicalType::DECIMAL, 10, 2, 4),
+  ASSERT_THROW(
+      PrimitiveNode::Make("foo", Repetition::REQUIRED, Type::FIXED_LEN_BYTE_ARRAY,
+                          LogicalType::DECIMAL, 10, 2, 4),
       ParquetException);
   ASSERT_NO_THROW(PrimitiveNode::Make("foo", Repetition::REQUIRED,
-      Type::FIXED_LEN_BYTE_ARRAY, LogicalType::DECIMAL, 10, 6, 4));
+                                      Type::FIXED_LEN_BYTE_ARRAY, LogicalType::DECIMAL,
+                                      10, 6, 4));
   ASSERT_NO_THROW(PrimitiveNode::Make("foo", Repetition::REQUIRED,
-      Type::FIXED_LEN_BYTE_ARRAY, LogicalType::INTERVAL, 12));
+                                      Type::FIXED_LEN_BYTE_ARRAY, LogicalType::INTERVAL,
+                                      12));
   ASSERT_THROW(PrimitiveNode::Make("foo", Repetition::REQUIRED,
-                   Type::FIXED_LEN_BYTE_ARRAY, LogicalType::INTERVAL, 10),
-      ParquetException);
+                                   Type::FIXED_LEN_BYTE_ARRAY, LogicalType::INTERVAL, 10),
+               ParquetException);
 }
 
 // ----------------------------------------------------------------------
@@ -372,10 +381,14 @@ bool check_for_parent_consistency(const GroupNode* node) {
   // Each node should have the group as parent
   for (int i = 0; i < node->field_count(); i++) {
     const NodePtr& field = node->field(i);
-    if (field->parent() != node) { return false; }
+    if (field->parent() != node) {
+      return false;
+    }
     if (field->is_group()) {
       const GroupNode* group = static_cast<GroupNode*>(field.get());
-      if (!check_for_parent_consistency(group)) { return false; }
+      if (!check_for_parent_consistency(group)) {
+        return false;
+      }
     }
   }
   return true;
@@ -468,8 +481,8 @@ class TestSchemaFlatten : public ::testing::Test {
 
 TEST_F(TestSchemaFlatten, DecimalMetadata) {
   // Checks that DecimalMetadata is only set for DecimalTypes
-  NodePtr node = PrimitiveNode::Make(
-      "decimal", Repetition::REQUIRED, Type::INT64, LogicalType::DECIMAL, -1, 8, 4);
+  NodePtr node = PrimitiveNode::Make("decimal", Repetition::REQUIRED, Type::INT64,
+                                     LogicalType::DECIMAL, -1, 8, 4);
   NodePtr group =
       GroupNode::Make("group", Repetition::REPEATED, {node}, LogicalType::LIST);
   Flatten(reinterpret_cast<GroupNode*>(group.get()));
@@ -526,8 +539,8 @@ TEST_F(TestSchemaFlatten, NestedExample) {
 }
 
 TEST(TestColumnDescriptor, TestAttrs) {
-  NodePtr node = PrimitiveNode::Make(
-      "name", Repetition::OPTIONAL, Type::BYTE_ARRAY, LogicalType::UTF8);
+  NodePtr node = PrimitiveNode::Make("name", Repetition::OPTIONAL, Type::BYTE_ARRAY,
+                                     LogicalType::UTF8);
   ColumnDescriptor descr(node, 4, 1);
 
   ASSERT_EQ("name", descr.name());
@@ -540,7 +553,7 @@ TEST(TestColumnDescriptor, TestAttrs) {
 
   // Test FIXED_LEN_BYTE_ARRAY
   node = PrimitiveNode::Make("name", Repetition::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY,
-      LogicalType::DECIMAL, 12, 10, 4);
+                             LogicalType::DECIMAL, 12, 10, 4);
   descr = ColumnDescriptor(node, 4, 1);
 
   ASSERT_EQ(Type::FIXED_LEN_BYTE_ARRAY, descr.physical_type());
@@ -572,8 +585,8 @@ TEST_F(TestSchemaDescriptor, Equals) {
   NodePtr item1 = Int64("item1", Repetition::REQUIRED);
   NodePtr item2 = Boolean("item2", Repetition::OPTIONAL);
   NodePtr item3 = Int32("item3", Repetition::REPEATED);
-  NodePtr list(GroupNode::Make(
-      "records", Repetition::REPEATED, {item1, item2, item3}, LogicalType::LIST));
+  NodePtr list(GroupNode::Make("records", Repetition::REPEATED, {item1, item2, item3},
+                               LogicalType::LIST));
 
   NodePtr bag(GroupNode::Make("bag", Repetition::OPTIONAL, {list}));
   NodePtr bag2(GroupNode::Make("bag", Repetition::REQUIRED, {list}));
@@ -624,8 +637,8 @@ TEST_F(TestSchemaDescriptor, BuildTree) {
   NodePtr item1 = Int64("item1", Repetition::REQUIRED);
   NodePtr item2 = Boolean("item2", Repetition::OPTIONAL);
   NodePtr item3 = Int32("item3", Repetition::REPEATED);
-  NodePtr list(GroupNode::Make(
-      "records", Repetition::REPEATED, {item1, item2, item3}, LogicalType::LIST));
+  NodePtr list(GroupNode::Make("records", Repetition::REPEATED, {item1, item2, item3},
+                               LogicalType::LIST));
   NodePtr bag(GroupNode::Make("bag", Repetition::OPTIONAL, {list}));
   fields.push_back(bag);
 
@@ -705,8 +718,8 @@ TEST(TestSchemaPrinter, Examples) {
   NodePtr bag(GroupNode::Make("bag", Repetition::OPTIONAL, {list}));
   fields.push_back(bag);
 
-  fields.push_back(PrimitiveNode::Make(
-      "c", Repetition::REQUIRED, Type::INT32, LogicalType::DECIMAL, -1, 3, 2));
+  fields.push_back(PrimitiveNode::Make("c", Repetition::REQUIRED, Type::INT32,
+                                       LogicalType::DECIMAL, -1, 3, 2));
 
   NodePtr schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
 

--- a/src/parquet/schema.cc
+++ b/src/parquet/schema.cc
@@ -72,15 +72,15 @@ std::shared_ptr<ColumnPath> ColumnPath::extend(const std::string& node_name) con
 std::string ColumnPath::ToDotString() const {
   std::stringstream ss;
   for (auto it = path_.cbegin(); it != path_.cend(); ++it) {
-    if (it != path_.cbegin()) { ss << "."; }
+    if (it != path_.cbegin()) {
+      ss << ".";
+    }
     ss << *it;
   }
   return ss.str();
 }
 
-const std::vector<std::string>& ColumnPath::ToDotVector() const {
-  return path_;
-}
+const std::vector<std::string>& ColumnPath::ToDotVector() const { return path_; }
 
 // ----------------------------------------------------------------------
 // Base node
@@ -96,16 +96,14 @@ bool Node::EqualsInternal(const Node* other) const {
          repetition_ == other->repetition_ && logical_type_ == other->logical_type_;
 }
 
-void Node::SetParent(const Node* parent) {
-  parent_ = parent;
-}
+void Node::SetParent(const Node* parent) { parent_ = parent; }
 
 // ----------------------------------------------------------------------
 // Primitive node
 
 PrimitiveNode::PrimitiveNode(const std::string& name, Repetition::type repetition,
-    Type::type type, LogicalType::type logical_type, int length, int precision, int scale,
-    int id)
+                             Type::type type, LogicalType::type logical_type, int length,
+                             int precision, int scale, int id)
     : Node(Node::PRIMITIVE, name, repetition, logical_type, id),
       physical_type_(type),
       type_length_(length) {
@@ -224,13 +222,13 @@ bool PrimitiveNode::EqualsInternal(const PrimitiveNode* other) const {
 }
 
 bool PrimitiveNode::Equals(const Node* other) const {
-  if (!Node::EqualsInternal(other)) { return false; }
+  if (!Node::EqualsInternal(other)) {
+    return false;
+  }
   return EqualsInternal(static_cast<const PrimitiveNode*>(other));
 }
 
-void PrimitiveNode::Visit(Node::Visitor* visitor) {
-  visitor->Visit(this);
-}
+void PrimitiveNode::Visit(Node::Visitor* visitor) { visitor->Visit(this); }
 
 void PrimitiveNode::VisitConst(Node::ConstVisitor* visitor) const {
   visitor->Visit(this);
@@ -240,16 +238,24 @@ void PrimitiveNode::VisitConst(Node::ConstVisitor* visitor) const {
 // Group node
 
 bool GroupNode::EqualsInternal(const GroupNode* other) const {
-  if (this == other) { return true; }
-  if (this->field_count() != other->field_count()) { return false; }
+  if (this == other) {
+    return true;
+  }
+  if (this->field_count() != other->field_count()) {
+    return false;
+  }
   for (int i = 0; i < this->field_count(); ++i) {
-    if (!this->field(i)->Equals(other->field(i).get())) { return false; }
+    if (!this->field(i)->Equals(other->field(i).get())) {
+      return false;
+    }
   }
   return true;
 }
 
 bool GroupNode::Equals(const Node* other) const {
-  if (!Node::EqualsInternal(other)) { return false; }
+  if (!Node::EqualsInternal(other)) {
+    return false;
+  }
   return EqualsInternal(static_cast<const GroupNode*>(other));
 }
 
@@ -264,7 +270,9 @@ int GroupNode::FieldIndex(const std::string& name) const {
 
 int GroupNode::FieldIndex(const Node& node) const {
   int result = FieldIndex(node.name());
-  if (result < 0) { return -1; }
+  if (result < 0) {
+    return -1;
+  }
   DCHECK(result < field_count());
   if (!node.Equals(field(result).get())) {
     // Same name but not the same node
@@ -273,13 +281,9 @@ int GroupNode::FieldIndex(const Node& node) const {
   return result;
 }
 
-void GroupNode::Visit(Node::Visitor* visitor) {
-  visitor->Visit(this);
-}
+void GroupNode::Visit(Node::Visitor* visitor) { visitor->Visit(this); }
 
-void GroupNode::VisitConst(Node::ConstVisitor* visitor) const {
-  visitor->Visit(this);
-}
+void GroupNode::VisitConst(Node::ConstVisitor* visitor) const { visitor->Visit(this); }
 
 // ----------------------------------------------------------------------
 // Node construction from Parquet metadata
@@ -304,25 +308,25 @@ static inline NodeParams GetNodeParams(const format::SchemaElement* element) {
   return params;
 }
 
-std::unique_ptr<Node> GroupNode::FromParquet(
-    const void* opaque_element, int node_id, const NodeVector& fields) {
+std::unique_ptr<Node> GroupNode::FromParquet(const void* opaque_element, int node_id,
+                                             const NodeVector& fields) {
   const format::SchemaElement* element =
       static_cast<const format::SchemaElement*>(opaque_element);
   NodeParams params = GetNodeParams(element);
-  return std::unique_ptr<Node>(new GroupNode(
-      params.name, params.repetition, fields, params.logical_type, node_id));
+  return std::unique_ptr<Node>(new GroupNode(params.name, params.repetition, fields,
+                                             params.logical_type, node_id));
 }
 
-std::unique_ptr<Node> PrimitiveNode::FromParquet(
-    const void* opaque_element, int node_id) {
+std::unique_ptr<Node> PrimitiveNode::FromParquet(const void* opaque_element,
+                                                 int node_id) {
   const format::SchemaElement* element =
       static_cast<const format::SchemaElement*>(opaque_element);
   NodeParams params = GetNodeParams(element);
 
   std::unique_ptr<PrimitiveNode> result =
-      std::unique_ptr<PrimitiveNode>(new PrimitiveNode(params.name, params.repetition,
-          FromThrift(element->type), params.logical_type, element->type_length,
-          element->precision, element->scale, node_id));
+      std::unique_ptr<PrimitiveNode>(new PrimitiveNode(
+          params.name, params.repetition, FromThrift(element->type), params.logical_type,
+          element->type_length, element->precision, element->scale, node_id));
 
   // Return as unique_ptr to the base type
   return std::unique_ptr<Node>(result.release());
@@ -442,8 +446,8 @@ class SchemaVisitor : public Node::ConstVisitor {
   std::vector<format::SchemaElement>* elements_;
 };
 
-SchemaFlattener::SchemaFlattener(
-    const GroupNode* schema, std::vector<format::SchemaElement>* out)
+SchemaFlattener::SchemaFlattener(const GroupNode* schema,
+                                 std::vector<format::SchemaElement>* out)
     : root_(schema), elements_(out) {}
 
 void SchemaFlattener::Flatten() {
@@ -546,7 +550,9 @@ void SchemaPrinter::Visit(const GroupNode* node) {
     PrintRepLevel(node->repetition(), stream_);
     stream_ << " group " << node->name();
     auto lt = node->logical_type();
-    if (lt != LogicalType::NONE) { stream_ << " (" << LogicalTypeToString(lt) << ")"; }
+    if (lt != LogicalType::NONE) {
+      stream_ << " (" << LogicalTypeToString(lt) << ")";
+    }
     stream_ << " {" << std::endl;
   }
 
@@ -609,17 +615,21 @@ void SchemaDescriptor::Init(const NodePtr& schema) {
 }
 
 bool SchemaDescriptor::Equals(const SchemaDescriptor& other) const {
-  if (this->num_columns() != other.num_columns()) { return false; }
+  if (this->num_columns() != other.num_columns()) {
+    return false;
+  }
 
   for (int i = 0; i < this->num_columns(); ++i) {
-    if (!this->Column(i)->Equals(*other.Column(i))) { return false; }
+    if (!this->Column(i)->Equals(*other.Column(i))) {
+      return false;
+    }
   }
 
   return true;
 }
 
 void SchemaDescriptor::BuildTree(const NodePtr& node, int16_t max_def_level,
-    int16_t max_rep_level, const NodePtr& base) {
+                                 int16_t max_rep_level, const NodePtr& base) {
   if (node->is_optional()) {
     ++max_def_level;
   } else if (node->is_repeated()) {
@@ -639,19 +649,22 @@ void SchemaDescriptor::BuildTree(const NodePtr& node, int16_t max_def_level,
     // Primitive node, append to leaves
     leaves_.push_back(ColumnDescriptor(node, max_def_level, max_rep_level, this));
     leaf_to_base_.emplace(static_cast<int>(leaves_.size()) - 1, base);
-    leaf_to_idx_.emplace(
-        node->path()->ToDotString(), static_cast<int>(leaves_.size()) - 1);
+    leaf_to_idx_.emplace(node->path()->ToDotString(),
+                         static_cast<int>(leaves_.size()) - 1);
   }
 }
 
 ColumnDescriptor::ColumnDescriptor(const schema::NodePtr& node,
-    int16_t max_definition_level, int16_t max_repetition_level,
-    const SchemaDescriptor* schema_descr)
+                                   int16_t max_definition_level,
+                                   int16_t max_repetition_level,
+                                   const SchemaDescriptor* schema_descr)
     : node_(node),
       max_definition_level_(max_definition_level),
       max_repetition_level_(max_repetition_level),
       schema_descr_(schema_descr) {
-  if (!node_->is_primitive()) { throw ParquetException("Must be a primitive type"); }
+  if (!node_->is_primitive()) {
+    throw ParquetException("Must be a primitive type");
+  }
   primitive_node_ = static_cast<const PrimitiveNode*>(node_.get());
 }
 
@@ -677,7 +690,9 @@ int SchemaDescriptor::ColumnIndex(const std::string& node_path) const {
 
 int SchemaDescriptor::ColumnIndex(const Node& node) const {
   int result = ColumnIndex(node.path()->ToDotString());
-  if (result < 0) { return -1; }
+  if (result < 0) {
+    return -1;
+  }
   DCHECK(result < num_columns());
   if (!node.Equals(Column(result)->schema_node().get())) {
     // Same path but not the same node
@@ -699,9 +714,7 @@ int ColumnDescriptor::type_precision() const {
   return primitive_node_->decimal_metadata().precision;
 }
 
-int ColumnDescriptor::type_length() const {
-  return primitive_node_->type_length();
-}
+int ColumnDescriptor::type_length() const { return primitive_node_->type_length(); }
 
 const std::shared_ptr<ColumnPath> ColumnDescriptor::path() const {
   return primitive_node_->path();

--- a/src/parquet/schema.h
+++ b/src/parquet/schema.h
@@ -108,7 +108,7 @@ class PARQUET_EXPORT Node {
   enum type { PRIMITIVE, GROUP };
 
   Node(Node::type type, const std::string& name, Repetition::type repetition,
-      LogicalType::type logical_type = LogicalType::NONE, int id = -1)
+       LogicalType::type logical_type = LogicalType::NONE, int id = -1)
       : type_(type),
         name_(name),
         repetition_(repetition),
@@ -195,10 +195,11 @@ class PARQUET_EXPORT PrimitiveNode : public Node {
   static std::unique_ptr<Node> FromParquet(const void* opaque_element, int id);
 
   static inline NodePtr Make(const std::string& name, Repetition::type repetition,
-      Type::type type, LogicalType::type logical_type = LogicalType::NONE,
-      int length = -1, int precision = -1, int scale = -1) {
-    return NodePtr(new PrimitiveNode(
-        name, repetition, type, logical_type, length, precision, scale));
+                             Type::type type,
+                             LogicalType::type logical_type = LogicalType::NONE,
+                             int length = -1, int precision = -1, int scale = -1) {
+    return NodePtr(new PrimitiveNode(name, repetition, type, logical_type, length,
+                                     precision, scale));
   }
 
   bool Equals(const Node* other) const override;
@@ -215,8 +216,8 @@ class PARQUET_EXPORT PrimitiveNode : public Node {
 
  private:
   PrimitiveNode(const std::string& name, Repetition::type repetition, Type::type type,
-      LogicalType::type logical_type = LogicalType::NONE, int length = -1,
-      int precision = -1, int scale = -1, int id = -1);
+                LogicalType::type logical_type = LogicalType::NONE, int length = -1,
+                int precision = -1, int scale = -1, int id = -1);
 
   Type::type physical_type_;
   int32_t type_length_;
@@ -243,11 +244,12 @@ class PARQUET_EXPORT GroupNode : public Node {
  public:
   // Like PrimitiveNode, GroupNode::FromParquet accepts an opaque void* to avoid exporting
   // parquet::SchemaElement into the public API
-  static std::unique_ptr<Node> FromParquet(
-      const void* opaque_element, int id, const NodeVector& fields);
+  static std::unique_ptr<Node> FromParquet(const void* opaque_element, int id,
+                                           const NodeVector& fields);
 
   static inline NodePtr Make(const std::string& name, Repetition::type repetition,
-      const NodeVector& fields, LogicalType::type logical_type = LogicalType::NONE) {
+                             const NodeVector& fields,
+                             LogicalType::type logical_type = LogicalType::NONE) {
     return NodePtr(new GroupNode(name, repetition, fields, logical_type));
   }
 
@@ -265,8 +267,8 @@ class PARQUET_EXPORT GroupNode : public Node {
 
  private:
   GroupNode(const std::string& name, Repetition::type repetition,
-      const NodeVector& fields, LogicalType::type logical_type = LogicalType::NONE,
-      int id = -1)
+            const NodeVector& fields, LogicalType::type logical_type = LogicalType::NONE,
+            int id = -1)
       : Node(Node::GROUP, name, repetition, logical_type, id), fields_(fields) {
     field_name_to_idx_.clear();
     auto field_idx = 0;
@@ -290,10 +292,10 @@ class PARQUET_EXPORT GroupNode : public Node {
 // ----------------------------------------------------------------------
 // Convenience primitive type factory functions
 
-#define PRIMITIVE_FACTORY(FuncName, TYPE)                                            \
-  static inline NodePtr FuncName(                                                    \
-      const std::string& name, Repetition::type repetition = Repetition::OPTIONAL) { \
-    return PrimitiveNode::Make(name, repetition, Type::TYPE);                        \
+#define PRIMITIVE_FACTORY(FuncName, TYPE)                                              \
+  static inline NodePtr FuncName(const std::string& name,                              \
+                                 Repetition::type repetition = Repetition::OPTIONAL) { \
+    return PrimitiveNode::Make(name, repetition, Type::TYPE);                          \
   }
 
 PRIMITIVE_FACTORY(Boolean, BOOLEAN);
@@ -304,8 +306,8 @@ PRIMITIVE_FACTORY(Float, FLOAT);
 PRIMITIVE_FACTORY(Double, DOUBLE);
 PRIMITIVE_FACTORY(ByteArray, BYTE_ARRAY);
 
-void PARQUET_EXPORT PrintSchema(
-    const schema::Node* schema, std::ostream& stream, int indent_width = 2);
+void PARQUET_EXPORT PrintSchema(const schema::Node* schema, std::ostream& stream,
+                                int indent_width = 2);
 
 }  // namespace schema
 
@@ -317,7 +319,8 @@ void PARQUET_EXPORT PrintSchema(
 class PARQUET_EXPORT ColumnDescriptor {
  public:
   ColumnDescriptor(const schema::NodePtr& node, int16_t max_definition_level,
-      int16_t max_repetition_level, const SchemaDescriptor* schema_descr = nullptr);
+                   int16_t max_repetition_level,
+                   const SchemaDescriptor* schema_descr = nullptr);
 
   bool Equals(const ColumnDescriptor& other) const;
 
@@ -402,7 +405,7 @@ class PARQUET_EXPORT SchemaDescriptor {
   const schema::GroupNode* group_node_;
 
   void BuildTree(const schema::NodePtr& node, int16_t max_def_level,
-      int16_t max_rep_level, const schema::NodePtr& base);
+                 int16_t max_rep_level, const schema::NodePtr& base);
 
   // Result of leaf node / tree analysis
   std::vector<ColumnDescriptor> leaves_;

--- a/src/parquet/statistics-test.cc
+++ b/src/parquet/statistics-test.cc
@@ -68,13 +68,13 @@ class TestRowGroupStatistics : public PrimitiveTypedTest<TestType> {
     std::string encoded_max = statistics1.EncodeMax();
 
     TypedStats statistics2(this->schema_.Column(0), encoded_min, encoded_max,
-        this->values_.size(), 0, 0, true);
+                           this->values_.size(), 0, 0, true);
 
     TypedStats statistics3(this->schema_.Column(0));
     std::vector<uint8_t> valid_bits(
         BitUtil::RoundUpNumBytes(static_cast<uint32_t>(this->values_.size())) + 1, 255);
-    statistics3.UpdateSpaced(
-        this->values_ptr_, valid_bits.data(), 0, this->values_.size(), 0);
+    statistics3.UpdateSpaced(this->values_ptr_, valid_bits.data(), 0,
+                             this->values_.size(), 0);
     std::string encoded_min_spaced = statistics3.EncodeMin();
     std::string encoded_max_spaced = statistics3.EncodeMax();
 
@@ -108,13 +108,13 @@ class TestRowGroupStatistics : public PrimitiveTypedTest<TestType> {
 
     TypedStats statistics1(this->schema_.Column(0));
     this->GenerateData(1000);
-    statistics1.Update(
-        this->values_ptr_, this->values_.size() - num_null[0], num_null[0]);
+    statistics1.Update(this->values_ptr_, this->values_.size() - num_null[0],
+                       num_null[0]);
 
     TypedStats statistics2(this->schema_.Column(0));
     this->GenerateData(1000);
-    statistics2.Update(
-        this->values_ptr_, this->values_.size() - num_null[1], num_null[1]);
+    statistics2.Update(this->values_ptr_, this->values_.size() - num_null[1],
+                       num_null[1]);
 
     TypedStats total(this->schema_.Column(0));
     total.Merge(statistics1);
@@ -149,14 +149,14 @@ class TestRowGroupStatistics : public PrimitiveTypedTest<TestType> {
       int64_t batch_null_count = i ? null_count : 0;
       DCHECK(null_count <= num_values);  // avoid too much headache
       std::vector<int16_t> definition_levels(batch_null_count, 0);
-      definition_levels.insert(
-          definition_levels.end(), batch_num_values - batch_null_count, 1);
+      definition_levels.insert(definition_levels.end(),
+                               batch_num_values - batch_null_count, 1);
       auto beg = this->values_.begin() + i * num_values / 2;
       auto end = beg + batch_num_values;
       std::vector<T> batch = GetDeepCopy(std::vector<T>(beg, end));
       T* batch_values_ptr = GetValuesPointer(batch);
-      column_writer->WriteBatch(
-          batch_num_values, definition_levels.data(), nullptr, batch_values_ptr);
+      column_writer->WriteBatch(batch_num_values, definition_levels.data(), nullptr,
+                                batch_values_ptr);
       DeepFree(batch);
     }
     column_writer->Close();
@@ -263,12 +263,13 @@ void TestRowGroupStatistics<ByteArrayType>::TestMinMaxEncode() {
 
   // encoded is same as unencoded
   ASSERT_EQ(encoded_min,
-      std::string((const char*)statistics1.min().ptr, statistics1.min().len));
+            std::string((const char*)statistics1.min().ptr, statistics1.min().len));
   ASSERT_EQ(encoded_max,
-      std::string((const char*)statistics1.max().ptr, statistics1.max().len));
+            std::string((const char*)statistics1.max().ptr, statistics1.max().len));
 
   TypedRowGroupStatistics<ByteArrayType> statistics2(this->schema_.Column(0), encoded_min,
-      encoded_max, this->values_.size(), 0, 0, true);
+                                                     encoded_max, this->values_.size(), 0,
+                                                     0, true);
 
   ASSERT_EQ(encoded_min, statistics2.EncodeMin());
   ASSERT_EQ(encoded_max, statistics2.EncodeMax());
@@ -277,7 +278,7 @@ void TestRowGroupStatistics<ByteArrayType>::TestMinMaxEncode() {
 }
 
 using TestTypes = ::testing::Types<Int32Type, Int64Type, Int96Type, FloatType, DoubleType,
-    ByteArrayType, FLBAType, BooleanType>;
+                                   ByteArrayType, FLBAType, BooleanType>;
 
 TYPED_TEST_CASE(TestRowGroupStatistics, TestTypes);
 
@@ -316,19 +317,20 @@ TEST(CorruptStatistics, Basics) {
   schema::NodePtr node;
   std::vector<schema::NodePtr> fields;
   // Test Physical Types
-  fields.push_back(schema::PrimitiveNode::Make(
-      "col1", Repetition::OPTIONAL, Type::INT32, LogicalType::NONE));
-  fields.push_back(schema::PrimitiveNode::Make(
-      "col2", Repetition::OPTIONAL, Type::BYTE_ARRAY, LogicalType::NONE));
+  fields.push_back(schema::PrimitiveNode::Make("col1", Repetition::OPTIONAL, Type::INT32,
+                                               LogicalType::NONE));
+  fields.push_back(schema::PrimitiveNode::Make("col2", Repetition::OPTIONAL,
+                                               Type::BYTE_ARRAY, LogicalType::NONE));
   // Test Logical Types
-  fields.push_back(schema::PrimitiveNode::Make(
-      "col3", Repetition::OPTIONAL, Type::INT32, LogicalType::DATE));
-  fields.push_back(schema::PrimitiveNode::Make(
-      "col4", Repetition::OPTIONAL, Type::INT32, LogicalType::UINT_32));
+  fields.push_back(schema::PrimitiveNode::Make("col3", Repetition::OPTIONAL, Type::INT32,
+                                               LogicalType::DATE));
+  fields.push_back(schema::PrimitiveNode::Make("col4", Repetition::OPTIONAL, Type::INT32,
+                                               LogicalType::UINT_32));
   fields.push_back(schema::PrimitiveNode::Make("col5", Repetition::OPTIONAL,
-      Type::FIXED_LEN_BYTE_ARRAY, LogicalType::INTERVAL, 12));
-  fields.push_back(schema::PrimitiveNode::Make(
-      "col6", Repetition::OPTIONAL, Type::BYTE_ARRAY, LogicalType::UTF8));
+                                               Type::FIXED_LEN_BYTE_ARRAY,
+                                               LogicalType::INTERVAL, 12));
+  fields.push_back(schema::PrimitiveNode::Make("col6", Repetition::OPTIONAL,
+                                               Type::BYTE_ARRAY, LogicalType::UTF8));
   node = schema::GroupNode::Make("schema", Repetition::REQUIRED, fields);
   schema.Init(node);
 

--- a/src/parquet/statistics.cc
+++ b/src/parquet/statistics.cc
@@ -30,8 +30,8 @@ using arrow::MemoryPool;
 namespace parquet {
 
 template <typename DType>
-TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(
-    const ColumnDescriptor* schema, MemoryPool* pool)
+TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(const ColumnDescriptor* schema,
+                                                        MemoryPool* pool)
     : pool_(pool),
       min_buffer_(AllocateBuffer(pool_, 0)),
       max_buffer_(AllocateBuffer(pool_, 0)) {
@@ -41,8 +41,10 @@ TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(
 
 template <typename DType>
 TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(const typename DType::c_type& min,
-    const typename DType::c_type& max, int64_t num_values, int64_t null_count,
-    int64_t distinct_count)
+                                                        const typename DType::c_type& max,
+                                                        int64_t num_values,
+                                                        int64_t null_count,
+                                                        int64_t distinct_count)
     : pool_(default_memory_pool()),
       min_buffer_(AllocateBuffer(pool_, 0)),
       max_buffer_(AllocateBuffer(pool_, 0)) {
@@ -56,9 +58,10 @@ TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(const typename DType::c_
 }
 
 template <typename DType>
-TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(const ColumnDescriptor* schema,
-    const std::string& encoded_min, const std::string& encoded_max, int64_t num_values,
-    int64_t null_count, int64_t distinct_count, bool has_min_max, MemoryPool* pool)
+TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(
+    const ColumnDescriptor* schema, const std::string& encoded_min,
+    const std::string& encoded_max, int64_t num_values, int64_t null_count,
+    int64_t distinct_count, bool has_min_max, MemoryPool* pool)
     : pool_(pool),
       min_buffer_(AllocateBuffer(pool_, 0)),
       max_buffer_(AllocateBuffer(pool_, 0)) {
@@ -68,8 +71,12 @@ TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(const ColumnDescriptor* 
 
   SetDescr(schema);
 
-  if (!encoded_min.empty()) { PlainDecode(encoded_min, &min_); }
-  if (!encoded_max.empty()) { PlainDecode(encoded_max, &max_); }
+  if (!encoded_min.empty()) {
+    PlainDecode(encoded_min, &min_);
+  }
+  if (!encoded_max.empty()) {
+    PlainDecode(encoded_max, &max_);
+  }
   has_min_max_ = has_min_max;
 }
 
@@ -85,8 +92,8 @@ void TypedRowGroupStatistics<DType>::Reset() {
 }
 
 template <typename DType>
-void TypedRowGroupStatistics<DType>::Update(
-    const T* values, int64_t num_not_null, int64_t num_null) {
+void TypedRowGroupStatistics<DType>::Update(const T* values, int64_t num_not_null,
+                                            int64_t num_null) {
   DCHECK(num_not_null >= 0);
   DCHECK(num_null >= 0);
 
@@ -109,8 +116,10 @@ void TypedRowGroupStatistics<DType>::Update(
 
 template <typename DType>
 void TypedRowGroupStatistics<DType>::UpdateSpaced(const T* values,
-    const uint8_t* valid_bits, int64_t valid_bits_offset, int64_t num_not_null,
-    int64_t num_null) {
+                                                  const uint8_t* valid_bits,
+                                                  int64_t valid_bits_offset,
+                                                  int64_t num_not_null,
+                                                  int64_t num_null) {
   DCHECK(num_not_null >= 0);
   DCHECK(num_null >= 0);
 
@@ -126,7 +135,9 @@ void TypedRowGroupStatistics<DType>::UpdateSpaced(const T* values,
   int64_t length = num_null + num_not_null;
   int64_t i = 0;
   for (; i < length; i++) {
-    if (bitset_valid_bits & (1 << bit_offset_valid_bits)) { break; }
+    if (bitset_valid_bits & (1 << bit_offset_valid_bits)) {
+      break;
+    }
     READ_NEXT_BITSET(valid_bits);
   }
   T min = values[i];
@@ -216,8 +227,8 @@ void TypedRowGroupStatistics<DType>::PlainEncode(const T& src, std::string* dst)
 template <typename DType>
 void TypedRowGroupStatistics<DType>::PlainDecode(const std::string& src, T* dst) {
   PlainDecoder<DType> decoder(descr());
-  decoder.SetData(
-      1, reinterpret_cast<const uint8_t*>(src.c_str()), static_cast<int>(src.size()));
+  decoder.SetData(1, reinterpret_cast<const uint8_t*>(src.c_str()),
+                  static_cast<int>(src.size()));
   decoder.Decode(dst, 1);
 }
 

--- a/src/parquet/statistics.h
+++ b/src/parquet/statistics.h
@@ -134,15 +134,15 @@ class TypedRowGroupStatistics : public RowGroupStatistics {
   using T = typename DType::c_type;
 
   TypedRowGroupStatistics(const ColumnDescriptor* schema,
-      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+                          ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
 
   TypedRowGroupStatistics(const T& min, const T& max, int64_t num_values,
-      int64_t null_count, int64_t distinct_count);
+                          int64_t null_count, int64_t distinct_count);
 
   TypedRowGroupStatistics(const ColumnDescriptor* schema, const std::string& encoded_min,
-      const std::string& encoded_max, int64_t num_values, int64_t null_count,
-      int64_t distinct_count, bool has_min_max,
-      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+                          const std::string& encoded_max, int64_t num_values,
+                          int64_t null_count, int64_t distinct_count, bool has_min_max,
+                          ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
 
   bool HasMinMax() const override;
   void Reset() override;
@@ -150,7 +150,7 @@ class TypedRowGroupStatistics : public RowGroupStatistics {
 
   void Update(const T* values, int64_t num_not_null, int64_t num_null);
   void UpdateSpaced(const T* values, const uint8_t* valid_bits, int64_t valid_bits_spaced,
-      int64_t num_not_null, int64_t num_null);
+                    int64_t num_not_null, int64_t num_null);
 
   const T& min() const;
   const T& max() const;
@@ -178,8 +178,8 @@ inline void TypedRowGroupStatistics<DType>::Copy(const T& src, T* dst, PoolBuffe
 }
 
 template <>
-inline void TypedRowGroupStatistics<FLBAType>::Copy(
-    const FLBA& src, FLBA* dst, PoolBuffer* buffer) {
+inline void TypedRowGroupStatistics<FLBAType>::Copy(const FLBA& src, FLBA* dst,
+                                                    PoolBuffer* buffer) {
   if (dst->ptr == src.ptr) return;
   uint32_t len = descr_->type_length();
   PARQUET_THROW_NOT_OK(buffer->Resize(len, false));
@@ -188,8 +188,9 @@ inline void TypedRowGroupStatistics<FLBAType>::Copy(
 }
 
 template <>
-inline void TypedRowGroupStatistics<ByteArrayType>::Copy(
-    const ByteArray& src, ByteArray* dst, PoolBuffer* buffer) {
+inline void TypedRowGroupStatistics<ByteArrayType>::Copy(const ByteArray& src,
+                                                         ByteArray* dst,
+                                                         PoolBuffer* buffer) {
   if (dst->ptr == src.ptr) return;
   PARQUET_THROW_NOT_OK(buffer->Resize(src.len, false));
   std::memcpy(buffer->mutable_data(), src.ptr, src.len);

--- a/src/parquet/test-specialization.h
+++ b/src/parquet/test-specialization.h
@@ -40,8 +40,8 @@ void InitValues<bool>(int num_values, vector<bool>& values, vector<uint8_t>& buf
 }
 
 template <>
-void InitValues<ByteArray>(
-    int num_values, vector<ByteArray>& values, vector<uint8_t>& buffer) {
+void InitValues<ByteArray>(int num_values, vector<ByteArray>& values,
+                           vector<uint8_t>& buffer) {
   int max_byte_array_len = 12;
   int num_bytes = max_byte_array_len + sizeof(uint32_t);
   size_t nbytes = num_values * num_bytes;
@@ -59,7 +59,7 @@ void InitValues<FLBA>(int num_values, vector<FLBA>& values, vector<uint8_t>& buf
 template <>
 void InitValues<Int96>(int num_values, vector<Int96>& values, vector<uint8_t>& buffer) {
   random_Int96_numbers(num_values, 0, std::numeric_limits<int32_t>::min(),
-      std::numeric_limits<int32_t>::max(), values.data());
+                       std::numeric_limits<int32_t>::max(), values.data());
 }
 
 inline std::string TestColumnName(int i) {
@@ -79,8 +79,8 @@ class PrimitiveTypedTest : public ::testing::Test {
 
     for (int i = 0; i < num_columns; ++i) {
       std::string name = TestColumnName(i);
-      fields.push_back(schema::PrimitiveNode::Make(
-          name, repetition, TestType::type_num, LogicalType::NONE, FLBA_LENGTH));
+      fields.push_back(schema::PrimitiveNode::Make(name, repetition, TestType::type_num,
+                                                   LogicalType::NONE, FLBA_LENGTH));
     }
     node_ = schema::GroupNode::Make("schema", Repetition::REQUIRED, fields);
     schema_.Init(node_);

--- a/src/parquet/test-util.h
+++ b/src/parquet/test-util.h
@@ -53,12 +53,12 @@ namespace test {
 template <typename T>
 static void InitValues(int num_values, vector<T>& values, vector<uint8_t>& buffer) {
   random_numbers(num_values, 0, std::numeric_limits<T>::min(),
-      std::numeric_limits<T>::max(), values.data());
+                 std::numeric_limits<T>::max(), values.data());
 }
 
 template <typename T>
-static void InitDictValues(
-    int num_values, int num_dicts, vector<T>& values, vector<uint8_t>& buffer) {
+static void InitDictValues(int num_values, int num_dicts, vector<T>& values,
+                           vector<uint8_t>& buffer) {
   int repeat_factor = num_values / num_dicts;
   InitValues<T>(num_dicts, values, buffer);
   // add some repeated values
@@ -112,7 +112,7 @@ class DataPageBuilder {
         have_values_(false) {}
 
   void AppendDefLevels(const vector<int16_t>& levels, int16_t max_level,
-      Encoding::type encoding = Encoding::RLE) {
+                       Encoding::type encoding = Encoding::RLE) {
     AppendLevels(levels, max_level, encoding);
 
     num_values_ = std::max(static_cast<int32_t>(levels.size()), num_values_);
@@ -121,7 +121,7 @@ class DataPageBuilder {
   }
 
   void AppendRepLevels(const vector<int16_t>& levels, int16_t max_level,
-      Encoding::type encoding = Encoding::RLE) {
+                       Encoding::type encoding = Encoding::RLE) {
     AppendLevels(levels, max_level, encoding);
 
     num_values_ = std::max(static_cast<int32_t>(levels.size()), num_values_);
@@ -130,7 +130,7 @@ class DataPageBuilder {
   }
 
   void AppendValues(const ColumnDescriptor* d, const vector<T>& values,
-      Encoding::type encoding = Encoding::PLAIN) {
+                    Encoding::type encoding = Encoding::PLAIN) {
     PlainEncoder<Type> encoder(d);
     encoder.Put(&values[0], static_cast<int>(values.size()));
     std::shared_ptr<Buffer> values_sink = encoder.FlushValues();
@@ -162,8 +162,8 @@ class DataPageBuilder {
   bool have_values_;
 
   // Used internally for both repetition and definition levels
-  void AppendLevels(
-      const vector<int16_t>& levels, int16_t max_level, Encoding::type encoding) {
+  void AppendLevels(const vector<int16_t>& levels, int16_t max_level,
+                    Encoding::type encoding) {
     if (encoding != Encoding::RLE) {
       ParquetException::NYI("only rle encoding currently implemented");
     }
@@ -176,7 +176,7 @@ class DataPageBuilder {
     // size.
     LevelEncoder encoder;
     encoder.Init(encoding, max_level, static_cast<int>(levels.size()),
-        encode_buffer.data(), static_cast<int>(encode_buffer.size()));
+                 encode_buffer.data(), static_cast<int>(encode_buffer.size()));
 
     encoder.Encode(static_cast<int>(levels.size()), levels.data());
 
@@ -187,8 +187,9 @@ class DataPageBuilder {
 };
 
 template <>
-void DataPageBuilder<BooleanType>::AppendValues(
-    const ColumnDescriptor* d, const vector<bool>& values, Encoding::type encoding) {
+void DataPageBuilder<BooleanType>::AppendValues(const ColumnDescriptor* d,
+                                                const vector<bool>& values,
+                                                Encoding::type encoding) {
   if (encoding != Encoding::PLAIN) {
     ParquetException::NYI("only plain encoding currently implemented");
   }
@@ -203,17 +204,22 @@ void DataPageBuilder<BooleanType>::AppendValues(
 }
 
 template <typename Type>
-static shared_ptr<DataPage> MakeDataPage(const ColumnDescriptor* d,
-    const vector<typename Type::c_type>& values, int num_vals, Encoding::type encoding,
-    const uint8_t* indices, int indices_size, const vector<int16_t>& def_levels,
-    int16_t max_def_level, const vector<int16_t>& rep_levels, int16_t max_rep_level) {
+static shared_ptr<DataPage> MakeDataPage(
+    const ColumnDescriptor* d, const vector<typename Type::c_type>& values, int num_vals,
+    Encoding::type encoding, const uint8_t* indices, int indices_size,
+    const vector<int16_t>& def_levels, int16_t max_def_level,
+    const vector<int16_t>& rep_levels, int16_t max_rep_level) {
   int num_values = 0;
 
   InMemoryOutputStream page_stream;
   test::DataPageBuilder<Type> page_builder(&page_stream);
 
-  if (!rep_levels.empty()) { page_builder.AppendRepLevels(rep_levels, max_rep_level); }
-  if (!def_levels.empty()) { page_builder.AppendDefLevels(def_levels, max_def_level); }
+  if (!rep_levels.empty()) {
+    page_builder.AppendRepLevels(rep_levels, max_rep_level);
+  }
+  if (!def_levels.empty()) {
+    page_builder.AppendDefLevels(def_levels, max_def_level);
+  }
 
   if (encoding == Encoding::PLAIN) {
     page_builder.AppendValues(d, values, encoding);
@@ -226,7 +232,8 @@ static shared_ptr<DataPage> MakeDataPage(const ColumnDescriptor* d,
   auto buffer = page_stream.GetBuffer();
 
   return std::make_shared<DataPage>(buffer, num_values, encoding,
-      page_builder.def_level_encoding(), page_builder.rep_level_encoding());
+                                    page_builder.def_level_encoding(),
+                                    page_builder.rep_level_encoding());
 }
 
 template <typename TYPE>
@@ -287,9 +294,10 @@ shared_ptr<Buffer> DictionaryPageBuilder<BooleanType>::AppendValues(
 }
 
 template <typename Type>
-static shared_ptr<DictionaryPage> MakeDictPage(const ColumnDescriptor* d,
-    const vector<typename Type::c_type>& values, const vector<int>& values_per_page,
-    Encoding::type encoding, vector<shared_ptr<Buffer>>& rle_indices) {
+static shared_ptr<DictionaryPage> MakeDictPage(
+    const ColumnDescriptor* d, const vector<typename Type::c_type>& values,
+    const vector<int>& values_per_page, Encoding::type encoding,
+    vector<shared_ptr<Buffer>>& rle_indices) {
   InMemoryOutputStream page_stream;
   test::DictionaryPageBuilder<Type> page_builder(d);
   int num_pages = static_cast<int>(values_per_page.size());
@@ -303,17 +311,19 @@ static shared_ptr<DictionaryPage> MakeDictPage(const ColumnDescriptor* d,
 
   auto buffer = page_builder.WriteDict();
 
-  return std::make_shared<DictionaryPage>(
-      buffer, page_builder.num_values(), Encoding::PLAIN);
+  return std::make_shared<DictionaryPage>(buffer, page_builder.num_values(),
+                                          Encoding::PLAIN);
 }
 
 // Given def/rep levels and values create multiple dict pages
 template <typename Type>
 static void PaginateDict(const ColumnDescriptor* d,
-    const vector<typename Type::c_type>& values, const vector<int16_t>& def_levels,
-    int16_t max_def_level, const vector<int16_t>& rep_levels, int16_t max_rep_level,
-    int num_levels_per_page, const vector<int>& values_per_page,
-    vector<shared_ptr<Page>>& pages, Encoding::type encoding = Encoding::RLE_DICTIONARY) {
+                         const vector<typename Type::c_type>& values,
+                         const vector<int16_t>& def_levels, int16_t max_def_level,
+                         const vector<int16_t>& rep_levels, int16_t max_rep_level,
+                         int num_levels_per_page, const vector<int>& values_per_page,
+                         vector<shared_ptr<Page>>& pages,
+                         Encoding::type encoding = Encoding::RLE_DICTIONARY) {
   int num_pages = static_cast<int>(values_per_page.size());
   vector<shared_ptr<Buffer>> rle_indices;
   shared_ptr<DictionaryPage> dict_page =
@@ -332,8 +342,9 @@ static void PaginateDict(const ColumnDescriptor* d,
       rep_level_start = i * num_levels_per_page;
       rep_level_end = (i + 1) * num_levels_per_page;
     }
-    shared_ptr<DataPage> data_page = MakeDataPage<Int32Type>(d, {}, values_per_page[i],
-        encoding, rle_indices[i]->data(), static_cast<int>(rle_indices[i]->size()),
+    shared_ptr<DataPage> data_page = MakeDataPage<Int32Type>(
+        d, {}, values_per_page[i], encoding, rle_indices[i]->data(),
+        static_cast<int>(rle_indices[i]->size()),
         slice(def_levels, def_level_start, def_level_end), max_def_level,
         slice(rep_levels, rep_level_start, rep_level_end), max_rep_level);
     pages.push_back(data_page);
@@ -343,10 +354,12 @@ static void PaginateDict(const ColumnDescriptor* d,
 // Given def/rep levels and values create multiple plain pages
 template <typename Type>
 static void PaginatePlain(const ColumnDescriptor* d,
-    const vector<typename Type::c_type>& values, const vector<int16_t>& def_levels,
-    int16_t max_def_level, const vector<int16_t>& rep_levels, int16_t max_rep_level,
-    int num_levels_per_page, const vector<int>& values_per_page,
-    vector<shared_ptr<Page>>& pages, Encoding::type encoding = Encoding::PLAIN) {
+                          const vector<typename Type::c_type>& values,
+                          const vector<int16_t>& def_levels, int16_t max_def_level,
+                          const vector<int16_t>& rep_levels, int16_t max_rep_level,
+                          int num_levels_per_page, const vector<int>& values_per_page,
+                          vector<shared_ptr<Page>>& pages,
+                          Encoding::type encoding = Encoding::PLAIN) {
   int num_pages = static_cast<int>(values_per_page.size());
   int def_level_start = 0;
   int def_level_end = 0;
@@ -362,10 +375,11 @@ static void PaginatePlain(const ColumnDescriptor* d,
       rep_level_start = i * num_levels_per_page;
       rep_level_end = (i + 1) * num_levels_per_page;
     }
-    shared_ptr<DataPage> page = MakeDataPage<Type>(d,
-        slice(values, value_start, value_start + values_per_page[i]), values_per_page[i],
-        encoding, NULL, 0, slice(def_levels, def_level_start, def_level_end),
-        max_def_level, slice(rep_levels, rep_level_start, rep_level_end), max_rep_level);
+    shared_ptr<DataPage> page = MakeDataPage<Type>(
+        d, slice(values, value_start, value_start + values_per_page[i]),
+        values_per_page[i], encoding, NULL, 0,
+        slice(def_levels, def_level_start, def_level_end), max_def_level,
+        slice(rep_levels, rep_level_start, rep_level_end), max_rep_level);
     pages.push_back(page);
     value_start += values_per_page[i];
   }
@@ -374,9 +388,10 @@ static void PaginatePlain(const ColumnDescriptor* d,
 // Generates pages from randomly generated data
 template <typename Type>
 static int MakePages(const ColumnDescriptor* d, int num_pages, int levels_per_page,
-    vector<int16_t>& def_levels, vector<int16_t>& rep_levels,
-    vector<typename Type::c_type>& values, vector<uint8_t>& buffer,
-    vector<shared_ptr<Page>>& pages, Encoding::type encoding = Encoding::PLAIN) {
+                     vector<int16_t>& def_levels, vector<int16_t>& rep_levels,
+                     vector<typename Type::c_type>& values, vector<uint8_t>& buffer,
+                     vector<shared_ptr<Page>>& pages,
+                     Encoding::type encoding = Encoding::PLAIN) {
   int num_levels = levels_per_page * num_pages;
   int num_values = 0;
   uint32_t seed = 0;
@@ -411,13 +426,13 @@ static int MakePages(const ColumnDescriptor* d, int num_pages, int levels_per_pa
   if (encoding == Encoding::PLAIN) {
     InitValues<typename Type::c_type>(num_values, values, buffer);
     PaginatePlain<Type>(d, values, def_levels, max_def_level, rep_levels, max_rep_level,
-        levels_per_page, values_per_page, pages);
+                        levels_per_page, values_per_page, pages);
   } else if (encoding == Encoding::RLE_DICTIONARY ||
              encoding == Encoding::PLAIN_DICTIONARY) {
     // Calls InitValues and repeats the data
     InitDictValues<typename Type::c_type>(num_values, levels_per_page, values, buffer);
     PaginateDict<Type>(d, values, def_levels, max_def_level, rep_levels, max_rep_level,
-        levels_per_page, values_per_page, pages);
+                       levels_per_page, values_per_page, pages);
   }
 
   return num_values;

--- a/src/parquet/thrift.h
+++ b/src/parquet/thrift.h
@@ -30,9 +30,9 @@
 #include <thrift/protocol/TCompactProtocol.h>
 #include <thrift/protocol/TDebugProtocol.h>
 
-#include <sstream>
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/transport/TBufferTransports.h>
+#include <sstream>
 
 #include "parquet/exception.h"
 #include "parquet/parquet_types.h"

--- a/src/parquet/types-test.cc
+++ b/src/parquet/types-test.cc
@@ -44,10 +44,10 @@ TEST(TestLogicalTypeToString, LogicalTypes) {
   ASSERT_STREQ("DATE", LogicalTypeToString(LogicalType::DATE).c_str());
   ASSERT_STREQ("TIME_MILLIS", LogicalTypeToString(LogicalType::TIME_MILLIS).c_str());
   ASSERT_STREQ("TIME_MICROS", LogicalTypeToString(LogicalType::TIME_MICROS).c_str());
-  ASSERT_STREQ(
-      "TIMESTAMP_MILLIS", LogicalTypeToString(LogicalType::TIMESTAMP_MILLIS).c_str());
-  ASSERT_STREQ(
-      "TIMESTAMP_MICROS", LogicalTypeToString(LogicalType::TIMESTAMP_MICROS).c_str());
+  ASSERT_STREQ("TIMESTAMP_MILLIS",
+               LogicalTypeToString(LogicalType::TIMESTAMP_MILLIS).c_str());
+  ASSERT_STREQ("TIMESTAMP_MICROS",
+               LogicalTypeToString(LogicalType::TIMESTAMP_MICROS).c_str());
   ASSERT_STREQ("UINT_8", LogicalTypeToString(LogicalType::UINT_8).c_str());
   ASSERT_STREQ("UINT_16", LogicalTypeToString(LogicalType::UINT_16).c_str());
   ASSERT_STREQ("UINT_32", LogicalTypeToString(LogicalType::UINT_32).c_str());
@@ -106,10 +106,10 @@ TEST(TypePrinter, StatisticsTypes) {
 
   smin = std::string("abcdefgh");
   smax = std::string("ijklmnop");
-  ASSERT_STREQ(
-      "abcdefgh ", FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smin.c_str()).c_str());
-  ASSERT_STREQ(
-      "ijklmnop ", FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smax.c_str()).c_str());
+  ASSERT_STREQ("abcdefgh ",
+               FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smin.c_str()).c_str());
+  ASSERT_STREQ("ijklmnop ",
+               FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smax.c_str()).c_str());
 }
 
 }  // namespace parquet

--- a/src/parquet/util/buffer-builder.h
+++ b/src/parquet/util/buffer-builder.h
@@ -20,8 +20,8 @@
 #ifndef PARQUET_UTIL_BUFFER_BUILDER_H
 #define PARQUET_UTIL_BUFFER_BUILDER_H
 
-#include <cstdint>
 #include <stdlib.h>
+#include <cstdint>
 
 namespace parquet {
 

--- a/src/parquet/util/comparison-test.cc
+++ b/src/parquet/util/comparison-test.cc
@@ -67,8 +67,9 @@ TEST(Comparison, FLBA) {
   auto arr1 = FLBAFromString(a);
   auto arr2 = FLBAFromString(b);
 
-  NodePtr node = PrimitiveNode::Make("FLBA", Repetition::REQUIRED,
-      Type::FIXED_LEN_BYTE_ARRAY, LogicalType::NONE, static_cast<int>(a.size()));
+  NodePtr node =
+      PrimitiveNode::Make("FLBA", Repetition::REQUIRED, Type::FIXED_LEN_BYTE_ARRAY,
+                          LogicalType::NONE, static_cast<int>(a.size()));
   ColumnDescriptor descr(node, 0, 0);
   Compare<parquet::FixedLenByteArray> less(&descr);
   ASSERT_TRUE(less(arr1, arr2));

--- a/src/parquet/util/comparison.h
+++ b/src/parquet/util/comparison.h
@@ -51,8 +51,8 @@ template <>
 inline bool Compare<FLBA>::operator()(const FLBA& a, const FLBA& b) {
   auto aptr = reinterpret_cast<const int8_t*>(a.ptr);
   auto bptr = reinterpret_cast<const int8_t*>(b.ptr);
-  return std::lexicographical_compare(
-      aptr, aptr + type_length_, bptr, bptr + type_length_);
+  return std::lexicographical_compare(aptr, aptr + type_length_, bptr,
+                                      bptr + type_length_);
 }
 
 }  // namespace parquet

--- a/src/parquet/util/memory.cc
+++ b/src/parquet/util/memory.cc
@@ -140,9 +140,7 @@ uint8_t* ChunkedAllocator::Allocate(int size) {
   return result;
 }
 
-uint8_t* ChunkedAllocator::Allocate(int size) {
-  return Allocate<false>(size);
-}
+uint8_t* ChunkedAllocator::Allocate(int size) { return Allocate<false>(size); }
 
 void ChunkedAllocator::Clear() {
   current_chunk_idx_ = -1;
@@ -335,9 +333,7 @@ ArrowInputFile::ArrowInputFile(
     const std::shared_ptr<::arrow::io::ReadableFileInterface>& file)
     : file_(file) {}
 
-::arrow::io::FileInterface* ArrowInputFile::file_interface() {
-  return file_.get();
-}
+::arrow::io::FileInterface* ArrowInputFile::file_interface() { return file_.get(); }
 
 int64_t ArrowInputFile::Size() const {
   int64_t size;
@@ -374,9 +370,7 @@ ArrowOutputStream::ArrowOutputStream(
     const std::shared_ptr<::arrow::io::OutputStream> file)
     : file_(file) {}
 
-::arrow::io::FileInterface* ArrowOutputStream::file_interface() {
-  return file_.get();
-}
+::arrow::io::FileInterface* ArrowOutputStream::file_interface() { return file_.get(); }
 
 // Copy bytes into the output stream
 void ArrowOutputStream::Write(const uint8_t* data, int64_t length) {
@@ -391,8 +385,8 @@ InMemoryInputStream::InMemoryInputStream(const std::shared_ptr<Buffer>& buffer)
   len_ = buffer_->size();
 }
 
-InMemoryInputStream::InMemoryInputStream(
-    RandomAccessSource* source, int64_t start, int64_t num_bytes)
+InMemoryInputStream::InMemoryInputStream(RandomAccessSource* source, int64_t start,
+                                         int64_t num_bytes)
     : offset_(0) {
   buffer_ = source->ReadAt(start, num_bytes);
   if (buffer_->size() < num_bytes) {
@@ -412,24 +406,22 @@ const uint8_t* InMemoryInputStream::Read(int64_t num_to_read, int64_t* num_bytes
   return result;
 }
 
-void InMemoryInputStream::Advance(int64_t num_bytes) {
-  offset_ += num_bytes;
-}
+void InMemoryInputStream::Advance(int64_t num_bytes) { offset_ += num_bytes; }
 
 // ----------------------------------------------------------------------
 // In-memory output stream
 
 InMemoryOutputStream::InMemoryOutputStream(MemoryPool* pool, int64_t initial_capacity)
     : size_(0), capacity_(initial_capacity) {
-  if (initial_capacity == 0) { initial_capacity = kInMemoryDefaultCapacity; }
+  if (initial_capacity == 0) {
+    initial_capacity = kInMemoryDefaultCapacity;
+  }
   buffer_ = AllocateBuffer(pool, initial_capacity);
 }
 
 InMemoryOutputStream::~InMemoryOutputStream() {}
 
-uint8_t* InMemoryOutputStream::Head() {
-  return buffer_->mutable_data() + size_;
-}
+uint8_t* InMemoryOutputStream::Head() { return buffer_->mutable_data() + size_; }
 
 void InMemoryOutputStream::Write(const uint8_t* data, int64_t length) {
   if (size_ + length > capacity_) {
@@ -444,9 +436,7 @@ void InMemoryOutputStream::Write(const uint8_t* data, int64_t length) {
   size_ += length;
 }
 
-int64_t InMemoryOutputStream::Tell() {
-  return size_;
-}
+int64_t InMemoryOutputStream::Tell() { return size_; }
 
 std::shared_ptr<Buffer> InMemoryOutputStream::GetBuffer() {
   PARQUET_THROW_NOT_OK(buffer_->Resize(size_));
@@ -459,7 +449,8 @@ std::shared_ptr<Buffer> InMemoryOutputStream::GetBuffer() {
 // BufferedInputStream
 
 BufferedInputStream::BufferedInputStream(MemoryPool* pool, int64_t buffer_size,
-    RandomAccessSource* source, int64_t start, int64_t num_bytes)
+                                         RandomAccessSource* source, int64_t start,
+                                         int64_t num_bytes)
     : source_(source), stream_offset_(start), stream_end_(start + num_bytes) {
   buffer_ = AllocateBuffer(pool, buffer_size);
   buffer_size_ = buffer_->size();
@@ -502,13 +493,17 @@ void BufferedInputStream::Advance(int64_t num_bytes) {
 
 std::shared_ptr<PoolBuffer> AllocateBuffer(MemoryPool* pool, int64_t size) {
   auto result = std::make_shared<PoolBuffer>(pool);
-  if (size > 0) { PARQUET_THROW_NOT_OK(result->Resize(size)); }
+  if (size > 0) {
+    PARQUET_THROW_NOT_OK(result->Resize(size));
+  }
   return result;
 }
 
 std::unique_ptr<PoolBuffer> AllocateUniqueBuffer(MemoryPool* pool, int64_t size) {
   std::unique_ptr<PoolBuffer> result(new PoolBuffer(pool));
-  if (size > 0) { PARQUET_THROW_NOT_OK(result->Resize(size)); }
+  if (size > 0) {
+    PARQUET_THROW_NOT_OK(result->Resize(size));
+  }
   return result;
 }
 

--- a/src/parquet/util/memory.h
+++ b/src/parquet/util/memory.h
@@ -414,7 +414,7 @@ class PARQUET_EXPORT InMemoryInputStream : public InputStream {
 class PARQUET_EXPORT BufferedInputStream : public InputStream {
  public:
   BufferedInputStream(::arrow::MemoryPool* pool, int64_t buffer_size,
-      RandomAccessSource* source, int64_t start, int64_t end);
+                      RandomAccessSource* source, int64_t start, int64_t end);
   virtual const uint8_t* Peek(int64_t num_to_peek, int64_t* num_bytes);
   virtual const uint8_t* Read(int64_t num_to_read, int64_t* num_bytes);
 
@@ -429,11 +429,11 @@ class PARQUET_EXPORT BufferedInputStream : public InputStream {
   int64_t buffer_size_;
 };
 
-std::shared_ptr<PoolBuffer> PARQUET_EXPORT AllocateBuffer(
-    ::arrow::MemoryPool* pool, int64_t size = 0);
+std::shared_ptr<PoolBuffer> PARQUET_EXPORT AllocateBuffer(::arrow::MemoryPool* pool,
+                                                          int64_t size = 0);
 
-std::unique_ptr<PoolBuffer> PARQUET_EXPORT AllocateUniqueBuffer(
-    ::arrow::MemoryPool* pool, int64_t size = 0);
+std::unique_ptr<PoolBuffer> PARQUET_EXPORT AllocateUniqueBuffer(::arrow::MemoryPool* pool,
+                                                                int64_t size = 0);
 
 }  // namespace parquet
 

--- a/src/parquet/util/schema-util.h
+++ b/src/parquet/util/schema-util.h
@@ -35,7 +35,9 @@ using parquet::schema::Node;
 using parquet::LogicalType;
 
 inline bool str_endswith_tuple(const std::string& str) {
-  if (str.size() >= 6) { return str.substr(str.size() - 6, 6) == "_tuple"; }
+  if (str.size() >= 6) {
+    return str.substr(str.size() - 6, 6) == "_tuple";
+  }
   return false;
 }
 
@@ -63,16 +65,21 @@ inline bool IsSimpleStruct(const NodePtr& node) {
 // Coalesce a list of schema fields indices which are the roots of the
 // columns referred by a list of column indices
 inline bool ColumnIndicesToFieldIndices(const SchemaDescriptor& descr,
-    const std::vector<int>& column_indices, std::vector<int>* out) {
+                                        const std::vector<int>& column_indices,
+                                        std::vector<int>* out) {
   const GroupNode* group = descr.group_node();
   std::unordered_set<int> already_added;
   out->clear();
   for (auto& column_idx : column_indices) {
     auto field_node = descr.GetColumnRoot(column_idx);
     auto field_idx = group->FieldIndex(field_node->name());
-    if (field_idx < 0) { return false; }
+    if (field_idx < 0) {
+      return false;
+    }
     auto insertion = already_added.insert(field_idx);
-    if (insertion.second) { out->push_back(field_idx); }
+    if (insertion.second) {
+      out->push_back(field_idx);
+    }
   }
 
   return true;

--- a/src/parquet/util/test-common.h
+++ b/src/parquet/util/test-common.h
@@ -32,7 +32,7 @@ namespace parquet {
 namespace test {
 
 typedef ::testing::Types<BooleanType, Int32Type, Int64Type, Int96Type, FloatType,
-    DoubleType, ByteArrayType, FLBAType>
+                         DoubleType, ByteArrayType, FLBAType>
     ParquetTypes;
 
 template <typename T>
@@ -46,7 +46,9 @@ static inline void assert_vector_equal(const vector<T>& left, const vector<T>& r
 
 template <typename T>
 static inline bool vector_equal(const vector<T>& left, const vector<T>& right) {
-  if (left.size() != right.size()) { return false; }
+  if (left.size() != right.size()) {
+    return false;
+  }
 
   for (size_t i = 0; i < left.size(); ++i) {
     if (left[i] != right[i]) {
@@ -61,7 +63,9 @@ static inline bool vector_equal(const vector<T>& left, const vector<T>& right) {
 
 template <typename T>
 static vector<T> slice(const vector<T>& values, int start, int end) {
-  if (end < start) { return vector<T>(0); }
+  if (end < start) {
+    return vector<T>(0);
+  }
 
   vector<T> out(end - start);
   for (int i = start; i < end; ++i) {
@@ -130,8 +134,8 @@ void random_numbers(int n, uint32_t seed, float min_value, float max_value, floa
 }
 
 template <>
-void random_numbers(
-    int n, uint32_t seed, double min_value, double max_value, double* out) {
+void random_numbers(int n, uint32_t seed, double min_value, double max_value,
+                    double* out) {
   std::mt19937 gen(seed);
   std::uniform_real_distribution<double> d(min_value, max_value);
   for (int i = 0; i < n; ++i) {
@@ -139,8 +143,8 @@ void random_numbers(
   }
 }
 
-void random_Int96_numbers(
-    int n, uint32_t seed, int32_t min_value, int32_t max_value, Int96* out) {
+void random_Int96_numbers(int n, uint32_t seed, int32_t min_value, int32_t max_value,
+                          Int96* out) {
   std::mt19937 gen(seed);
   std::uniform_int_distribution<int32_t> d(min_value, max_value);
   for (int i = 0; i < n; ++i) {
@@ -162,8 +166,8 @@ void random_fixed_byte_array(int n, uint32_t seed, uint8_t* buf, int len, FLBA* 
   }
 }
 
-void random_byte_array(
-    int n, uint32_t seed, uint8_t* buf, ByteArray* out, int min_size, int max_size) {
+void random_byte_array(int n, uint32_t seed, uint8_t* buf, ByteArray* out, int min_size,
+                       int max_size) {
   std::mt19937 gen(seed);
   std::uniform_int_distribution<int> d1(min_size, max_size);
   std::uniform_int_distribution<int> d2(0, 255);

--- a/tools/parquet-scan.cc
+++ b/tools/parquet-scan.cc
@@ -49,7 +49,9 @@ int main(int argc, char** argv) {
       }
     } else if ((param = std::strstr(argv[i], BATCH_SIZE_PREFIX.c_str()))) {
       value = std::strtok(param + BATCH_SIZE_PREFIX.length(), " ");
-      if (value) { batch_size = std::atoi(value); }
+      if (value) {
+        batch_size = std::atoi(value);
+      }
     } else {
       filename = argv[i];
     }
@@ -84,8 +86,9 @@ int main(int argc, char** argv) {
 
         int64_t values_read = 0;
         while (col_reader->HasNext()) {
-          total_rows[col] += ScanAllValues(batch_size, def_levels.data(),
-              rep_levels.data(), values.data(), &values_read, col_reader.get());
+          total_rows[col] +=
+              ScanAllValues(batch_size, def_levels.data(), rep_levels.data(),
+                            values.data(), &values_read, col_reader.get());
         }
         col++;
       }


### PR DESCRIPTION
The main change is horizontal alignment. We should also do a clang-tidy pass sometime to do some further scrubbing