### PR TITLE
PARQUET-1098: Install util/comparison.h

### DIFF
--- a/src/parquet/util/CMakeLists.txt
+++ b/src/parquet/util/CMakeLists.txt
@@ -18,6 +18,7 @@
 # Headers: util
 install(FILES
   buffer-builder.h
+  comparison.h
   logging.h
   macros.h
   memory.h


### PR DESCRIPTION
This was breaking third party builds. cc @majetideepak 