### PR TITLE
account for total_size being 0, having no dictionary entries to allocate for

### DIFF
--- a/src/parquet/encoding-internal.h
+++ b/src/parquet/encoding-internal.h
@@ -398,9 +398,11 @@ inline void DictionaryDecoder<ByteArrayType>::SetDict(
   for (int i = 0; i < num_dictionary_values; ++i) {
     total_size += dictionary_[i].len;
   }
-  PARQUET_THROW_NOT_OK(byte_array_data_->Resize(total_size, false));
-  int offset = 0;
+  if (total_size > 0) {
+    PARQUET_THROW_NOT_OK(byte_array_data_->Resize(total_size, false));
+  }
 
+  int offset = 0;
   uint8_t* bytes_data = byte_array_data_->mutable_data();
   for (int i = 0; i < num_dictionary_values; ++i) {
     memcpy(bytes_data + offset, dictionary_[i].ptr, dictionary_[i].len);


### PR DESCRIPTION
The call with size 0 ends up in arrows memory_pool, https://github.com/apache/arrow/blob/884474ca5ca1b8da55c0b23eb7cb784c2cd9bdb4/cpp/src/arrow/memory_pool.cc#L50, and the according allocation fails. See according documentation, https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-malloc. Only happens on Windows environment, as posix_memalign seems to handle 0 inputs in unix environments.