### PR TITLE
PARQUET-1085: [C++] Use namespaced macros from arrow/util/macros.h, work around UNUSED rename

### DIFF
--- a/src/parquet/encoding-internal.h
+++ b/src/parquet/encoding-internal.h
@@ -27,6 +27,7 @@
 #include "arrow/util/bit-stream-utils.h"
 #include "arrow/util/bit-util.h"
 #include "arrow/util/cpu-info.h"
+#include "arrow/util/macros.h"
 #include "arrow/util/hash-util.h"
 #include "arrow/util/rle-encoding.h"
 
@@ -490,8 +491,8 @@ class DictEncoder : public Encoder<DType> {
 
   /// The minimum bit width required to encode the currently buffered indices.
   int bit_width() const {
-    if (UNLIKELY(num_entries() == 0)) return 0;
-    if (UNLIKELY(num_entries() == 1)) return 1;
+    if (ARROW_PREDICT_FALSE(num_entries() == 0)) return 0;
+    if (ARROW_PREDICT_FALSE(num_entries() == 1)) return 1;
     return BitUtil::Log2(num_entries());
   }
 
@@ -639,7 +640,7 @@ inline void DictEncoder<DType>::Put(const typename DType::c_type& v) {
     hash_slots_[j] = index;
     AddDictKey(v);
 
-    if (UNLIKELY(static_cast<int>(uniques_.size()) > hash_table_size_ * MAX_HASH_LOAD)) {
+    if (ARROW_PREDICT_FALSE(static_cast<int>(uniques_.size()) > hash_table_size_ * MAX_HASH_LOAD)) {
       DoubleTableSize();
     }
   }
@@ -693,7 +694,7 @@ inline void DictEncoder<DType>::AddDictKey(const typename DType::c_type& v) {
 template <>
 inline void DictEncoder<ByteArrayType>::AddDictKey(const ByteArray& v) {
   uint8_t* heap = pool_->Allocate(v.len);
-  if (UNLIKELY(v.len > 0 && heap == nullptr)) {
+  if (ARROW_PREDICT_FALSE(v.len > 0 && heap == nullptr)) {
     throw ParquetException("out of memory");
   }
   memcpy(heap, v.ptr, v.len);
@@ -704,7 +705,7 @@ inline void DictEncoder<ByteArrayType>::AddDictKey(const ByteArray& v) {
 template <>
 inline void DictEncoder<FLBAType>::AddDictKey(const FixedLenByteArray& v) {
   uint8_t* heap = pool_->Allocate(type_length_);
-  if (UNLIKELY(type_length_ > 0 && heap == nullptr)) {
+  if (ARROW_PREDICT_FALSE(type_length_ > 0 && heap == nullptr)) {
     throw ParquetException("out of memory");
   }
   memcpy(heap, v.ptr, type_length_);
@@ -830,7 +831,7 @@ class DeltaBitPackDecoder : public Decoder<DType> {
     max_values = std::min(max_values, num_values_);
     const uint8_t* bit_width_data = delta_bit_widths_->data();
     for (int i = 0; i < max_values; ++i) {
-      if (UNLIKELY(values_current_mini_block_ == 0)) {
+      if (ARROW_PREDICT_FALSE(values_current_mini_block_ == 0)) {
         ++mini_block_idx_;
         if (mini_block_idx_ < static_cast<size_t>(delta_bit_widths_->size())) {
           delta_bit_width_ = bit_width_data[mini_block_idx_];

--- a/src/parquet/encoding-internal.h
+++ b/src/parquet/encoding-internal.h
@@ -27,8 +27,8 @@
 #include "arrow/util/bit-stream-utils.h"
 #include "arrow/util/bit-util.h"
 #include "arrow/util/cpu-info.h"
-#include "arrow/util/macros.h"
 #include "arrow/util/hash-util.h"
+#include "arrow/util/macros.h"
 #include "arrow/util/rle-encoding.h"
 
 #include "parquet/encoding.h"
@@ -640,7 +640,8 @@ inline void DictEncoder<DType>::Put(const typename DType::c_type& v) {
     hash_slots_[j] = index;
     AddDictKey(v);
 
-    if (ARROW_PREDICT_FALSE(static_cast<int>(uniques_.size()) > hash_table_size_ * MAX_HASH_LOAD)) {
+    if (ARROW_PREDICT_FALSE(static_cast<int>(uniques_.size()) >
+                            hash_table_size_ * MAX_HASH_LOAD)) {
       DoubleTableSize();
     }
   }

--- a/src/parquet/exception.h
+++ b/src/parquet/exception.h
@@ -26,6 +26,11 @@
 
 #include "parquet/util/visibility.h"
 
+// PARQUET-1085
+#if !defined(ARROW_UNUSED)
+#define ARROW_UNUSED(x) UNUSED(x)
+#endif
+
 #define PARQUET_CATCH_NOT_OK(s)                    \
   try {                                            \
     (s);                                           \
@@ -36,7 +41,7 @@
 #define PARQUET_IGNORE_NOT_OK(s) \
   do {                           \
     ::arrow::Status _s = (s);    \
-    UNUSED(_s);                  \
+    ARROW_UNUSED(_s);            \
   } while (0)
 
 #define PARQUET_THROW_NOT_OK(s)                     \

--- a/src/parquet/util/memory.cc
+++ b/src/parquet/util/memory.cc
@@ -128,7 +128,7 @@ uint8_t* ChunkedAllocator::Allocate(int size) {
       num_bytes + chunks_[current_chunk_idx_].allocated_bytes >
           chunks_[current_chunk_idx_].size) {
     // If we couldn't allocate a new chunk, return NULL.
-    if (UNLIKELY(!FindChunk(num_bytes))) return NULL;
+    if (ARROW_PREDICT_FALSE(!FindChunk(num_bytes))) return NULL;
   }
   ChunkInfo& info = chunks_[current_chunk_idx_];
   uint8_t* result = info.data + info.allocated_bytes;
@@ -195,7 +195,7 @@ bool ChunkedAllocator::FindChunk(int64_t min_size) {
     // Allocate a new chunk. Return early if malloc fails.
     uint8_t* buf = nullptr;
     PARQUET_THROW_NOT_OK(pool_->Allocate(chunk_size, &buf));
-    if (UNLIKELY(buf == NULL)) {
+    if (ARROW_PREDICT_FALSE(buf == NULL)) {
       DCHECK_EQ(current_chunk_idx_, static_cast<int>(chunks_.size()));
       current_chunk_idx_ = static_cast<int>(chunks_.size()) - 1;
       return false;


### PR DESCRIPTION
UNUSED being renamed to ARROW_UNUSED, so I work around this. I also account for LIKELY/UNLIKELY disappearing because ARROW_PREDICT_TRUE/FALSE were already in Arrow 0.6.0. We can always give these distinct names when used inside parquet-cpp but seems OK for now