### PR TITLE
PARQUET-1209: define ARROW_STATIC when PARQUET_ARROW_LINKAGE is static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -573,7 +573,7 @@ else()
     zstd
   )
 
-  add_definitions(-DARROW_EXPORTING)
+  add_definitions(-DARROW_STATIC)
 
   set(ARROW_LINK_LIBS
     arrow_static


### PR DESCRIPTION
It does not solve the problem in general, but more correct anyway