### PR TITLE
PARQUET-1323: Fix compiler warnings on clang-6

### DIFF
--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -165,7 +165,7 @@ class RowGroupRecordBatchReader : public ::arrow::RecordBatchReader {
         file_reader_(reader),
         next_row_group_(0) {}
 
-  ~RowGroupRecordBatchReader() {}
+  ~RowGroupRecordBatchReader() override {}
 
   std::shared_ptr<::arrow::Schema> schema() const override { return schema_; }
 

--- a/src/parquet/metadata.cc
+++ b/src/parquet/metadata.cc
@@ -66,7 +66,7 @@ static std::shared_ptr<RowGroupStatistics> MakeTypedColumnStats(
 
 std::shared_ptr<RowGroupStatistics> MakeColumnStats(
     const format::ColumnMetaData& meta_data, const ColumnDescriptor* descr) {
-  switch (meta_data.type) {
+  switch (static_cast<Type::type>(meta_data.type)) {
     case Type::BOOLEAN:
       return MakeTypedColumnStats<BooleanType>(meta_data, descr);
     case Type::INT32:

--- a/src/parquet/schema.cc
+++ b/src/parquet/schema.cc
@@ -690,8 +690,7 @@ ColumnDescriptor::ColumnDescriptor(const schema::NodePtr& node,
                                    const SchemaDescriptor* schema_descr)
     : node_(node),
       max_definition_level_(max_definition_level),
-      max_repetition_level_(max_repetition_level),
-      schema_descr_(schema_descr) {
+      max_repetition_level_(max_repetition_level) {
   if (!node_->is_primitive()) {
     throw ParquetException("Must be a primitive type");
   }

--- a/src/parquet/schema.h
+++ b/src/parquet/schema.h
@@ -369,11 +369,6 @@ class PARQUET_EXPORT ColumnDescriptor {
 
   int16_t max_definition_level_;
   int16_t max_repetition_level_;
-
-  // When this descriptor is part of a real schema (and not being used for
-  // testing purposes), maintain a link back to the parent SchemaDescriptor to
-  // enable reverse graph traversals
-  const SchemaDescriptor* schema_descr_;
 };
 
 // Container for the converted Parquet schema with a computed information from


### PR DESCRIPTION
The `schema_descr_` field was unused