### PR TITLE
PARQUET-1225: NaN values may lead to incorrect filtering under certai…

### DIFF
--- a/src/parquet/statistics-test.cc
+++ b/src/parquet/statistics-test.cc
@@ -659,16 +659,17 @@ TEST_F(TestStatisticsFLBA, UnknownSortOrder) {
   ASSERT_FALSE(cc_metadata->is_stats_set());
 }
 
-// PARQUET-1225: Float NaN values may lead to incorrect filtering under certain circumstances
+// PARQUET-1225: Float NaN values may lead to incorrect filtering under certain
+// circumstances
 TEST(TestStatisticsFloatNaN, NaNValues) {
   constexpr int NUM_VALUES = 10;
   NodePtr node = PrimitiveNode::Make("nan_float", Repetition::OPTIONAL, Type::FLOAT);
   ColumnDescriptor descr(node, 1, 1);
-  float values[NUM_VALUES] =
-        {std::nanf(""), -4.0f, -3.0f, -2.0f, -1.0f, std::nanf(""), 1.0f, 2.0f, 3.0f, std::nanf("")};
+  float values[NUM_VALUES] = {std::nanf(""), -4.0f, -3.0f, -2.0f, -1.0f,
+                              std::nanf(""), 1.0f,  2.0f,  3.0f,  std::nanf("")};
   float nan_values[NUM_VALUES];
-  for (int i = 0; i < NUM_VALUES; i ++) {
-       nan_values[i] = std::nanf("");
+  for (int i = 0; i < NUM_VALUES; i++) {
+    nan_values[i] = std::nanf("");
   }
 
   // Test values
@@ -709,21 +710,21 @@ TEST(TestStatisticsFloatNaN, NaNValues) {
   ASSERT_EQ(max, 3.0f);
 }
 
-// PARQUET-1225: Float NaN values may lead to incorrect filtering under certain circumstances
+// PARQUET-1225: Float NaN values may lead to incorrect filtering under certain
+// circumstances
 TEST(TestStatisticsFloatNaN, NaNValuesSpaced) {
   constexpr int NUM_VALUES = 10;
   NodePtr node = PrimitiveNode::Make("nan_float", Repetition::OPTIONAL, Type::FLOAT);
   ColumnDescriptor descr(node, 1, 1);
-  float values[NUM_VALUES] =
-        {std::nanf(""), -4.0f, -3.0f, -2.0f, -1.0f, std::nanf(""), 1.0f, 2.0f, 3.0f, std::nanf("")};
+  float values[NUM_VALUES] = {std::nanf(""), -4.0f, -3.0f, -2.0f, -1.0f,
+                              std::nanf(""), 1.0f,  2.0f,  3.0f,  std::nanf("")};
   float nan_values[NUM_VALUES];
-  for (int i = 0; i < NUM_VALUES; i ++) {
-       nan_values[i] = std::nanf("");
+  for (int i = 0; i < NUM_VALUES; i++) {
+    nan_values[i] = std::nanf("");
   }
-  std::vector<uint8_t> valid_bits(
-       BitUtil::RoundUpNumBytes(NUM_VALUES) + 1, 255);
+  std::vector<uint8_t> valid_bits(BitUtil::RoundUpNumBytes(NUM_VALUES) + 1, 255);
 
-  // Test values 
+  // Test values
   TypedRowGroupStatistics<FloatType> nan_stats(&descr);
   nan_stats.UpdateSpaced(&values[0], valid_bits.data(), 0, NUM_VALUES, 0);
   float min = nan_stats.min();
@@ -767,8 +768,8 @@ TEST(TestStatisticsDoubleNaN, NaNValues) {
   NodePtr node = PrimitiveNode::Make("nan_double", Repetition::OPTIONAL, Type::DOUBLE);
   ColumnDescriptor descr(node, 1, 1);
   TypedRowGroupStatistics<DoubleType> nan_stats(&descr);
-  double values[NUM_VALUES] =
-        {std::nan(""), std::nan(""), -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0};
+  double values[NUM_VALUES] = {std::nan(""), std::nan(""), -3.0, -2.0, -1.0,
+                               0.0,          1.0,          2.0,  3.0,  4.0};
   double* values_ptr = &values[0];
   nan_stats.Update(values_ptr, NUM_VALUES, 0);
   double min = nan_stats.min();

--- a/src/parquet/statistics.cc
+++ b/src/parquet/statistics.cc
@@ -128,9 +128,7 @@ struct StatsHelper<T, typename std::enable_if<std::is_floating_point<T>::value>:
     return 0;
   }
 
-  inline bool IsNaN(const T value) {
-    return std::isnan(value);
-  }
+  inline bool IsNaN(const T value) { return std::isnan(value); }
 };
 
 template <typename T>
@@ -222,11 +220,13 @@ void TypedRowGroupStatistics<DType>::UpdateSpaced(const T* values,
   }
 
   // All are NaNs and stats are not set yet
-  if ((i == length) && helper.IsNaN(values[i - 1]) && !has_min_max_) {
+  if ((i == length) && helper.IsNaN(values[i - 1])) {
     // Don't set has_min_max flag since
     // these values must be over-written by valid stats later
-    SetNaN(&min_);
-    SetNaN(&max_);
+    if (!has_min_max_) {
+      SetNaN(&min_);
+      SetNaN(&max_);
+    }
     return;
   }
 

--- a/src/parquet/statistics.cc
+++ b/src/parquet/statistics.cc
@@ -99,16 +99,16 @@ void TypedRowGroupStatistics<DType>::Reset() {
 
 template <typename T, typename Enable = void>
 struct StatsHelper {
-  inline int GetValueBeginOffset(const T* values, int64_t count) { return 0; }
+  inline int64_t GetValueBeginOffset(const T* values, int64_t count) { return 0; }
 
-  inline int GetValueEndOffset(const T* values, int64_t count) { return count; }
+  inline int64_t GetValueEndOffset(const T* values, int64_t count) { return count; }
 
   inline bool IsNaN(const T value) { return false; }
 };
 
 template <typename T>
 struct StatsHelper<T, typename std::enable_if<std::is_floating_point<T>::value>::type> {
-  inline int GetValueBeginOffset(const T* values, int64_t count) {
+  inline int64_t GetValueBeginOffset(const T* values, int64_t count) {
     // Skip NaNs
     for (int64_t i = 0; i < count; i++) {
       if (!std::isnan(values[i])) {
@@ -118,7 +118,7 @@ struct StatsHelper<T, typename std::enable_if<std::is_floating_point<T>::value>:
     return count;
   }
 
-  inline int GetValueEndOffset(const T* values, int64_t count) {
+  inline int64_t GetValueEndOffset(const T* values, int64_t count) {
     // Skip NaNs
     for (int64_t i = (count - 1); i >= 0; i--) {
       if (!std::isnan(values[i])) {

--- a/src/parquet/statistics.h
+++ b/src/parquet/statistics.h
@@ -159,6 +159,7 @@ class TypedRowGroupStatistics : public RowGroupStatistics {
   void Update(const T* values, int64_t num_not_null, int64_t num_null);
   void UpdateSpaced(const T* values, const uint8_t* valid_bits, int64_t valid_bits_spaced,
                     int64_t num_not_null, int64_t num_null);
+  void SetMinMax(const T& min, const T& max);
 
   const T& min() const;
   const T& max() const;


### PR DESCRIPTION
1) `parquet-cpp` does not implement filtering (predicate pushdown). Clients such as Vertica, read the statistics from the metadata and implement their own filtering based on these stats.
Therefore, the read path does not require any changes. We should document that the min/max value can potentially contain NaNs.

2) I made changes to the write path to ignore the NaNs.