### PR TITLE
PARQUET-1348: Add ability to write FileMetaData in arrow FileWriter

### DIFF
--- a/src/parquet/arrow/writer.cc
+++ b/src/parquet/arrow/writer.cc
@@ -1092,6 +1092,19 @@ Status FileWriter::Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool
   return Open(schema, pool, wrapper, properties, arrow_properties, writer);
 }
 
+Status FileWriter::WriteMetaData(const std::unique_ptr<FileMetaData>& fileMetaData,
+                                 const std::shared_ptr<OutputStream>& sink) {
+  ParquetFileWriter::WriteMetaData(sink, fileMetaData);
+  return Status::OK();
+}
+
+Status FileWriter::WriteMetaData(const std::unique_ptr<FileMetaData>& fileMetaData,
+                                 const std::shared_ptr<::arrow::io::OutputStream>& sink) {
+  auto wrapper = std::make_shared<ArrowOutputStream>(sink);
+  return WriteMetaData(fileMetaData, wrapper);
+}
+
+
 namespace {}  // namespace
 
 Status FileWriter::WriteTable(const Table& table, int64_t chunk_size) {

--- a/src/parquet/arrow/writer.h
+++ b/src/parquet/arrow/writer.h
@@ -132,6 +132,14 @@ class PARQUET_EXPORT FileWriter {
       const std::shared_ptr<ArrowWriterProperties>& arrow_properties,
       std::unique_ptr<FileWriter>* writer);
 
+  static ::arrow::Status WriteMetaData(
+      const std::unique_ptr<FileMetaData>& fileMetaData,
+      const std::shared_ptr<OutputStream>& sink);
+
+  static ::arrow::Status WriteMetaData(
+      const std::unique_ptr<FileMetaData>& fileMetaData,
+      const std::shared_ptr<::arrow::io::OutputStream>& sink);
+
   /// \brief Write a Table to Parquet.
   ::arrow::Status WriteTable(const ::arrow::Table& table, int64_t chunk_size);
 

--- a/src/parquet/file_writer.h
+++ b/src/parquet/file_writer.h
@@ -133,6 +133,14 @@ class PARQUET_EXPORT ParquetFileWriter {
       const std::shared_ptr<WriterProperties>& properties = default_writer_properties(),
       const std::shared_ptr<const KeyValueMetadata>& key_value_metadata = nullptr);
 
+  static void WriteMetaData(
+          const std::shared_ptr<::arrow::io::OutputStream> &sink,
+          const std::unique_ptr<FileMetaData> &fileMetaData);
+
+  static void WriteMetaData(
+          const std::shared_ptr<OutputStream> &sink,
+          const std::unique_ptr<FileMetaData> &fileMetaData);
+
   void Open(std::unique_ptr<Contents> contents);
   void Close();
 


### PR DESCRIPTION
I used static functions since there was no better way I could see