### PR TITLE
PARQUET-1360: Use conforming API style, variable names in WriteFileMetaData functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ enable_testing()
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")
 set(BUILD_SUPPORT_DIR "${CMAKE_SOURCE_DIR}/build-support")
 
-set(CLANG_FORMAT_VERSION "5.0")
+set(CLANG_FORMAT_VERSION "6.0")
 find_package(ClangTools)
 if ("$ENV{CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "1" OR CLANG_TIDY_FOUND)
   # Generate a Clang compile_commands.json "compilation database" file for use

--- a/src/parquet/arrow/arrow-schema-test.cc
+++ b/src/parquet/arrow/arrow-schema-test.cc
@@ -62,8 +62,8 @@ class TestConvertParquetSchema : public ::testing::Test {
     for (int i = 0; i < expected_schema->num_fields(); ++i) {
       auto lhs = result_schema_->field(i);
       auto rhs = expected_schema->field(i);
-      EXPECT_TRUE(lhs->Equals(rhs)) << i << " " << lhs->ToString()
-                                    << " != " << rhs->ToString();
+      EXPECT_TRUE(lhs->Equals(rhs))
+          << i << " " << lhs->ToString() << " != " << rhs->ToString();
     }
   }
 
@@ -607,9 +607,10 @@ TEST_F(TestConvertParquetSchema, ParquetRepeatedNestedSchema) {
     auto inner_group_type = std::make_shared<::arrow::StructType>(inner_group_fields);
     auto outer_group_fields = {
         std::make_shared<Field>("leaf2", INT32, true),
-        std::make_shared<Field>("innerGroup", ::arrow::list(std::make_shared<Field>(
-                                                  "innerGroup", inner_group_type, false)),
-                                false)};
+        std::make_shared<Field>(
+            "innerGroup",
+            ::arrow::list(std::make_shared<Field>("innerGroup", inner_group_type, false)),
+            false)};
     auto outer_group_type = std::make_shared<::arrow::StructType>(outer_group_fields);
 
     arrow_fields.push_back(std::make_shared<Field>("leaf1", INT32, true));

--- a/src/parquet/arrow/reader.cc
+++ b/src/parquet/arrow/reader.cc
@@ -301,9 +301,7 @@ class PARQUET_NO_EXPORT StructImpl : public ColumnReader::ColumnReaderImpl {
  public:
   explicit StructImpl(const std::vector<std::shared_ptr<ColumnReaderImpl>>& children,
                       int16_t struct_def_level, MemoryPool* pool, const Node* node)
-      : children_(children),
-        struct_def_level_(struct_def_level),
-        pool_(pool) {
+      : children_(children), struct_def_level_(struct_def_level), pool_(pool) {
     InitField(node, children);
   }
 

--- a/src/parquet/arrow/test-util.h
+++ b/src/parquet/arrow/test-util.h
@@ -402,17 +402,16 @@ Status MakeEmptyListsArray(int64_t size, std::shared_ptr<Array>* out_array) {
                                         &offsets_buffer));
   memset(offsets_buffer->mutable_data(), 0, offsets_nbytes);
 
-  auto value_field = ::arrow::field("item", ::arrow::float64(),
-                                    false /* nullable_values */);
+  auto value_field =
+      ::arrow::field("item", ::arrow::float64(), false /* nullable_values */);
   auto list_type = ::arrow::list(value_field);
 
   std::vector<std::shared_ptr<Buffer>> child_buffers = {nullptr /* null bitmap */,
-                                                        nullptr /* values */ };
-  auto child_data = ::arrow::ArrayData::Make(value_field->type(), 0,
-                                             std::move(child_buffers));
+                                                        nullptr /* values */};
+  auto child_data =
+      ::arrow::ArrayData::Make(value_field->type(), 0, std::move(child_buffers));
 
-  std::vector<std::shared_ptr<Buffer>> buffers = {nullptr /* bitmap */,
-                                                  offsets_buffer };
+  std::vector<std::shared_ptr<Buffer>> buffers = {nullptr /* bitmap */, offsets_buffer};
   auto array_data = ::arrow::ArrayData::Make(list_type, size, std::move(buffers));
   array_data->child_data.push_back(child_data);
 

--- a/src/parquet/arrow/writer.h
+++ b/src/parquet/arrow/writer.h
@@ -132,14 +132,6 @@ class PARQUET_EXPORT FileWriter {
       const std::shared_ptr<ArrowWriterProperties>& arrow_properties,
       std::unique_ptr<FileWriter>* writer);
 
-  static ::arrow::Status WriteMetaData(
-      const std::unique_ptr<FileMetaData>& fileMetaData,
-      const std::shared_ptr<OutputStream>& sink);
-
-  static ::arrow::Status WriteMetaData(
-      const std::unique_ptr<FileMetaData>& fileMetaData,
-      const std::shared_ptr<::arrow::io::OutputStream>& sink);
-
   /// \brief Write a Table to Parquet.
   ::arrow::Status WriteTable(const ::arrow::Table& table, int64_t chunk_size);
 
@@ -160,6 +152,15 @@ class PARQUET_EXPORT FileWriter {
   class PARQUET_NO_EXPORT Impl;
   std::unique_ptr<Impl> impl_;
 };
+
+/// \brief Write Parquet file metadata only to indicated OutputStream
+PARQUET_EXPORT
+::arrow::Status WriteFileMetaData(const FileMetaData& file_metadata, OutputStream* sink);
+
+/// \brief Write Parquet file metadata only to indicated Arrow OutputStream
+PARQUET_EXPORT
+::arrow::Status WriteFileMetaData(const FileMetaData& file_metadata,
+                                  const std::shared_ptr<::arrow::io::OutputStream>& sink);
 
 /**
  * Write a Table to Parquet.

--- a/src/parquet/encoding-benchmark.cc
+++ b/src/parquet/encoding-benchmark.cc
@@ -20,8 +20,8 @@
 #include "parquet/encoding-internal.h"
 #include "parquet/util/memory.h"
 
-using arrow::MemoryPool;
 using arrow::default_memory_pool;
+using arrow::MemoryPool;
 
 namespace parquet {
 

--- a/src/parquet/encoding-test.cc
+++ b/src/parquet/encoding-test.cc
@@ -30,8 +30,8 @@
 #include "parquet/util/memory.h"
 #include "parquet/util/test-common.h"
 
-using arrow::MemoryPool;
 using arrow::default_memory_pool;
+using arrow::MemoryPool;
 
 using std::string;
 using std::vector;

--- a/src/parquet/encoding.h
+++ b/src/parquet/encoding.h
@@ -51,12 +51,12 @@ class Encoder {
   virtual void PutSpaced(const T* src, int num_values, const uint8_t* valid_bits,
                          int64_t valid_bits_offset) {
     std::shared_ptr<ResizableBuffer> buffer;
-    auto status = ::arrow::AllocateResizableBuffer(pool_, num_values * sizeof(T),
-                                                   &buffer);
+    auto status =
+        ::arrow::AllocateResizableBuffer(pool_, num_values * sizeof(T), &buffer);
     if (!status.ok()) {
       std::ostringstream ss;
-      ss << "AllocateResizableBuffer failed in Encoder.PutSpaced in "
-         << __FILE__ << ", on line " << __LINE__;
+      ss << "AllocateResizableBuffer failed in Encoder.PutSpaced in " << __FILE__
+         << ", on line " << __LINE__;
       throw ParquetException(ss.str());
     }
     int32_t num_valid_values = 0;

--- a/src/parquet/file_writer.h
+++ b/src/parquet/file_writer.h
@@ -79,6 +79,9 @@ class PARQUET_EXPORT RowGroupWriter {
   std::unique_ptr<Contents> contents_;
 };
 
+PARQUET_EXPORT
+void WriteFileMetaData(const FileMetaData& file_metadata, OutputStream* sink);
+
 class PARQUET_EXPORT ParquetFileWriter {
  public:
   // Forward declare a virtual class 'Contents' to aid dependency injection and more
@@ -132,14 +135,6 @@ class PARQUET_EXPORT ParquetFileWriter {
       const std::shared_ptr<schema::GroupNode>& schema,
       const std::shared_ptr<WriterProperties>& properties = default_writer_properties(),
       const std::shared_ptr<const KeyValueMetadata>& key_value_metadata = nullptr);
-
-  static void WriteMetaData(
-          const std::shared_ptr<::arrow::io::OutputStream> &sink,
-          const std::unique_ptr<FileMetaData> &fileMetaData);
-
-  static void WriteMetaData(
-          const std::shared_ptr<OutputStream> &sink,
-          const std::unique_ptr<FileMetaData> &fileMetaData);
 
   void Open(std::unique_ptr<Contents> contents);
   void Close();

--- a/src/parquet/metadata.cc
+++ b/src/parquet/metadata.cc
@@ -222,9 +222,7 @@ int64_t ColumnChunkMetaData::data_page_offset() const {
   return impl_->data_page_offset();
 }
 
-bool ColumnChunkMetaData::has_index_page() const {
-  return impl_->has_index_page();
-}
+bool ColumnChunkMetaData::has_index_page() const { return impl_->has_index_page(); }
 
 int64_t ColumnChunkMetaData::index_page_offset() const {
   return impl_->index_page_offset();
@@ -345,7 +343,9 @@ class FileMetaData::FileMetaDataImpl {
 
   const ApplicationVersion& writer_version() const { return writer_version_; }
 
-  void WriteTo(OutputStream* dst) { SerializeThriftMsg(metadata_.get(), 1024, dst); }
+  void WriteTo(OutputStream* dst) const {
+    SerializeThriftMsg(metadata_.get(), 1024, dst);
+  }
 
   std::unique_ptr<RowGroupMetaData> RowGroup(int i) {
     if (!(i < num_row_groups())) {
@@ -462,7 +462,7 @@ std::shared_ptr<const KeyValueMetadata> FileMetaData::key_value_metadata() const
   return impl_->key_value_metadata();
 }
 
-void FileMetaData::WriteTo(OutputStream* dst) { return impl_->WriteTo(dst); }
+void FileMetaData::WriteTo(OutputStream* dst) const { return impl_->WriteTo(dst); }
 
 ApplicationVersion::ApplicationVersion(const std::string& application, int major,
                                        int minor, int patch)

--- a/src/parquet/metadata.h
+++ b/src/parquet/metadata.h
@@ -171,7 +171,7 @@ class PARQUET_EXPORT FileMetaData {
 
   const ApplicationVersion& writer_version() const;
 
-  void WriteTo(OutputStream* dst);
+  void WriteTo(OutputStream* dst) const;
 
   // Return const-pointer to make it clear that this object is not to be copied
   const SchemaDescriptor* schema() const;

--- a/src/parquet/statistics-test.cc
+++ b/src/parquet/statistics-test.cc
@@ -36,8 +36,8 @@
 #include "parquet/types.h"
 #include "parquet/util/memory.h"
 
-using arrow::MemoryPool;
 using arrow::default_memory_pool;
+using arrow::MemoryPool;
 
 namespace parquet {
 
@@ -194,8 +194,9 @@ bool* TestRowGroupStatistics<BooleanType>::GetValuesPointer(std::vector<bool>& v
 }
 
 template <typename TestType>
-typename std::vector<typename TestType::c_type> TestRowGroupStatistics<
-    TestType>::GetDeepCopy(const std::vector<typename TestType::c_type>& values) {
+typename std::vector<typename TestType::c_type>
+TestRowGroupStatistics<TestType>::GetDeepCopy(
+    const std::vector<typename TestType::c_type>& values) {
   return values;
 }
 

--- a/src/parquet/statistics.cc
+++ b/src/parquet/statistics.cc
@@ -24,8 +24,8 @@
 #include "parquet/statistics.h"
 #include "parquet/util/memory.h"
 
-using arrow::MemoryPool;
 using arrow::default_memory_pool;
+using arrow::MemoryPool;
 
 namespace parquet {
 

--- a/src/parquet/util/memory-test.cc
+++ b/src/parquet/util/memory-test.cc
@@ -27,8 +27,8 @@
 #include "parquet/util/memory.h"
 #include "parquet/util/test-common.h"
 
-using arrow::MemoryPool;
 using arrow::default_memory_pool;
+using arrow::MemoryPool;
 
 namespace parquet {
 
@@ -255,8 +255,8 @@ TEST(TestBufferedInputStream, Basics) {
   int64_t stream_offset = 10;
   int64_t stream_size = source_size - stream_offset;
   int64_t chunk_size = 50;
-  std::shared_ptr<ResizableBuffer> buf = AllocateBuffer(default_memory_pool(),
-                                                        source_size);
+  std::shared_ptr<ResizableBuffer> buf =
+      AllocateBuffer(default_memory_pool(), source_size);
   ASSERT_EQ(source_size, buf->size());
   for (int i = 0; i < source_size; i++) {
     buf->mutable_data()[i] = static_cast<uint8_t>(i);

--- a/src/parquet/util/memory.cc
+++ b/src/parquet/util/memory.cc
@@ -36,9 +36,7 @@ namespace parquet {
 
 template <class T>
 Vector<T>::Vector(int64_t size, MemoryPool* pool)
-    : buffer_(AllocateBuffer(pool, size * sizeof(T))),
-      size_(size),
-      capacity_(size) {
+    : buffer_(AllocateBuffer(pool, size * sizeof(T))), size_(size), capacity_(size) {
   if (size > 0) {
     data_ = reinterpret_cast<T*>(buffer_->mutable_data());
   } else {
@@ -497,8 +495,7 @@ void BufferedInputStream::Advance(int64_t num_bytes) {
 
 std::shared_ptr<ResizableBuffer> AllocateBuffer(MemoryPool* pool, int64_t size) {
   std::shared_ptr<ResizableBuffer> result;
-  PARQUET_THROW_NOT_OK(arrow::AllocateResizableBuffer(pool, size,
-                                                      &result));
+  PARQUET_THROW_NOT_OK(arrow::AllocateResizableBuffer(pool, size, &result));
   return result;
 }
 

--- a/src/parquet/util/memory.h
+++ b/src/parquet/util/memory.h
@@ -438,7 +438,7 @@ class PARQUET_EXPORT BufferedInputStream : public InputStream {
 };
 
 std::shared_ptr<ResizableBuffer> PARQUET_EXPORT AllocateBuffer(
-  ::arrow::MemoryPool* pool = ::arrow::default_memory_pool(), int64_t size = 0);
+    ::arrow::MemoryPool* pool = ::arrow::default_memory_pool(), int64_t size = 0);
 
 }  // namespace parquet
 


### PR DESCRIPTION
Per comments in PARQUET-1348. I also upgraded clang-format to 6.0 here so pardon the diff noise from that.

To summarize the style points:

* Don't pass `const std:shared_ptr<T>&` if `const T&` will do
* Don't pass `const std::shared_ptr<T>&` if `T*` will do
* I prefer to only use class static function members for alternate constructors
* Out arguments after in arguments
* `lower_with_underscores` for variable names