### PR TITLE
PARQUET-1180: Fix behaviour of num_children element of primitive nodes

### DIFF
--- a/src/parquet/schema-test.cc
+++ b/src/parquet/schema-test.cc
@@ -47,7 +47,6 @@ static inline SchemaElement NewPrimitive(const std::string& name,
   result.__set_name(name);
   result.__set_repetition_type(repetition);
   result.__set_type(type);
-  result.__set_num_children(0);
 
   return result;
 }

--- a/src/parquet/schema.cc
+++ b/src/parquet/schema.cc
@@ -348,7 +348,6 @@ void PrimitiveNode::ToParquet(void* opaque_element) const {
   format::SchemaElement* element = static_cast<format::SchemaElement*>(opaque_element);
 
   element->__set_name(name_);
-  element->__set_num_children(0);
   element->__set_repetition_type(ToThrift(repetition_));
   if (logical_type_ != LogicalType::NONE) {
     element->__set_converted_type(ToThrift(logical_type_));


### PR DESCRIPTION
Per the parquet.thift spec, for primitive nodes the num_children schema
attibute should remain unset. This is implemeted correctly in parquet-mr
see [1]. However currently parquet-cpp does set the num_children
attribute to 0 if it is a primitive node. This pull requests fixes this
issue and the tests that were relying on this behavior

[1] parquet-mr/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java