### PR TITLE
PARQUET-1273: Properly write dictionary values when writing in chunks

### DIFF
--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -1734,30 +1734,28 @@ TEST(TestArrowReadWrite, DictionaryColumnChunkedWrite) {
   // As of the writing of this test, columns of type
   // dictionary are written as their raw/expanded values.
   // The regression was that the whole column was being
-  // written for each chunk. 
+  // written for each chunk.
   using ::arrow::ArrayFromVector;
 
-  std::vector<std::string> values = { "first", "second", "third" };
+  std::vector<std::string> values = {"first", "second", "third"};
   auto type = ::arrow::utf8();
   std::shared_ptr<Array> dict_values;
   ArrayFromVector<::arrow::StringType, std::string>(values, &dict_values);
 
   auto dict_type = ::arrow::dictionary(::arrow::int32(), dict_values);
   auto f0 = field("dictionary", dict_type);
-  std::vector<std::shared_ptr<::arrow::Field> > fields;
+  std::vector<std::shared_ptr<::arrow::Field>> fields;
   fields.emplace_back(f0);
   auto schema = ::arrow::schema(fields);
 
   std::shared_ptr<Array> f0_values, f1_values;
-  ArrayFromVector<::arrow::Int32Type, int32_t>({ 0, 1, 0, 2, 1 }, &f0_values);
-  ArrayFromVector<::arrow::Int32Type, int32_t>({ 2, 0, 1, 0, 2 }, &f1_values);
-  ::arrow::ArrayVector dict_arrays =
-  {
-    std::make_shared<::arrow::DictionaryArray>(dict_type, f0_values),
-    std::make_shared<::arrow::DictionaryArray>(dict_type, f1_values)
-  };
+  ArrayFromVector<::arrow::Int32Type, int32_t>({0, 1, 0, 2, 1}, &f0_values);
+  ArrayFromVector<::arrow::Int32Type, int32_t>({2, 0, 1, 0, 2}, &f1_values);
+  ::arrow::ArrayVector dict_arrays = {
+      std::make_shared<::arrow::DictionaryArray>(dict_type, f0_values),
+      std::make_shared<::arrow::DictionaryArray>(dict_type, f1_values)};
 
-  std::vector<std::shared_ptr<::arrow::Column> > columns;
+  std::vector<std::shared_ptr<::arrow::Column>> columns;
   auto column = MakeColumn("column", dict_arrays, false);
   columns.emplace_back(column);
 
@@ -1765,14 +1763,14 @@ TEST(TestArrowReadWrite, DictionaryColumnChunkedWrite) {
 
   std::shared_ptr<Table> result;
   DoSimpleRoundtrip(table, 1,
-		    // Just need to make sure that we make
-		    // a chunk size that is smaller than the
-		    // total number of values
-		    2, {}, &result);
+                    // Just need to make sure that we make
+                    // a chunk size that is smaller than the
+                    // total number of values
+                    2, {}, &result);
 
-  std::vector<std::string> expected_values = {
-    "first", "second", "first", "third", "second",
-    "third", "first", "second", "first", "third" };
+  std::vector<std::string> expected_values = {"first",  "second", "first", "third",
+                                              "second", "third",  "first", "second",
+                                              "first",  "third"};
   columns.clear();
 
   std::shared_ptr<Array> expected_array;
@@ -1780,16 +1778,17 @@ TEST(TestArrowReadWrite, DictionaryColumnChunkedWrite) {
 
   // The column name gets changed on output to the name of the
   // field, and it also turns into a nullable column
-  columns.emplace_back(MakeColumn("dictionary", expected_array, true));;
+  columns.emplace_back(MakeColumn("dictionary", expected_array, true));
+  ;
   fields.clear();
   fields.emplace_back(::arrow::field("dictionary", ::arrow::utf8()));
   schema = ::arrow::schema(fields);
 
   auto expected_table = Table::Make(schema, columns);
-  
+
   AssertTablesEqual(*expected_table, *result, false);
 }
-  
+
 TEST(TestArrowWrite, CheckChunkSize) {
   const int num_columns = 2;
   const int num_rows = 128;

--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -1779,7 +1779,7 @@ TEST(TestArrowReadWrite, DictionaryColumnChunkedWrite) {
   // The column name gets changed on output to the name of the
   // field, and it also turns into a nullable column
   columns.emplace_back(MakeColumn("dictionary", expected_array, true));
-  ;
+
   fields.clear();
   fields.emplace_back(::arrow::field("dictionary", ::arrow::utf8()));
   schema = ::arrow::schema(fields);

--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -389,9 +389,11 @@ void AssertTablesEqual(const Table& expected, const Table& actual,
     if (!actual.Equals(expected)) {
       for (int i = 0; i < expected.num_columns(); ++i) {
         ss << "Actual column " << i << std::endl;
+	ss << "Column " << i << " type " << actual.column(i)->type()->name() << std::endl;
         PrintColumn(*actual.column(i), &ss);
 
         ss << "Expected column " << i << std::endl;
+	ss << "Column " << i << " type " << expected.column(i)->type()->name() << std::endl;
         PrintColumn(*expected.column(i), &ss);
       }
       FAIL() << ss.str();
@@ -1726,6 +1728,70 @@ TEST(TestArrowReadWrite, TableWithDuplicateColumns) {
   CheckSimpleRoundtrip(table, table->num_rows());
 }
 
+TEST(TestArrowReadWrite, DictionaryColumnChunkedWrite) {
+  // This is a regression test for this:
+  //
+  // https://issues.apache.org/jira/browse/ARROW-1938
+  //
+  // As of the writing of this test, columns of type
+  // dictionary are written as their raw/expanded values.
+  // The regression was that the whole column was being
+  // written for each chunk. 
+  using ::arrow::ArrayFromVector;
+
+  std::vector<std::string> values = { "first", "second", "third" };
+  auto type = ::arrow::utf8();
+  std::shared_ptr<Array> dict_values;
+  ArrayFromVector<::arrow::StringType, std::string>(values, &dict_values);
+
+  auto dict_type = ::arrow::dictionary(::arrow::int32(), dict_values);
+  auto f0 = field("dictionary", dict_type);
+  std::vector<std::shared_ptr<::arrow::Field> > fields;
+  fields.emplace_back(f0);
+  auto schema = ::arrow::schema(fields);
+
+  std::shared_ptr<Array> f0_values, f1_values;
+  ArrayFromVector<::arrow::Int32Type, int32_t>({ 0, 1, 0, 2, 1 }, &f0_values);
+  ArrayFromVector<::arrow::Int32Type, int32_t>({ 2, 0, 1, 0, 2 }, &f1_values);
+  ::arrow::ArrayVector dict_arrays =
+  {
+    std::make_shared<::arrow::DictionaryArray>(dict_type, f0_values),
+    std::make_shared<::arrow::DictionaryArray>(dict_type, f1_values)
+  };
+
+  std::vector<std::shared_ptr<::arrow::Column> > columns;
+  auto column = MakeColumn("column", dict_arrays, false);
+  columns.emplace_back(column);
+
+  auto table = Table::Make(schema, columns);
+
+  std::shared_ptr<Table> result;
+  DoSimpleRoundtrip(table, 1,
+		    // Just need to make sure that we make
+		    // a chunk size that is smaller than the
+		    // total number of values
+		    2, {}, &result);
+
+  std::vector<std::string> expected_values = {
+    "first", "second", "first", "third", "second",
+    "third", "first", "second", "first", "third" };
+  columns.clear();
+
+  std::shared_ptr<Array> expected_array;
+  ArrayFromVector<::arrow::StringType, std::string>(expected_values, &expected_array);
+
+  // The column name gets changed on output to the name of the
+  // field, and it also turns into a nullable column
+  columns.emplace_back(MakeColumn("dictionary", expected_array, true));;
+  fields.clear();
+  fields.emplace_back(::arrow::field("dictionary", ::arrow::utf8()));
+  schema = ::arrow::schema(fields);
+
+  auto expected_table = Table::Make(schema, columns);
+  
+  AssertTablesEqual(*expected_table, *result, false);
+}
+  
 TEST(TestArrowWrite, CheckChunkSize) {
   const int num_columns = 2;
   const int num_rows = 128;

--- a/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -389,11 +389,9 @@ void AssertTablesEqual(const Table& expected, const Table& actual,
     if (!actual.Equals(expected)) {
       for (int i = 0; i < expected.num_columns(); ++i) {
         ss << "Actual column " << i << std::endl;
-	ss << "Column " << i << " type " << actual.column(i)->type()->name() << std::endl;
         PrintColumn(*actual.column(i), &ss);
 
         ss << "Expected column " << i << std::endl;
-	ss << "Column " << i << " type " << expected.column(i)->type()->name() << std::endl;
         PrintColumn(*expected.column(i), &ss);
       }
       FAIL() << ss.str();

--- a/src/parquet/arrow/writer.cc
+++ b/src/parquet/arrow/writer.cc
@@ -962,7 +962,7 @@ class FileWriter::Impl {
       ::arrow::compute::Datum cast_output;
       RETURN_NOT_OK(Cast(&ctx, cast_input, dict_type.dictionary()->type(), CastOptions(),
                          &cast_output));
-      return WriteColumnChunk(cast_output.chunked_array(), 0, data->length());
+      return WriteColumnChunk(cast_output.chunked_array(), offset, size);
     }
 
     ColumnWriter* column_writer;


### PR DESCRIPTION
The error was reported here: https://issues.apache.org/jira/browse/ARROW-1938.

Because dictionary types are not supported in writing yet, the code converts the dictionary column to the actual values first before writing. However, the existing code was accidentally using zero as the offset and the length of the column as the size. This resulted in writing all of the column values for each chunk of the column that was supposed to be written.

The fix is to pass the offset and size when recursively calling through to WriteColumnChunk with the "flattened" data. 