### PR TITLE
PARQUET-1111: Fix help for verify-release-candidate

### DIFF
--- a/dev/release/verify-release-candidate
+++ b/dev/release/verify-release-candidate
@@ -71,7 +71,8 @@ case $# in
      verify_rc_num="$2"
      ;;
 
-  *) echo "Usage: $0 RC_VERSION"
+  *) echo "Usage: $0 VERSION RC_NUM"
+     echo "Example to test 1.3.0-rc2: $0 1.3.0 2"
      exit 1
      ;;
 esac


### PR DESCRIPTION
The tool takes 2 parameters, version and rc-num. The help only printed a
single parameter.