### PR TITLE
PARQUET-1087: Add ScanContents function to arrow::FileReader that catches Parquet exceptions

### DIFF
--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -214,6 +214,8 @@ class FileReader::Impl {
 
   void set_num_threads(int num_threads) { num_threads_ = num_threads; }
 
+  ParquetFileReader* reader() { return reader_.get(); }
+
  private:
   MemoryPool* pool_;
   std::unique_ptr<ParquetFileReader> reader_;
@@ -625,6 +627,16 @@ Status FileReader::ReadRowGroup(int i, const std::vector<int>& indices,
 int FileReader::num_row_groups() const { return impl_->num_row_groups(); }
 
 void FileReader::set_num_threads(int num_threads) { impl_->set_num_threads(num_threads); }
+
+Status FileReader::ScanContents(std::vector<int> columns, const int32_t column_batch_size,
+                                int64_t* num_rows) {
+  try {
+    *num_rows = ScanFileContents(columns, column_batch_size, impl_->reader());
+    return Status::OK();
+  } catch (const ::parquet::ParquetException& e) {
+    return Status::IOError(e.what());
+  }
+}
 
 const ParquetFileReader* FileReader::parquet_reader() const {
   return impl_->parquet_reader();

--- a/src/parquet/arrow/reader.h
+++ b/src/parquet/arrow/reader.h
@@ -146,6 +146,10 @@ class PARQUET_EXPORT FileReader {
 
   ::arrow::Status ReadRowGroup(int i, std::shared_ptr<::arrow::Table>* out);
 
+  /// \brief Scan file contents with one thread, return number of rows
+  ::arrow::Status ScanContents(std::vector<int> columns, const int32_t column_batch_size,
+                               int64_t* num_rows);
+
   int num_row_groups() const;
 
   const ParquetFileReader* parquet_reader() const;

--- a/src/parquet/file/reader.cc
+++ b/src/parquet/file/reader.cc
@@ -153,13 +153,12 @@ int64_t ScanFileContents(std::vector<int> columns, const int32_t column_batch_si
     }
   }
 
-  std::vector<int64_t> total_rows(num_columns);
+  std::vector<int64_t> total_rows(num_columns, 0);
 
   for (int r = 0; r < reader->metadata()->num_row_groups(); ++r) {
     auto group_reader = reader->RowGroup(r);
     int col = 0;
     for (auto i : columns) {
-      total_rows[col] = 0;
       std::shared_ptr<ColumnReader> col_reader = group_reader->Column(i);
       size_t value_byte_size = GetTypeByteSize(col_reader->descr()->physical_type());
       std::vector<uint8_t> values(column_batch_size * value_byte_size);


### PR DESCRIPTION
Also fixes a bug in ScanFileContents re: number of rows returned