### PR TITLE
PARQUET-1315: ColumnChunkMetaData.has_dictionary_page() should return…

### DIFF
--- a/src/parquet/metadata.cc
+++ b/src/parquet/metadata.cc
@@ -141,7 +141,7 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
 
   const std::vector<Encoding::type>& encodings() const { return encodings_; }
 
-  inline int64_t has_dictionary_page() const {
+  inline bool has_dictionary_page() const {
     return column_->meta_data.__isset.dictionary_page_offset;
   }
 
@@ -206,7 +206,7 @@ std::shared_ptr<RowGroupStatistics> ColumnChunkMetaData::statistics() const {
 
 bool ColumnChunkMetaData::is_stats_set() const { return impl_->is_stats_set(); }
 
-int64_t ColumnChunkMetaData::has_dictionary_page() const {
+bool ColumnChunkMetaData::has_dictionary_page() const {
   return impl_->has_dictionary_page();
 }
 

--- a/src/parquet/metadata.h
+++ b/src/parquet/metadata.h
@@ -108,7 +108,7 @@ class PARQUET_EXPORT ColumnChunkMetaData {
   std::shared_ptr<RowGroupStatistics> statistics() const;
   Compression::type compression() const;
   const std::vector<Encoding::type>& encodings() const;
-  int64_t has_dictionary_page() const;
+  bool has_dictionary_page() const;
   int64_t dictionary_page_offset() const;
   int64_t data_page_offset() const;
   int64_t index_page_offset() const;


### PR DESCRIPTION
… bool, not int64_t