### PR TITLE
PARQUET-1037: allow arbitrary size row-groups

### DIFF
--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -795,7 +795,7 @@ TEST_F(TestInt96ParquetIO, ReadIntoTimestamp) {
   // to write an Int96 file.
   this->sink_ = std::make_shared<InMemoryOutputStream>();
   auto writer = ParquetFileWriter::Open(this->sink_, schema);
-  RowGroupWriter* rg_writer = writer->AppendRowGroup(1);
+  RowGroupWriter* rg_writer = writer->AppendRowGroup();
   ColumnWriter* c_writer = rg_writer->NextColumn();
   auto typed_writer = dynamic_cast<TypedColumnWriter<Int96Type>*>(c_writer);
   ASSERT_NE(typed_writer, nullptr);
@@ -954,7 +954,7 @@ class TestPrimitiveParquetIO : public TestParquetIO<TestType> {
         reinterpret_cast<ParquetCDataType<TestType>*>(values_buffer.data());
     std::copy(values.cbegin(), values.cend(), values_parquet);
     for (int i = 0; i < num_chunks; i++) {
-      auto row_group_writer = file_writer->AppendRowGroup(chunk_size);
+      auto row_group_writer = file_writer->AppendRowGroup();
       auto column_writer =
           static_cast<ParquetWriter<TestType>*>(row_group_writer->NextColumn());
       ParquetCDataType<TestType>* data = values_parquet + i * chunk_size;
@@ -1496,7 +1496,7 @@ class TestNestedSchemaRead : public ::testing::TestWithParam<Repetition::type> {
 
     writer_ = parquet::ParquetFileWriter::Open(nested_parquet_, schema,
                                                default_writer_properties());
-    row_group_writer_ = writer_->AppendRowGroup(num_rows);
+    row_group_writer_ = writer_->AppendRowGroup();
   }
 
   void FinalizeParquetFile() {

--- a/src/parquet/column-io-benchmark.cc
+++ b/src/parquet/column-io-benchmark.cc
@@ -36,7 +36,7 @@ std::unique_ptr<Int64Writer> BuildWriter(int64_t output_size, OutputStream* dst,
   std::unique_ptr<SerializedPageWriter> pager(
       new SerializedPageWriter(dst, Compression::UNCOMPRESSED, metadata));
   return std::unique_ptr<Int64Writer>(new Int64Writer(
-      metadata, std::move(pager), output_size, Encoding::PLAIN, properties));
+      metadata, std::move(pager), true, output_size, Encoding::PLAIN, properties));
 }
 
 std::shared_ptr<ColumnDescriptor> Int64Schema(Repetition::type repetition) {

--- a/src/parquet/column-io-benchmark.cc
+++ b/src/parquet/column-io-benchmark.cc
@@ -35,8 +35,8 @@ std::unique_ptr<Int64Writer> BuildWriter(int64_t output_size, OutputStream* dst,
                                          const WriterProperties* properties) {
   std::unique_ptr<SerializedPageWriter> pager(
       new SerializedPageWriter(dst, Compression::UNCOMPRESSED, metadata));
-  return std::unique_ptr<Int64Writer>(new Int64Writer(
-      metadata, std::move(pager), true, output_size, Encoding::PLAIN, properties));
+  return std::unique_ptr<Int64Writer>(
+      new Int64Writer(metadata, std::move(pager), Encoding::PLAIN, properties));
 }
 
 std::shared_ptr<ColumnDescriptor> Int64Schema(Repetition::type repetition) {

--- a/src/parquet/column_writer-test.cc
+++ b/src/parquet/column_writer-test.cc
@@ -86,7 +86,7 @@ class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
     }
     writer_properties_ = wp_builder.build();
     std::shared_ptr<ColumnWriter> writer = ColumnWriter::Make(
-        metadata_.get(), std::move(pager), output_size, writer_properties_.get());
+        metadata_.get(), std::move(pager), true, output_size, writer_properties_.get());
     return std::static_pointer_cast<TypedColumnWriter<TestType>>(writer);
   }
 

--- a/src/parquet/column_writer-test.cc
+++ b/src/parquet/column_writer-test.cc
@@ -85,8 +85,8 @@ class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
       wp_builder.encoding(column_properties.encoding);
     }
     writer_properties_ = wp_builder.build();
-    std::shared_ptr<ColumnWriter> writer = ColumnWriter::Make(
-        metadata_.get(), std::move(pager), true, output_size, writer_properties_.get());
+    std::shared_ptr<ColumnWriter> writer =
+        ColumnWriter::Make(metadata_.get(), std::move(pager), writer_properties_.get());
     return std::static_pointer_cast<TypedColumnWriter<TestType>>(writer);
   }
 
@@ -400,39 +400,6 @@ TYPED_TEST(TestPrimitiveWriter, Repeated) {
   this->values_out_.resize(SMALL_SIZE - 1);
   this->values_.resize(SMALL_SIZE - 1);
   ASSERT_EQ(this->values_, this->values_out_);
-}
-
-TYPED_TEST(TestPrimitiveWriter, RequiredTooFewRows) {
-  this->GenerateData(SMALL_SIZE - 1);
-
-  auto writer = this->BuildWriter();
-  writer->WriteBatch(this->values_.size(), nullptr, nullptr, this->values_ptr_);
-  ASSERT_THROW(writer->Close(), ParquetException);
-}
-
-TYPED_TEST(TestPrimitiveWriter, RequiredTooMany) {
-  this->GenerateData(2 * SMALL_SIZE);
-
-  auto writer = this->BuildWriter();
-  ASSERT_THROW(
-      writer->WriteBatch(this->values_.size(), nullptr, nullptr, this->values_ptr_),
-      ParquetException);
-}
-
-TYPED_TEST(TestPrimitiveWriter, RepeatedTooFewRows) {
-  // Optional and repeated, so definition and repetition levels
-  this->SetUpSchema(Repetition::REPEATED);
-
-  this->GenerateData(SMALL_SIZE);
-  std::vector<int16_t> definition_levels(SMALL_SIZE, 1);
-  definition_levels[1] = 0;
-  std::vector<int16_t> repetition_levels(SMALL_SIZE, 0);
-  repetition_levels[3] = 1;
-
-  auto writer = this->BuildWriter();
-  writer->WriteBatch(this->values_.size(), definition_levels.data(),
-                     repetition_levels.data(), this->values_ptr_);
-  ASSERT_THROW(writer->Close(), ParquetException);
 }
 
 TYPED_TEST(TestPrimitiveWriter, RequiredLargeChunk) {

--- a/src/parquet/column_writer.cc
+++ b/src/parquet/column_writer.cc
@@ -113,15 +113,11 @@ std::shared_ptr<WriterProperties> default_writer_properties() {
 }
 
 ColumnWriter::ColumnWriter(ColumnChunkMetaDataBuilder* metadata,
-                           std::unique_ptr<PageWriter> pager,
-                           bool row_count_determined, int64_t expected_rows,
-                           bool has_dictionary, Encoding::type encoding,
-                           const WriterProperties* properties)
+                           std::unique_ptr<PageWriter> pager, bool has_dictionary,
+                           Encoding::type encoding, const WriterProperties* properties)
     : metadata_(metadata),
       descr_(metadata->descr()),
       pager_(std::move(pager)),
-      row_count_determined_(row_count_determined),
-      expected_rows_(expected_rows),
       has_dictionary_(has_dictionary),
       encoding_(encoding),
       properties_(properties),
@@ -129,7 +125,7 @@ ColumnWriter::ColumnWriter(ColumnChunkMetaDataBuilder* metadata,
       pool_(properties->memory_pool()),
       num_buffered_values_(0),
       num_buffered_encoded_values_(0),
-      num_rows_(0),
+      rows_written_(0),
       total_bytes_written_(0),
       closed_(false),
       fallback_(false) {
@@ -276,18 +272,7 @@ int64_t ColumnWriter::Close() {
     pager_->Close(has_dictionary_, fallback_);
   }
 
-  if (row_count_determined_ && num_rows_ != expected_rows_) {
-    std::stringstream ss;
-    ss << "Written rows: " << num_rows_ << " != expected rows: " << expected_rows_
-       << "in the current column chunk";
-    throw ParquetException(ss.str());
-  }
-
   return total_bytes_written_;
-}
-
-int64_t ColumnWriter::RowsWritten() {
-  return num_rows_;
 }
 
 void ColumnWriter::FlushBufferedDataPages() {
@@ -306,19 +291,12 @@ void ColumnWriter::FlushBufferedDataPages() {
 
 template <typename Type>
 TypedColumnWriter<Type>::TypedColumnWriter(ColumnChunkMetaDataBuilder* metadata,
-                                            std::unique_ptr<PageWriter> pager,
-                                            bool row_count_determined,
-                                            int64_t expected_rows,
-                                            Encoding::type encoding,
-                                            const WriterProperties* properties)
-    : ColumnWriter(
-        metadata,
-        std::move(pager),
-        row_count_determined,
-        expected_rows,
-        (encoding == Encoding::PLAIN_DICTIONARY || encoding == Encoding::RLE_DICTIONARY),
-        encoding,
-        properties) {
+                                           std::unique_ptr<PageWriter> pager,
+                                           Encoding::type encoding,
+                                           const WriterProperties* properties)
+    : ColumnWriter(metadata, std::move(pager), (encoding == Encoding::PLAIN_DICTIONARY ||
+                                                encoding == Encoding::RLE_DICTIONARY),
+                   encoding, properties) {
   switch (encoding) {
     case Encoding::PLAIN:
       current_encoder_.reset(new PlainEncoder<Type>(descr_, properties->memory_pool()));
@@ -395,10 +373,8 @@ void TypedColumnWriter<Type>::ResetPageStatistics() {
 // Dynamic column writer constructor
 
 std::shared_ptr<ColumnWriter> ColumnWriter::Make(ColumnChunkMetaDataBuilder* metadata,
-                                                std::unique_ptr<PageWriter> pager,
-                                                bool row_count_determined,
-                                                int64_t expected_rows,
-                                                const WriterProperties* properties) {
+                                                 std::unique_ptr<PageWriter> pager,
+                                                 const WriterProperties* properties) {
   const ColumnDescriptor* descr = metadata->descr();
   Encoding::type encoding = properties->encoding(descr->path());
   if (properties->dictionary_enabled(descr->path()) &&
@@ -407,38 +383,29 @@ std::shared_ptr<ColumnWriter> ColumnWriter::Make(ColumnChunkMetaDataBuilder* met
   }
   switch (descr->physical_type()) {
     case Type::BOOLEAN:
-      return std::make_shared<BoolWriter>(metadata, std::move(pager),
-                                          row_count_determined,
-                                          expected_rows, encoding, properties);
+      return std::make_shared<BoolWriter>(metadata, std::move(pager), encoding,
+                                          properties);
     case Type::INT32:
-      return std::make_shared<Int32Writer>(metadata, std::move(pager),
-                                          row_count_determined,
-                                          expected_rows, encoding, properties);
+      return std::make_shared<Int32Writer>(metadata, std::move(pager), encoding,
+                                           properties);
     case Type::INT64:
-      return std::make_shared<Int64Writer>(metadata, std::move(pager),
-                                          row_count_determined,
-                                          expected_rows, encoding, properties);
+      return std::make_shared<Int64Writer>(metadata, std::move(pager), encoding,
+                                           properties);
     case Type::INT96:
-      return std::make_shared<Int96Writer>(metadata, std::move(pager),
-                                          row_count_determined,
-                                          expected_rows, encoding, properties);
+      return std::make_shared<Int96Writer>(metadata, std::move(pager), encoding,
+                                           properties);
     case Type::FLOAT:
-      return std::make_shared<FloatWriter>(metadata, std::move(pager),
-                                          row_count_determined,
-                                          expected_rows, encoding, properties);
+      return std::make_shared<FloatWriter>(metadata, std::move(pager), encoding,
+                                           properties);
     case Type::DOUBLE:
-      return std::make_shared<DoubleWriter>(metadata, std::move(pager),
-                                          row_count_determined,
-                                          expected_rows, encoding, properties);
+      return std::make_shared<DoubleWriter>(metadata, std::move(pager), encoding,
+                                            properties);
     case Type::BYTE_ARRAY:
-      return std::make_shared<ByteArrayWriter>(metadata, std::move(pager),
-                                          row_count_determined,
-                                          expected_rows, encoding, properties);
+      return std::make_shared<ByteArrayWriter>(metadata, std::move(pager), encoding,
+                                               properties);
     case Type::FIXED_LEN_BYTE_ARRAY:
       return std::make_shared<FixedLenByteArrayWriter>(metadata, std::move(pager),
-                                                        row_count_determined,
-                                                        expected_rows, encoding,
-                                                        properties);
+                                                       encoding, properties);
     default:
       ParquetException::NYI("type reader not implemented");
   }
@@ -475,18 +442,14 @@ inline int64_t TypedColumnWriter<DType>::WriteMiniBatch(int64_t num_values,
     // Count the occasions where we start a new row
     for (int64_t i = 0; i < num_values; ++i) {
       if (rep_levels[i] == 0) {
-        num_rows_++;
+        rows_written_++;
       }
     }
 
     WriteRepetitionLevels(num_values, rep_levels);
   } else {
     // Each value is exactly one row
-    num_rows_ += static_cast<int>(num_values);
-  }
-
-  if (row_count_determined_ && num_rows_ > expected_rows_) {
-    throw ParquetException("More rows were written in the column chunk than expected");
+    rows_written_ += static_cast<int>(num_values);
   }
 
   // PARQUET-780
@@ -549,18 +512,14 @@ inline int64_t TypedColumnWriter<DType>::WriteMiniBatchSpaced(
     // Count the occasions where we start a new row
     for (int64_t i = 0; i < num_values; ++i) {
       if (rep_levels[i] == 0) {
-        num_rows_++;
+        rows_written_++;
       }
     }
 
     WriteRepetitionLevels(num_values, rep_levels);
   } else {
     // Each value is exactly one row
-    num_rows_ += static_cast<int>(num_values);
-  }
-
-  if (row_count_determined_ && num_rows_ > expected_rows_) {
-    throw ParquetException("More rows were written in the column chunk than expected");
+    rows_written_ += static_cast<int>(num_values);
   }
 
   if (descr_->schema_node()->is_optional()) {

--- a/src/parquet/column_writer.h
+++ b/src/parquet/column_writer.h
@@ -73,11 +73,13 @@ static constexpr int WRITE_BATCH_SIZE = 1000;
 class PARQUET_EXPORT ColumnWriter {
  public:
   ColumnWriter(ColumnChunkMetaDataBuilder*, std::unique_ptr<PageWriter>,
+               bool row_count_determined,
                int64_t expected_rows, bool has_dictionary, Encoding::type encoding,
                const WriterProperties* properties);
 
   static std::shared_ptr<ColumnWriter> Make(ColumnChunkMetaDataBuilder*,
                                             std::unique_ptr<PageWriter>,
+                                            bool row_count_determined,
                                             int64_t expected_rows,
                                             const WriterProperties* properties);
 
@@ -91,6 +93,8 @@ class PARQUET_EXPORT ColumnWriter {
    * @return Total size of the column in bytes
    */
   int64_t Close();
+
+  int64_t RowsWritten();
 
  protected:
   virtual std::shared_ptr<Buffer> GetValuesBuffer() = 0;
@@ -137,6 +141,9 @@ class PARQUET_EXPORT ColumnWriter {
   const ColumnDescriptor* descr_;
 
   std::unique_ptr<PageWriter> pager_;
+
+  // Whether the number of rows is determined.
+  bool row_count_determined_;
 
   // The number of rows that should be written in this column chunk.
   int64_t expected_rows_;
@@ -195,8 +202,9 @@ class PARQUET_EXPORT TypedColumnWriter : public ColumnWriter {
   typedef typename DType::c_type T;
 
   TypedColumnWriter(ColumnChunkMetaDataBuilder* metadata,
-                    std::unique_ptr<PageWriter> pager, int64_t expected_rows,
-                    Encoding::type encoding, const WriterProperties* properties);
+                    std::unique_ptr<PageWriter> pager, bool row_count_determined,
+                    int64_t expected_rows, Encoding::type encoding,
+                    const WriterProperties* properties);
 
   // Write a batch of repetition levels, definition levels, and values to the
   // column.

--- a/src/parquet/column_writer.h
+++ b/src/parquet/column_writer.h
@@ -73,14 +73,11 @@ static constexpr int WRITE_BATCH_SIZE = 1000;
 class PARQUET_EXPORT ColumnWriter {
  public:
   ColumnWriter(ColumnChunkMetaDataBuilder*, std::unique_ptr<PageWriter>,
-               bool row_count_determined,
-               int64_t expected_rows, bool has_dictionary, Encoding::type encoding,
+               bool has_dictionary, Encoding::type encoding,
                const WriterProperties* properties);
 
   static std::shared_ptr<ColumnWriter> Make(ColumnChunkMetaDataBuilder*,
                                             std::unique_ptr<PageWriter>,
-                                            bool row_count_determined,
-                                            int64_t expected_rows,
                                             const WriterProperties* properties);
 
   Type::type type() const { return descr_->physical_type(); }
@@ -94,7 +91,7 @@ class PARQUET_EXPORT ColumnWriter {
    */
   int64_t Close();
 
-  int64_t RowsWritten();
+  int64_t rows_written() const { return rows_written_; }
 
  protected:
   virtual std::shared_ptr<Buffer> GetValuesBuffer() = 0;
@@ -142,11 +139,6 @@ class PARQUET_EXPORT ColumnWriter {
 
   std::unique_ptr<PageWriter> pager_;
 
-  // Whether the number of rows is determined.
-  bool row_count_determined_;
-
-  // The number of rows that should be written in this column chunk.
-  int64_t expected_rows_;
   bool has_dictionary_;
   Encoding::type encoding_;
   const WriterProperties* properties_;
@@ -169,7 +161,7 @@ class PARQUET_EXPORT ColumnWriter {
   int64_t num_buffered_encoded_values_;
 
   // Total number of rows written with this ColumnWriter
-  int num_rows_;
+  int rows_written_;
 
   // Records the total number of bytes written by the serializer
   int64_t total_bytes_written_;
@@ -202,8 +194,7 @@ class PARQUET_EXPORT TypedColumnWriter : public ColumnWriter {
   typedef typename DType::c_type T;
 
   TypedColumnWriter(ColumnChunkMetaDataBuilder* metadata,
-                    std::unique_ptr<PageWriter> pager, bool row_count_determined,
-                    int64_t expected_rows, Encoding::type encoding,
+                    std::unique_ptr<PageWriter> pager, Encoding::type encoding,
                     const WriterProperties* properties);
 
   // Write a batch of repetition levels, definition levels, and values to the

--- a/src/parquet/file/file-metadata-test.cc
+++ b/src/parquet/file/file-metadata-test.cc
@@ -55,8 +55,8 @@ TEST(Metadata, TestBuildAccess) {
       .set_max(std::string(reinterpret_cast<const char*>(&float_max), 4));
 
   auto f_builder = FileMetaDataBuilder::Make(&schema, props);
-  auto rg1_builder = f_builder->AppendRowGroup(nrows / 2);
-  auto rg2_builder = f_builder->AppendRowGroup(nrows / 2);
+  auto rg1_builder = f_builder->AppendRowGroup();
+  auto rg2_builder = f_builder->AppendRowGroup();
 
   // Write the metadata
   // rowgroup1 metadata
@@ -67,6 +67,8 @@ TEST(Metadata, TestBuildAccess) {
   col2_builder->SetStatistics(true, stats_float);
   col1_builder->Finish(nrows / 2, 4, 0, 10, 512, 600, true, false);
   col2_builder->Finish(nrows / 2, 24, 0, 30, 512, 600, true, false);
+
+  rg1_builder->set_num_rows(nrows / 2);
   rg1_builder->Finish(1024);
 
   // rowgroup2 metadata
@@ -77,6 +79,8 @@ TEST(Metadata, TestBuildAccess) {
   col2_builder->SetStatistics(true, stats_float);
   col1_builder->Finish(nrows / 2, 6, 0, 10, 512, 600, true, false);
   col2_builder->Finish(nrows / 2, 16, 0, 26, 512, 600, true, false);
+
+  rg2_builder->set_num_rows(nrows / 2);
   rg2_builder->Finish(1024);
 
   // Read the metadata

--- a/src/parquet/file/file-serialize-test.cc
+++ b/src/parquet/file/file-serialize-test.cc
@@ -41,13 +41,17 @@ class TestSerialize : public PrimitiveTypedTest<TestType> {
 
   void SetUp() {
     num_columns_ = 4;
+    num_rowgroups_ = 2;
+    rows_per_rowgroup_ = 50;
     this->SetUpSchema(Repetition::OPTIONAL, num_columns_);
   }
 
  protected:
   int num_columns_;
+  int num_rowgroups_;
+  int rows_per_rowgroup_;
 
-  void FileSerializeTest(Compression::type codec_type) {
+  void FileSerializeTest_(Compression::type codec_type, bool row_count_known) {
     std::shared_ptr<InMemoryOutputStream> sink(new InMemoryOutputStream());
     auto gnode = std::static_pointer_cast<GroupNode>(this->node_);
 
@@ -59,49 +63,68 @@ class TestSerialize : public PrimitiveTypedTest<TestType> {
     std::shared_ptr<WriterProperties> writer_properties = prop_builder.build();
 
     auto file_writer = ParquetFileWriter::Open(sink, gnode, writer_properties);
-    auto row_group_writer = file_writer->AppendRowGroup(100);
-
-    this->GenerateData(100);
-    for (int i = 0; i < num_columns_; ++i) {
-      auto column_writer =
+    for (int rg = 0; rg < num_rowgroups_; ++rg) {
+      RowGroupWriter* row_group_writer;
+      if (row_count_known) {
+        row_group_writer = file_writer->AppendRowGroup(rows_per_rowgroup_);
+      } else {
+        row_group_writer = file_writer->AppendRowGroup();
+      }
+      this->GenerateData(rows_per_rowgroup_);
+      for (int col = 0; col < num_columns_; ++col) {
+        auto column_writer =
           static_cast<TypedColumnWriter<TestType>*>(row_group_writer->NextColumn());
-      column_writer->WriteBatch(100, this->def_levels_.data(), nullptr,
-                                this->values_ptr_);
-      column_writer->Close();
-    }
+        column_writer->WriteBatch(rows_per_rowgroup_, this->def_levels_.data(), nullptr,
+                                  this->values_ptr_);
+        column_writer->Close();
+      }
 
-    row_group_writer->Close();
+      row_group_writer->Close();
+    }
     file_writer->Close();
 
     auto buffer = sink->GetBuffer();
+    int num_rows_ = num_rowgroups_ * rows_per_rowgroup_;
+
 
     auto source = std::make_shared<::arrow::io::BufferReader>(buffer);
     auto file_reader = ParquetFileReader::Open(source);
     ASSERT_EQ(num_columns_, file_reader->metadata()->num_columns());
-    ASSERT_EQ(1, file_reader->metadata()->num_row_groups());
-    ASSERT_EQ(100, file_reader->metadata()->num_rows());
+    ASSERT_EQ(num_rowgroups_, file_reader->metadata()->num_row_groups());
+    ASSERT_EQ(num_rows_, file_reader->metadata()->num_rows());
 
-    auto rg_reader = file_reader->RowGroup(0);
-    ASSERT_EQ(num_columns_, rg_reader->metadata()->num_columns());
-    ASSERT_EQ(100, rg_reader->metadata()->num_rows());
-    // Check that the specified compression was actually used.
-    ASSERT_EQ(codec_type, rg_reader->metadata()->ColumnChunk(0)->compression());
+    for (int rg = 0; rg < num_rowgroups_; ++rg) {
+      auto rg_reader = file_reader->RowGroup(rg);
+      ASSERT_EQ(num_columns_, rg_reader->metadata()->num_columns());
+      ASSERT_EQ(rows_per_rowgroup_, rg_reader->metadata()->num_rows());
+      // Check that the specified compression was actually used.
+      ASSERT_EQ(codec_type, rg_reader->metadata()->ColumnChunk(0)->compression());
 
-    int64_t values_read;
+      int64_t values_read;
 
-    for (int i = 0; i < num_columns_; ++i) {
-      std::vector<int16_t> def_levels_out(100);
-      std::vector<int16_t> rep_levels_out(100);
-      auto col_reader =
+      for (int i = 0; i < num_columns_; ++i) {
+        std::vector<int16_t> def_levels_out(rows_per_rowgroup_);
+        std::vector<int16_t> rep_levels_out(rows_per_rowgroup_);
+        auto col_reader =
           std::static_pointer_cast<TypedColumnReader<TestType>>(rg_reader->Column(i));
-      this->SetupValuesOut(100);
-      col_reader->ReadBatch(100, def_levels_out.data(), rep_levels_out.data(),
-                            this->values_out_ptr_, &values_read);
-      this->SyncValuesOut();
-      ASSERT_EQ(100, values_read);
-      ASSERT_EQ(this->values_, this->values_out_);
-      ASSERT_EQ(this->def_levels_, def_levels_out);
+        this->SetupValuesOut(rows_per_rowgroup_);
+        col_reader->ReadBatch(rows_per_rowgroup_, def_levels_out.data(),
+                              rep_levels_out.data(),
+                              this->values_out_ptr_,
+                              &values_read);
+        this->SyncValuesOut();
+        ASSERT_EQ(rows_per_rowgroup_, values_read);
+        ASSERT_EQ(this->values_, this->values_out_);
+        ASSERT_EQ(this->def_levels_, def_levels_out);
+      }
     }
+  }
+  void FileSerializeTest(Compression::type codec_type) {
+    FileSerializeTest_(codec_type, true);
+  }
+
+  void FileSerializeRowCountUnknownTest(Compression::type codec_type) {
+    FileSerializeTest_(codec_type, false);
   }
 };
 
@@ -110,6 +133,10 @@ typedef ::testing::Types<Int32Type, Int64Type, Int96Type, FloatType, DoubleType,
     TestTypes;
 
 TYPED_TEST_CASE(TestSerialize, TestTypes);
+
+TYPED_TEST(TestSerialize, WriteRowGroupUnknownSize) {
+  this->FileSerializeRowCountUnknownTest(Compression::UNCOMPRESSED);
+}
 
 TYPED_TEST(TestSerialize, SmallFileUncompressed) {
   this->FileSerializeTest(Compression::UNCOMPRESSED);

--- a/src/parquet/file/metadata.cc
+++ b/src/parquet/file/metadata.cc
@@ -702,7 +702,13 @@ class RowGroupMetaDataBuilder::RowGroupMetaDataBuilderImpl {
     row_group_->__set_total_byte_size(total_byte_size);
   }
 
+  void __set_num_rows(int64_t num_rows) {
+    row_group_->num_rows = num_rows;
+  }
+
   int num_columns() { return static_cast<int>(row_group_->columns.size()); }
+
+  int64_t num_rows() { return row_group_->num_rows; }
 
  private:
   void InitializeColumns(int ncols) { row_group_->columns.resize(ncols); }
@@ -736,6 +742,14 @@ ColumnChunkMetaDataBuilder* RowGroupMetaDataBuilder::NextColumnChunk() {
 int RowGroupMetaDataBuilder::current_column() const { return impl_->current_column(); }
 
 int RowGroupMetaDataBuilder::num_columns() { return impl_->num_columns(); }
+
+int64_t RowGroupMetaDataBuilder::num_rows() {
+  return impl_->num_rows();
+}
+
+void RowGroupMetaDataBuilder::__set_num_rows(int64_t num_rows) {
+  impl_->__set_num_rows(num_rows);
+}
 
 void RowGroupMetaDataBuilder::Finish(int64_t total_bytes_written) {
   impl_->Finish(total_bytes_written);

--- a/src/parquet/file/metadata.cc
+++ b/src/parquet/file/metadata.cc
@@ -651,13 +651,11 @@ void ColumnChunkMetaDataBuilder::SetStatistics(bool is_signed,
 
 class RowGroupMetaDataBuilder::RowGroupMetaDataBuilderImpl {
  public:
-  explicit RowGroupMetaDataBuilderImpl(int64_t num_rows,
-                                       const std::shared_ptr<WriterProperties>& props,
+  explicit RowGroupMetaDataBuilderImpl(const std::shared_ptr<WriterProperties>& props,
                                        const SchemaDescriptor* schema, uint8_t* contents)
       : properties_(props), schema_(schema), current_column_(0) {
     row_group_ = reinterpret_cast<format::RowGroup*>(contents);
     InitializeColumns(schema->num_columns());
-    row_group_->__set_num_rows(num_rows);
   }
   ~RowGroupMetaDataBuilderImpl() {}
 
@@ -702,9 +700,7 @@ class RowGroupMetaDataBuilder::RowGroupMetaDataBuilderImpl {
     row_group_->__set_total_byte_size(total_byte_size);
   }
 
-  void __set_num_rows(int64_t num_rows) {
-    row_group_->num_rows = num_rows;
-  }
+  void set_num_rows(int64_t num_rows) { row_group_->num_rows = num_rows; }
 
   int num_columns() { return static_cast<int>(row_group_->columns.size()); }
 
@@ -721,17 +717,17 @@ class RowGroupMetaDataBuilder::RowGroupMetaDataBuilderImpl {
 };
 
 std::unique_ptr<RowGroupMetaDataBuilder> RowGroupMetaDataBuilder::Make(
-    int64_t num_rows, const std::shared_ptr<WriterProperties>& props,
-    const SchemaDescriptor* schema_, uint8_t* contents) {
+    const std::shared_ptr<WriterProperties>& props, const SchemaDescriptor* schema_,
+    uint8_t* contents) {
   return std::unique_ptr<RowGroupMetaDataBuilder>(
-      new RowGroupMetaDataBuilder(num_rows, props, schema_, contents));
+      new RowGroupMetaDataBuilder(props, schema_, contents));
 }
 
 RowGroupMetaDataBuilder::RowGroupMetaDataBuilder(
-    int64_t num_rows, const std::shared_ptr<WriterProperties>& props,
-    const SchemaDescriptor* schema_, uint8_t* contents)
+    const std::shared_ptr<WriterProperties>& props, const SchemaDescriptor* schema_,
+    uint8_t* contents)
     : impl_{std::unique_ptr<RowGroupMetaDataBuilderImpl>(
-          new RowGroupMetaDataBuilderImpl(num_rows, props, schema_, contents))} {}
+          new RowGroupMetaDataBuilderImpl(props, schema_, contents))} {}
 
 RowGroupMetaDataBuilder::~RowGroupMetaDataBuilder() {}
 
@@ -743,12 +739,10 @@ int RowGroupMetaDataBuilder::current_column() const { return impl_->current_colu
 
 int RowGroupMetaDataBuilder::num_columns() { return impl_->num_columns(); }
 
-int64_t RowGroupMetaDataBuilder::num_rows() {
-  return impl_->num_rows();
-}
+int64_t RowGroupMetaDataBuilder::num_rows() { return impl_->num_rows(); }
 
-void RowGroupMetaDataBuilder::__set_num_rows(int64_t num_rows) {
-  impl_->__set_num_rows(num_rows);
+void RowGroupMetaDataBuilder::set_num_rows(int64_t num_rows) {
+  impl_->set_num_rows(num_rows);
 }
 
 void RowGroupMetaDataBuilder::Finish(int64_t total_bytes_written) {
@@ -767,10 +761,10 @@ class FileMetaDataBuilder::FileMetaDataBuilderImpl {
   }
   ~FileMetaDataBuilderImpl() {}
 
-  RowGroupMetaDataBuilder* AppendRowGroup(int64_t num_rows) {
+  RowGroupMetaDataBuilder* AppendRowGroup() {
     auto row_group = std::unique_ptr<format::RowGroup>(new format::RowGroup());
     auto row_group_builder = RowGroupMetaDataBuilder::Make(
-        num_rows, properties_, schema_, reinterpret_cast<uint8_t*>(row_group.get()));
+        properties_, schema_, reinterpret_cast<uint8_t*>(row_group.get()));
     RowGroupMetaDataBuilder* row_group_ptr = row_group_builder.get();
     row_group_builders_.push_back(std::move(row_group_builder));
     row_groups_.push_back(std::move(row_group));
@@ -850,8 +844,8 @@ FileMetaDataBuilder::FileMetaDataBuilder(
 
 FileMetaDataBuilder::~FileMetaDataBuilder() {}
 
-RowGroupMetaDataBuilder* FileMetaDataBuilder::AppendRowGroup(int64_t num_rows) {
-  return impl_->AppendRowGroup(num_rows);
+RowGroupMetaDataBuilder* FileMetaDataBuilder::AppendRowGroup() {
+  return impl_->AppendRowGroup();
 }
 
 std::unique_ptr<FileMetaData> FileMetaDataBuilder::Finish() { return impl_->Finish(); }

--- a/src/parquet/file/metadata.h
+++ b/src/parquet/file/metadata.h
@@ -231,7 +231,10 @@ class PARQUET_EXPORT RowGroupMetaDataBuilder {
 
   ColumnChunkMetaDataBuilder* NextColumnChunk();
   int num_columns();
+  int64_t num_rows();
   int current_column() const;
+
+  void __set_num_rows(int64_t num_rows);
 
   // commit the metadata
   void Finish(int64_t total_bytes_written);

--- a/src/parquet/file/metadata.h
+++ b/src/parquet/file/metadata.h
@@ -224,8 +224,8 @@ class PARQUET_EXPORT RowGroupMetaDataBuilder {
  public:
   // API convenience to get a MetaData reader
   static std::unique_ptr<RowGroupMetaDataBuilder> Make(
-      int64_t num_rows, const std::shared_ptr<WriterProperties>& props,
-      const SchemaDescriptor* schema_, uint8_t* contents);
+      const std::shared_ptr<WriterProperties>& props, const SchemaDescriptor* schema_,
+      uint8_t* contents);
 
   ~RowGroupMetaDataBuilder();
 
@@ -234,14 +234,13 @@ class PARQUET_EXPORT RowGroupMetaDataBuilder {
   int64_t num_rows();
   int current_column() const;
 
-  void __set_num_rows(int64_t num_rows);
+  void set_num_rows(int64_t num_rows);
 
   // commit the metadata
   void Finish(int64_t total_bytes_written);
 
  private:
-  explicit RowGroupMetaDataBuilder(int64_t num_rows,
-                                   const std::shared_ptr<WriterProperties>& props,
+  explicit RowGroupMetaDataBuilder(const std::shared_ptr<WriterProperties>& props,
                                    const SchemaDescriptor* schema_, uint8_t* contents);
   // PIMPL Idiom
   class RowGroupMetaDataBuilderImpl;
@@ -257,7 +256,7 @@ class PARQUET_EXPORT FileMetaDataBuilder {
 
   ~FileMetaDataBuilder();
 
-  RowGroupMetaDataBuilder* AppendRowGroup(int64_t num_rows);
+  RowGroupMetaDataBuilder* AppendRowGroup();
 
   // commit the metadata
   std::unique_ptr<FileMetaData> Finish();

--- a/src/parquet/file/writer-internal.h
+++ b/src/parquet/file/writer-internal.h
@@ -75,15 +75,17 @@ class SerializedPageWriter : public PageWriter {
 // RowGroupWriter::Contents implementation for the Parquet file specification
 class RowGroupSerializer : public RowGroupWriter::Contents {
  public:
-  RowGroupSerializer(int64_t num_rows, OutputStream* sink,
+  RowGroupSerializer(OutputStream* sink,
                      RowGroupMetaDataBuilder* metadata,
-                     const WriterProperties* properties)
-      : num_rows_(num_rows),
-        sink_(sink),
+                     const WriterProperties* properties,
+                     bool row_count_determined)
+      : sink_(sink),
         metadata_(metadata),
         properties_(properties),
         total_bytes_written_(0),
-        closed_(false) {}
+        closed_(false),
+        row_count_determined_(row_count_determined),
+        num_rows_(metadata->num_rows()) {}
 
   int num_columns() const override;
   int64_t num_rows() const override;
@@ -93,12 +95,13 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
   void Close() override;
 
  private:
-  int64_t num_rows_;
   OutputStream* sink_;
   RowGroupMetaDataBuilder* metadata_;
   const WriterProperties* properties_;
   int64_t total_bytes_written_;
   bool closed_;
+  bool row_count_determined_;
+  int64_t num_rows_;
 
   std::shared_ptr<ColumnWriter> current_column_writer_;
 };
@@ -116,7 +119,9 @@ class FileSerializer : public ParquetFileWriter::Contents {
 
   void Close() override;
 
+  RowGroupWriter* AppendRowGroup(int64_t num_rows, bool row_count_determined);
   RowGroupWriter* AppendRowGroup(int64_t num_rows) override;
+  RowGroupWriter* AppendRowGroup() override;
 
   const std::shared_ptr<WriterProperties>& properties() const override;
 

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -33,7 +33,6 @@ RowGroupWriter::RowGroupWriter(std::unique_ptr<Contents> contents)
 void RowGroupWriter::Close() {
   if (contents_) {
     contents_->Close();
-    contents_.reset();
   }
 }
 
@@ -107,6 +106,10 @@ void ParquetFileWriter::Close() {
 
 RowGroupWriter* ParquetFileWriter::AppendRowGroup(int64_t num_rows) {
   return contents_->AppendRowGroup(num_rows);
+}
+
+RowGroupWriter* ParquetFileWriter::AppendRowGroup() {
+  return contents_->AppendRowGroup();
 }
 
 const std::shared_ptr<WriterProperties>& ParquetFileWriter::properties() const {

--- a/src/parquet/file/writer.cc
+++ b/src/parquet/file/writer.cc
@@ -104,12 +104,12 @@ void ParquetFileWriter::Close() {
   }
 }
 
-RowGroupWriter* ParquetFileWriter::AppendRowGroup(int64_t num_rows) {
-  return contents_->AppendRowGroup(num_rows);
-}
-
 RowGroupWriter* ParquetFileWriter::AppendRowGroup() {
   return contents_->AppendRowGroup();
+}
+
+RowGroupWriter* ParquetFileWriter::AppendRowGroup(int64_t num_rows) {
+  return AppendRowGroup();
 }
 
 const std::shared_ptr<WriterProperties>& ParquetFileWriter::properties() const {

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -97,6 +97,7 @@ class PARQUET_EXPORT ParquetFileWriter {
     virtual void Close() = 0;
 
     virtual RowGroupWriter* AppendRowGroup(int64_t num_rows) = 0;
+    virtual RowGroupWriter* AppendRowGroup() = 0;
 
     virtual int64_t num_rows() const = 0;
     virtual int num_columns() const = 0;
@@ -144,6 +145,14 @@ class PARQUET_EXPORT ParquetFileWriter {
    * @param num_rows The number of rows that are stored in the new RowGroup
    */
   RowGroupWriter* AppendRowGroup(int64_t num_rows);
+
+  /**
+  * Construct a RowGroupWriter with an arbitrary number of rows.
+  *
+  * Ownership is solely within the ParquetFileWriter. The RowGroupWriter is only valid
+  * until the next call to AppendRowGroup or Close.
+  */
+  RowGroupWriter* AppendRowGroup();
 
   /**
    * Number of columns.

--- a/src/parquet/file/writer.h
+++ b/src/parquet/file/writer.h
@@ -56,14 +56,12 @@ class PARQUET_EXPORT RowGroupWriter {
 
   explicit RowGroupWriter(std::unique_ptr<Contents> contents);
 
-  /**
-   * Construct a ColumnWriter for the indicated row group-relative column.
-   *
-   * Ownership is solely within the RowGroupWriter. The ColumnWriter is only valid
-   * until the next call to NextColumn or Close. As the contents are directly written to
-   * the sink, once a new column is started, the contents of the previous one cannot be
-   * modified anymore.
-   */
+  /// Construct a ColumnWriter for the indicated row group-relative column.
+  ///
+  /// Ownership is solely within the RowGroupWriter. The ColumnWriter is only
+  /// valid until the next call to NextColumn or Close. As the contents are
+  /// directly written to the sink, once a new column is started, the contents
+  /// of the previous one cannot be modified anymore.
   ColumnWriter* NextColumn();
   /// Index of currently written column
   int current_column();
@@ -96,7 +94,9 @@ class PARQUET_EXPORT ParquetFileWriter {
     // Perform any cleanup associated with the file contents
     virtual void Close() = 0;
 
-    virtual RowGroupWriter* AppendRowGroup(int64_t num_rows) = 0;
+    /// \deprecated Since 1.3.0
+    RowGroupWriter* AppendRowGroup(int64_t num_rows);
+
     virtual RowGroupWriter* AppendRowGroup() = 0;
 
     virtual int64_t num_rows() const = 0;
@@ -136,62 +136,45 @@ class PARQUET_EXPORT ParquetFileWriter {
   void Open(std::unique_ptr<Contents> contents);
   void Close();
 
-  /**
-   * Construct a RowGroupWriter for the indicated number of rows.
-   *
-   * Ownership is solely within the ParquetFileWriter. The RowGroupWriter is only valid
-   * until the next call to AppendRowGroup or Close.
-   *
-   * @param num_rows The number of rows that are stored in the new RowGroup
-   */
+  // Construct a RowGroupWriter for the indicated number of rows.
+  //
+  // Ownership is solely within the ParquetFileWriter. The RowGroupWriter is only valid
+  // until the next call to AppendRowGroup or Close.
+  // @param num_rows The number of rows that are stored in the new RowGroup
+  //
+  // \deprecated Since 1.3.0
   RowGroupWriter* AppendRowGroup(int64_t num_rows);
 
-  /**
-  * Construct a RowGroupWriter with an arbitrary number of rows.
-  *
-  * Ownership is solely within the ParquetFileWriter. The RowGroupWriter is only valid
-  * until the next call to AppendRowGroup or Close.
-  */
+  /// Construct a RowGroupWriter with an arbitrary number of rows.
+  ///
+  /// Ownership is solely within the ParquetFileWriter. The RowGroupWriter is only valid
+  /// until the next call to AppendRowGroup or Close.
   RowGroupWriter* AppendRowGroup();
 
-  /**
-   * Number of columns.
-   *
-   * This number is fixed during the lifetime of the writer as it is determined via
-   * the schema.
-   */
+  /// Number of columns.
+  ///
+  /// This number is fixed during the lifetime of the writer as it is determined via
+  /// the schema.
   int num_columns() const;
 
-  /**
-   * Number of rows in the yet started RowGroups.
-   *
-   * Changes on the addition of a new RowGroup.
-   */
+  /// Number of rows in the yet started RowGroups.
+  ///
+  /// Changes on the addition of a new RowGroup.
   int64_t num_rows() const;
 
-  /**
-   * Number of started RowGroups.
-   */
+  /// Number of started RowGroups.
   int num_row_groups() const;
 
-  /**
-   * Configuration passed to the writer, e.g. the used Parquet format version.
-   */
+  /// Configuration passed to the writer, e.g. the used Parquet format version.
   const std::shared_ptr<WriterProperties>& properties() const;
 
-  /**
-    * Returns the file schema descriptor
-    */
+  /// Returns the file schema descriptor
   const SchemaDescriptor* schema() const;
 
-  /**
-   * Returns a column descriptor in schema
-   */
+  /// Returns a column descriptor in schema
   const ColumnDescriptor* descr(int i) const;
 
-  /**
-   * Returns the file custom metadata
-   */
+  /// Returns the file custom metadata
   const std::shared_ptr<const KeyValueMetadata>& key_value_metadata() const;
 
  private:

--- a/src/parquet/statistics-test.cc
+++ b/src/parquet/statistics-test.cc
@@ -138,7 +138,7 @@ class TestRowGroupStatistics : public PrimitiveTypedTest<TestType> {
     std::shared_ptr<WriterProperties> writer_properties =
         WriterProperties::Builder().enable_statistics("column")->build();
     auto file_writer = ParquetFileWriter::Open(sink, gnode, writer_properties);
-    auto row_group_writer = file_writer->AppendRowGroup(num_values);
+    auto row_group_writer = file_writer->AppendRowGroup();
     auto column_writer =
         static_cast<TypedColumnWriter<TestType>*>(row_group_writer->NextColumn());
 
@@ -438,7 +438,7 @@ class TestStatistics : public ::testing::Test {
     auto file_writer = parquet::ParquetFileWriter::Open(parquet_sink_, schema_, props);
 
     // Append a RowGroup with a specific number of rows.
-    auto rg_writer = file_writer->AppendRowGroup(NUM_VALUES);
+    auto rg_writer = file_writer->AppendRowGroup();
 
     this->SetValues();
 


### PR DESCRIPTION
The main change made is that you don't have to specify the size of a row-group upfront when writing it. This is signalled through a "row_count_determined" flag which is threaded through the relevant classes.

The AppendRowGroup(int64_t num_rows) method should have identical behaviour as before.
The AppendRowGroup() method should fix its row group after completing a single column, and enforce all
future columns match that. Empty row groups are still not allowed.

(You'll definitely want to squash these commits. Apologies for the poor git usage.)