### PR TITLE
PARQUET-1096: Update sha{1, 256, 512} checksums per latest ASF release policy

### DIFF
--- a/dev/release/release-candidate
+++ b/dev/release/release-candidate
@@ -216,7 +216,9 @@ pushd ${dist_dir}
   # Create the checksums
   echo "Creating checksums"
   gpg --print-md MD5 ${dist_name}.tar.gz > ${dist_name}.tar.gz.md5
-  shasum ${dist_name}.tar.gz > ${dist_name}.tar.gz.sha
+  sha1sum ${dist_name}.tar.gz > ${dist_name}.tar.gz.sha1
+  sha256sum ${dist_name}.tar.gz > ${dist_name}.tar.gz.sha256
+  sha512sum ${dist_name}.tar.gz > ${dist_name}.tar.gz.sha512
 popd
 
 parquet_svn_rc_url="${parquet_svn_dist_url}/apache-parquet-cpp-${rc_version}"


### PR DESCRIPTION
See http://www.apache.org/dev/release-distribution#sigs-and-sums