### PR TITLE
PARQUET-1283: [C++] Remove trailing space for string and int96 statis…

### DIFF
--- a/src/parquet/types-test.cc
+++ b/src/parquet/types-test.cc
@@ -96,19 +96,19 @@ TEST(TypePrinter, StatisticsTypes) {
   Int96 Int96_max = {{2048, 4096, 8192}};
   smin = std::string(reinterpret_cast<char*>(&Int96_min), sizeof(Int96));
   smax = std::string(reinterpret_cast<char*>(&Int96_max), sizeof(Int96));
-  ASSERT_STREQ("1024 2048 4096 ", FormatStatValue(Type::INT96, smin.c_str()).c_str());
-  ASSERT_STREQ("2048 4096 8192 ", FormatStatValue(Type::INT96, smax.c_str()).c_str());
+  ASSERT_STREQ("1024 2048 4096", FormatStatValue(Type::INT96, smin.c_str()).c_str());
+  ASSERT_STREQ("2048 4096 8192", FormatStatValue(Type::INT96, smax.c_str()).c_str());
 
   smin = std::string("abcdef");
   smax = std::string("ijklmnop");
-  ASSERT_STREQ("abcdef ", FormatStatValue(Type::BYTE_ARRAY, smin.c_str()).c_str());
-  ASSERT_STREQ("ijklmnop ", FormatStatValue(Type::BYTE_ARRAY, smax.c_str()).c_str());
+  ASSERT_STREQ("abcdef", FormatStatValue(Type::BYTE_ARRAY, smin.c_str()).c_str());
+  ASSERT_STREQ("ijklmnop", FormatStatValue(Type::BYTE_ARRAY, smax.c_str()).c_str());
 
   smin = std::string("abcdefgh");
   smax = std::string("ijklmnop");
-  ASSERT_STREQ("abcdefgh ",
+  ASSERT_STREQ("abcdefgh",
                FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smin.c_str()).c_str());
-  ASSERT_STREQ("ijklmnop ",
+  ASSERT_STREQ("ijklmnop",
                FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smax.c_str()).c_str());
 }
 

--- a/src/parquet/types.cc
+++ b/src/parquet/types.cc
@@ -43,17 +43,16 @@ std::string FormatStatValue(Type::type parquet_type, const char* val) {
       result << reinterpret_cast<const float*>(val)[0];
       break;
     case Type::INT96: {
-      for (int i = 0; i < 3; i++) {
-        result << reinterpret_cast<const int32_t*>(val)[i] << " ";
-      }
+      auto const i32_val = reinterpret_cast<const int32_t*>(val);
+      result << i32_val[0] << " " << i32_val[1] << " " << i32_val[2];
       break;
     }
     case Type::BYTE_ARRAY: {
-      result << val << " ";
+      result << val;
       break;
     }
     case Type::FIXED_LEN_BYTE_ARRAY: {
-      result << val << " ";
+      result << val;
       break;
     }
     default:


### PR DESCRIPTION
…tics

Prevent the function FormatStatValue from adding a trailing space
to the formatted statistics of strings and int96.