### PR TITLE
PARQUET-1193: [CPP] Implement ColumnOrder to support min_value and max_value

### DIFF
--- a/src/parquet/column_writer-test.cc
+++ b/src/parquet/column_writer-test.cc
@@ -219,7 +219,8 @@ void TestPrimitiveWriter<TestType>::ReadColumnFully(Compression::type compressio
 }
 
 template <>
-void TestPrimitiveWriter<Int96Type>::ReadAndCompare(Compression::type compression, int64_t num_rows) {
+void TestPrimitiveWriter<Int96Type>::ReadAndCompare(Compression::type compression,
+                                                    int64_t num_rows) {
   this->SetupValuesOut(num_rows);
   this->ReadColumnFully(compression);
   std::shared_ptr<CompareDefault<Int96Type>> compare;

--- a/src/parquet/column_writer-test.cc
+++ b/src/parquet/column_writer-test.cc
@@ -219,6 +219,23 @@ void TestPrimitiveWriter<TestType>::ReadColumnFully(Compression::type compressio
 }
 
 template <>
+void TestPrimitiveWriter<Int96Type>::ReadAndCompare(Compression::type compression, int64_t num_rows) {
+  this->SetupValuesOut(num_rows);
+  this->ReadColumnFully(compression);
+  std::shared_ptr<CompareDefault<Int96Type>> compare;
+  compare = std::make_shared<CompareDefaultInt96>();
+  for (size_t i = 0; i < this->values_.size(); i++) {
+    if ((*compare)(this->values_[i], this->values_out_[i]) ||
+        (*compare)(this->values_out_[i], this->values_[i])) {
+      std::cout << "Failed at " << i << std::endl;
+    }
+    ASSERT_FALSE((*compare)(this->values_[i], this->values_out_[i]));
+    ASSERT_FALSE((*compare)(this->values_out_[i], this->values_[i]));
+  }
+  ASSERT_EQ(this->values_, this->values_out_);
+}
+
+template <>
 void TestPrimitiveWriter<FLBAType>::ReadColumnFully(Compression::type compression) {
   int64_t total_values = static_cast<int64_t>(this->values_out_.size());
   BuildReader(total_values, compression);

--- a/src/parquet/metadata-test.cc
+++ b/src/parquet/metadata-test.cc
@@ -219,7 +219,7 @@ TEST(ApplicationVersion, Basics) {
 
   ASSERT_EQ(true, version.VersionLt(version1));
 
-  ASSERT_FALSE(version1.HasCorrectStatistics(Type::INT96, SortOrder::SIGNED));
+  ASSERT_FALSE(version1.HasCorrectStatistics(Type::INT96, SortOrder::UNKNOWN));
   ASSERT_TRUE(version.HasCorrectStatistics(Type::INT32, SortOrder::SIGNED));
   ASSERT_FALSE(version.HasCorrectStatistics(Type::BYTE_ARRAY, SortOrder::SIGNED));
   ASSERT_TRUE(version1.HasCorrectStatistics(Type::BYTE_ARRAY, SortOrder::SIGNED));

--- a/src/parquet/metadata.cc
+++ b/src/parquet/metadata.cc
@@ -513,10 +513,9 @@ bool ApplicationVersion::HasCorrectStatistics(Type::type col_type,
   // Parquet cpp version 1.3.0 onwards stats are computed correctly for all types
   if ((application_ != "parquet-cpp") || (VersionLt(PARQUET_CPP_FIXED_STATS_VERSION))) {
     // Only SIGNED are valid
-    if (SortOrder::SIGNED != sort_order) return false;
-
-    // None of the current tools write INT96 Statistics correctly
-    if (col_type == Type::INT96) return false;
+    if (SortOrder::SIGNED != sort_order) {
+      return false;
+    }
 
     // Statistics of other types are OK
     if (col_type != Type::FIXED_LEN_BYTE_ARRAY && col_type != Type::BYTE_ARRAY) {
@@ -527,6 +526,11 @@ bool ApplicationVersion::HasCorrectStatistics(Type::type col_type,
   // parquet-mr during the same time as PARQUET-251, see PARQUET-297
   if (application_ == "unknown") {
     return true;
+  }
+
+  // Unknown sort order has incorrect stats
+  if (SortOrder::UNKNOWN == sort_order) {
+    return false;
   }
 
   // PARQUET-251

--- a/src/parquet/metadata.cc
+++ b/src/parquet/metadata.cc
@@ -363,16 +363,16 @@ class FileMetaData::FileMetaDataImpl {
     std::vector<parquet::ColumnOrder> column_orders;
     if (metadata_->__isset.column_orders) {
       for (auto column_order : metadata_->column_orders) {
-        if (column_order.__isset.TYPE_ORDER) { 
+        if (column_order.__isset.TYPE_ORDER) {
           column_orders.push_back(ColumnOrder::type_defined_);
         } else {
           column_orders.push_back(ColumnOrder::undefined_);
         }
       }
     } else {
-        column_orders.resize(schema_.num_columns(), ColumnOrder::undefined_);
+      column_orders.resize(schema_.num_columns(), ColumnOrder::undefined_);
     }
-    
+
     schema_.updateColumnOrders(column_orders);
   }
   SchemaDescriptor schema_;

--- a/src/parquet/metadata.cc
+++ b/src/parquet/metadata.cc
@@ -831,7 +831,11 @@ class FileMetaDataBuilder::FileMetaDataBuilderImpl {
     metadata_->__set_version(file_version);
     metadata_->__set_created_by(properties_->created_by());
 
-    // Empty TypeDefinedOrder implies choose SortOrder based on LogicalType/PhysicalType
+    // Users cannot set the `ColumnOrder` since we donot not have user defined sort order
+    // in the spec yet.
+    // We always default to `TYPE_DEFINED_ORDER`. We can expose it in
+    // the API once we have user defined sort orders in the Parquet format.
+    // TypeDefinedOrder implies choose SortOrder based on LogicalType/PhysicalType
     format::TypeDefinedOrder type_defined_order;
     format::ColumnOrder column_order;
     column_order.__set_TYPE_ORDER(type_defined_order);

--- a/src/parquet/schema.cc
+++ b/src/parquet/schema.cc
@@ -602,6 +602,38 @@ void SchemaDescriptor::Init(std::unique_ptr<schema::Node> schema) {
   Init(NodePtr(schema.release()));
 }
 
+class SchemaUpdater : public Node::Visitor {
+ public:
+  explicit SchemaUpdater(const std::vector<ColumnOrder>& column_orders)
+      : column_orders_(column_orders), leaf_count_(0) {}
+  virtual ~SchemaUpdater() {}
+
+  void Visit(Node* node) override {
+    if (node->is_group()) {
+      GroupNode* group_node = static_cast<GroupNode*>(node);
+      for (int i = 0; i < group_node->field_count(); ++i) {
+        group_node->field(i)->Visit(this);
+      }
+    } else { // leaf node
+      PrimitiveNode* leaf_node = static_cast<PrimitiveNode*>(node);
+      leaf_node->SetColumnOrder(column_orders_[leaf_count_++]);
+    }
+  }
+
+ private:
+  const std::vector<ColumnOrder>& column_orders_;
+  int leaf_count_;
+};
+
+void SchemaDescriptor::updateColumnOrders(const std::vector<ColumnOrder>& column_orders) {
+  if (static_cast<int>(column_orders.size()) != num_columns()) {
+    throw ParquetException("Malformed schema: not enough ColumnOrder values");
+  }
+  SchemaUpdater visitor(column_orders);
+  const_cast<GroupNode*>(group_node_)->Visit(&visitor);
+}
+
+
 void SchemaDescriptor::Init(const NodePtr& schema) {
   schema_ = schema;
 

--- a/src/parquet/schema.cc
+++ b/src/parquet/schema.cc
@@ -614,7 +614,7 @@ class SchemaUpdater : public Node::Visitor {
       for (int i = 0; i < group_node->field_count(); ++i) {
         group_node->field(i)->Visit(this);
       }
-    } else { // leaf node
+    } else {  // leaf node
       PrimitiveNode* leaf_node = static_cast<PrimitiveNode*>(node);
       leaf_node->SetColumnOrder(column_orders_[leaf_count_++]);
     }
@@ -632,7 +632,6 @@ void SchemaDescriptor::updateColumnOrders(const std::vector<ColumnOrder>& column
   SchemaUpdater visitor(column_orders);
   const_cast<GroupNode*>(group_node_)->Visit(&visitor);
 }
-
 
 void SchemaDescriptor::Init(const NodePtr& schema) {
   schema_ = schema;

--- a/src/parquet/schema.h
+++ b/src/parquet/schema.h
@@ -209,6 +209,10 @@ class PARQUET_EXPORT PrimitiveNode : public Node {
 
   Type::type physical_type() const { return physical_type_; }
 
+  ColumnOrder column_order() const { return column_order_; }
+
+  void SetColumnOrder(ColumnOrder column_order) { column_order_ = column_order; }
+  
   int32_t type_length() const { return type_length_; }
 
   const DecimalMetadata& decimal_metadata() const { return decimal_metadata_; }
@@ -225,7 +229,8 @@ class PARQUET_EXPORT PrimitiveNode : public Node {
   Type::type physical_type_;
   int32_t type_length_;
   DecimalMetadata decimal_metadata_;
-
+  ColumnOrder column_order_;
+  
   // For FIXED_LEN_BYTE_ARRAY
   void SetTypeLength(int32_t length) { type_length_ = length; }
 
@@ -335,6 +340,8 @@ class PARQUET_EXPORT ColumnDescriptor {
 
   LogicalType::type logical_type() const { return primitive_node_->logical_type(); }
 
+  ColumnOrder column_order() const { return primitive_node_->column_order(); }
+
   SortOrder::type sort_order() const {
     return GetSortOrder(logical_type(), physical_type());
   }
@@ -407,10 +414,14 @@ class PARQUET_EXPORT SchemaDescriptor {
 
   std::string ToString() const;
 
+  void updateColumnOrders(const std::vector<ColumnOrder>& column_orders);
+
  private:
   friend class ColumnDescriptor;
 
+  // Root Node
   schema::NodePtr schema_;
+  // Root Node
   const schema::GroupNode* group_node_;
 
   void BuildTree(const schema::NodePtr& node, int16_t max_def_level,

--- a/src/parquet/schema.h
+++ b/src/parquet/schema.h
@@ -212,7 +212,7 @@ class PARQUET_EXPORT PrimitiveNode : public Node {
   ColumnOrder column_order() const { return column_order_; }
 
   void SetColumnOrder(ColumnOrder column_order) { column_order_ = column_order; }
-  
+
   int32_t type_length() const { return type_length_; }
 
   const DecimalMetadata& decimal_metadata() const { return decimal_metadata_; }
@@ -230,7 +230,7 @@ class PARQUET_EXPORT PrimitiveNode : public Node {
   int32_t type_length_;
   DecimalMetadata decimal_metadata_;
   ColumnOrder column_order_;
-  
+
   // For FIXED_LEN_BYTE_ARRAY
   void SetTypeLength(int32_t length) { type_length_ = length; }
 

--- a/src/parquet/statistics-test.cc
+++ b/src/parquet/statistics-test.cc
@@ -277,7 +277,7 @@ void TestRowGroupStatistics<ByteArrayType>::TestMinMaxEncode() {
   ASSERT_EQ(statistics1.max(), statistics2.max());
 }
 
-using TestTypes = ::testing::Types<Int32Type, Int64Type, Int96Type, FloatType, DoubleType,
+using TestTypes = ::testing::Types<Int32Type, Int64Type, FloatType, DoubleType,
                                    ByteArrayType, FLBAType, BooleanType>;
 
 TYPED_TEST_CASE(TestRowGroupStatistics, TestTypes);
@@ -397,7 +397,7 @@ TEST(CorrectStatistics, Basics) {
   ASSERT_TRUE(column_chunk4->is_stats_set());
   auto column_chunk5 = ColumnChunkMetaData::Make(
       reinterpret_cast<const uint8_t*>(&col_chunk), schema.Column(4), &version);
-  ASSERT_TRUE(column_chunk5->is_stats_set());
+  ASSERT_FALSE(column_chunk5->is_stats_set());
   auto column_chunk6 = ColumnChunkMetaData::Make(
       reinterpret_cast<const uint8_t*>(&col_chunk), schema.Column(5), &version);
   ASSERT_TRUE(column_chunk6->is_stats_set());
@@ -478,7 +478,7 @@ class TestStatistics : public ::testing::Test {
   std::vector<EncodedStatistics> stats_;
 };
 
-using CompareTestTypes = ::testing::Types<Int32Type, Int64Type, Int96Type, FloatType,
+using CompareTestTypes = ::testing::Types<Int32Type, Int64Type, FloatType,
                                           DoubleType, ByteArrayType, FLBAType>;
 
 // TYPE::INT32
@@ -535,28 +535,6 @@ void TestStatistics<Int64Type>::SetValues() {
   stats_[1]
       .set_min(std::string(reinterpret_cast<const char*>(&values_[0]), sizeof(T)))
       .set_max(std::string(reinterpret_cast<const char*>(&values_[9]), sizeof(T)));
-}
-
-// TYPE::INT96
-template <>
-void TestStatistics<Int96Type>::AddNodes(std::string name) {
-  // INT96 physical type has only Unsigned Statistics
-  fields_.push_back(schema::PrimitiveNode::Make(name, Repetition::REQUIRED, Type::INT96,
-                                                LogicalType::NONE));
-}
-
-template <>
-void TestStatistics<Int96Type>::SetValues() {
-  for (int i = 0; i < NUM_VALUES; i++) {
-    values_[i].value[0] = i - 5;  // {-5, -4, -3, -2, -1, 0, 1, 2, 3, 4};
-    values_[i].value[1] = i - 5;  // {-5, -4, -3, -2, -1, 0, 1, 2, 3, 4};
-    values_[i].value[2] = i - 5;  // {-5, -4, -3, -2, -1, 0, 1, 2, 3, 4};
-  }
-
-  // Write Int96 min/max values
-  stats_[0]
-      .set_min(std::string(reinterpret_cast<const char*>(&values_[5]), sizeof(T)))
-      .set_max(std::string(reinterpret_cast<const char*>(&values_[4]), sizeof(T)));
 }
 
 // TYPE::FLOAT

--- a/src/parquet/statistics-test.cc
+++ b/src/parquet/statistics-test.cc
@@ -478,8 +478,8 @@ class TestStatistics : public ::testing::Test {
   std::vector<EncodedStatistics> stats_;
 };
 
-using CompareTestTypes = ::testing::Types<Int32Type, Int64Type, FloatType,
-                                          DoubleType, ByteArrayType, FLBAType>;
+using CompareTestTypes = ::testing::Types<Int32Type, Int64Type, FloatType, DoubleType,
+                                          ByteArrayType, FLBAType>;
 
 // TYPE::INT32
 template <>

--- a/src/parquet/test-specialization.h
+++ b/src/parquet/test-specialization.h
@@ -35,13 +35,14 @@ namespace parquet {
 namespace test {
 
 template <>
-void InitValues<bool>(int num_values, vector<bool>& values, vector<uint8_t>& buffer) {
+void inline InitValues<bool>(int num_values, vector<bool>& values,
+                             vector<uint8_t>& buffer) {
   values = flip_coins(num_values, 0);
 }
 
 template <>
-void InitValues<ByteArray>(int num_values, vector<ByteArray>& values,
-                           vector<uint8_t>& buffer) {
+void inline InitValues<ByteArray>(int num_values, vector<ByteArray>& values,
+                                  vector<uint8_t>& buffer) {
   int max_byte_array_len = 12;
   int num_bytes = static_cast<int>(max_byte_array_len + sizeof(uint32_t));
   size_t nbytes = num_values * num_bytes;
@@ -50,14 +51,16 @@ void InitValues<ByteArray>(int num_values, vector<ByteArray>& values,
 }
 
 template <>
-void InitValues<FLBA>(int num_values, vector<FLBA>& values, vector<uint8_t>& buffer) {
+void inline InitValues<FLBA>(int num_values, vector<FLBA>& values,
+                             vector<uint8_t>& buffer) {
   size_t nbytes = num_values * FLBA_LENGTH;
   buffer.resize(nbytes);
   random_fixed_byte_array(num_values, 0, buffer.data(), FLBA_LENGTH, values.data());
 }
 
 template <>
-void InitValues<Int96>(int num_values, vector<Int96>& values, vector<uint8_t>& buffer) {
+void inline InitValues<Int96>(int num_values, vector<Int96>& values,
+                              vector<uint8_t>& buffer) {
   random_Int96_numbers(num_values, 0, std::numeric_limits<int32_t>::min(),
                        std::numeric_limits<int32_t>::max(), values.data());
 }

--- a/src/parquet/types.cc
+++ b/src/parquet/types.cc
@@ -213,8 +213,9 @@ SortOrder::type DefaultSortOrder(Type::type primitive) {
       return SortOrder::SIGNED;
     case Type::BYTE_ARRAY:
     case Type::FIXED_LEN_BYTE_ARRAY:
-    case Type::INT96:
       return SortOrder::UNSIGNED;
+    case Type::INT96:
+      return SortOrder::UNKNOWN;
   }
   return SortOrder::UNKNOWN;
 }

--- a/src/parquet/types.cc
+++ b/src/parquet/types.cc
@@ -213,7 +213,7 @@ SortOrder::type DefaultSortOrder(Type::type primitive) {
       return SortOrder::SIGNED;
     case Type::BYTE_ARRAY:
     case Type::FIXED_LEN_BYTE_ARRAY:
-    case Type::INT96:  // only used for timestamp, which uses unsigned values
+    case Type::INT96:
       return SortOrder::UNSIGNED;
   }
   return SortOrder::UNKNOWN;
@@ -253,5 +253,8 @@ SortOrder::type GetSortOrder(LogicalType::type converted, Type::type primitive) 
   }
   return SortOrder::UNKNOWN;
 }
+
+ColumnOrder ColumnOrder::undefined_ = ColumnOrder(ColumnOrder::UNDEFINED);
+ColumnOrder ColumnOrder::type_defined_ = ColumnOrder(ColumnOrder::TYPE_DEFINED_ORDER);
 
 }  // namespace parquet

--- a/src/parquet/types.h
+++ b/src/parquet/types.h
@@ -132,13 +132,14 @@ struct SortOrder {
 
 class ColumnOrder {
  public:
-  enum type {UNDEFINED, TYPE_DEFINED_ORDER};
-  ColumnOrder(ColumnOrder::type column_order) : column_order_(column_order) {}
+  enum type { UNDEFINED, TYPE_DEFINED_ORDER };
+  explicit ColumnOrder(ColumnOrder::type column_order) : column_order_(column_order) {}
   ColumnOrder() : column_order_(type::TYPE_DEFINED_ORDER) {}
-  ColumnOrder::type get_order() {return column_order_;}
+  ColumnOrder::type get_order() { return column_order_; }
 
   static ColumnOrder undefined_;
   static ColumnOrder type_defined_;
+
  private:
   ColumnOrder::type column_order_;
 };

--- a/src/parquet/types.h
+++ b/src/parquet/types.h
@@ -130,6 +130,19 @@ struct SortOrder {
   enum type { SIGNED, UNSIGNED, UNKNOWN };
 };
 
+class ColumnOrder {
+ public:
+  enum type {UNDEFINED, TYPE_DEFINED_ORDER};
+  ColumnOrder(ColumnOrder::type column_order) : column_order_(column_order) {}
+  ColumnOrder() : column_order_(type::TYPE_DEFINED_ORDER) {}
+  ColumnOrder::type get_order() {return column_order_;}
+
+  static ColumnOrder undefined_;
+  static ColumnOrder type_defined_;
+ private:
+  ColumnOrder::type column_order_;
+};
+
 // ----------------------------------------------------------------------
 
 struct ByteArray {

--- a/src/parquet/types.h
+++ b/src/parquet/types.h
@@ -134,6 +134,7 @@ class ColumnOrder {
  public:
   enum type { UNDEFINED, TYPE_DEFINED_ORDER };
   explicit ColumnOrder(ColumnOrder::type column_order) : column_order_(column_order) {}
+  // Default to Type Defined Order
   ColumnOrder() : column_order_(type::TYPE_DEFINED_ORDER) {}
   ColumnOrder::type get_order() { return column_order_; }
 

--- a/src/parquet/util/comparison.cc
+++ b/src/parquet/util/comparison.cc
@@ -33,8 +33,6 @@ std::shared_ptr<Comparator> Comparator::Make(const ColumnDescriptor* descr) {
         return std::make_shared<CompareDefaultInt32>();
       case Type::INT64:
         return std::make_shared<CompareDefaultInt64>();
-      case Type::INT96:
-        return std::make_shared<CompareDefaultInt96>();
       case Type::FLOAT:
         return std::make_shared<CompareDefaultFloat>();
       case Type::DOUBLE:
@@ -52,8 +50,6 @@ std::shared_ptr<Comparator> Comparator::Make(const ColumnDescriptor* descr) {
         return std::make_shared<CompareUnsignedInt32>();
       case Type::INT64:
         return std::make_shared<CompareUnsignedInt64>();
-      case Type::INT96:
-        return std::make_shared<CompareUnsignedInt96>();
       case Type::BYTE_ARRAY:
         return std::make_shared<CompareUnsignedByteArray>();
       case Type::FIXED_LEN_BYTE_ARRAY:


### PR DESCRIPTION
Changes:

1. Update parquet.thrift format
2. Add ColumnOrder Implementation
3. Make Int96 sort order UNKNOWN 