### PR TITLE
PARQUET-1334: [C++] memory_map parameter seems missleading in parquet file opener

### DIFF
--- a/src/parquet/file_reader.cc
+++ b/src/parquet/file_reader.cc
@@ -273,14 +273,14 @@ std::unique_ptr<ParquetFileReader> ParquetFileReader::OpenFile(
     const std::shared_ptr<FileMetaData>& metadata) {
   std::shared_ptr<::arrow::io::ReadableFileInterface> source;
   if (memory_map) {
-    std::shared_ptr<::arrow::io::ReadableFile> handle;
-    PARQUET_THROW_NOT_OK(
-        ::arrow::io::ReadableFile::Open(path, props.memory_pool(), &handle));
-    source = handle;
-  } else {
     std::shared_ptr<::arrow::io::MemoryMappedFile> handle;
     PARQUET_THROW_NOT_OK(
         ::arrow::io::MemoryMappedFile::Open(path, ::arrow::io::FileMode::READ, &handle));
+    source = handle;
+  } else {
+    std::shared_ptr<::arrow::io::ReadableFile> handle;
+    PARQUET_THROW_NOT_OK(
+        ::arrow::io::ReadableFile::Open(path, props.memory_pool(), &handle));
     source = handle;
   }
 


### PR DESCRIPTION
If memory_map parameter is true, normal file operation is executed, while in negative case, the according memory mapped file operation happens. Seems either be used via inverted logic or being bug.