### PR TITLE
PARQUET-1402: [C++] parquet-mr writes dictionary_page_offset == 0 when it is (supposed?) …

### DIFF
--- a/src/parquet/file_reader.cc
+++ b/src/parquet/file_reader.cc
@@ -103,7 +103,7 @@ class SerializedRowGroup : public RowGroupReader::Contents {
     auto col = row_group_metadata_->ColumnChunk(i);
 
     int64_t col_start = col->data_page_offset();
-    if (col->has_dictionary_page() && col_start > col->dictionary_page_offset()) {
+    if (col->has_dictionary_page() && col->dictionary_page_offset() > 0 && col_start > col->dictionary_page_offset()) {
       col_start = col->dictionary_page_offset();
     }
 

--- a/src/parquet/file_reader.cc
+++ b/src/parquet/file_reader.cc
@@ -103,7 +103,7 @@ class SerializedRowGroup : public RowGroupReader::Contents {
     auto col = row_group_metadata_->ColumnChunk(i);
 
     int64_t col_start = col->data_page_offset();
-    if (col->has_dictionary_page() && 
+    if (col->has_dictionary_page() &&
         col->dictionary_page_offset() > 0 && col_start > col->dictionary_page_offset()) {
       col_start = col->dictionary_page_offset();
     }

--- a/src/parquet/file_reader.cc
+++ b/src/parquet/file_reader.cc
@@ -103,7 +103,8 @@ class SerializedRowGroup : public RowGroupReader::Contents {
     auto col = row_group_metadata_->ColumnChunk(i);
 
     int64_t col_start = col->data_page_offset();
-    if (col->has_dictionary_page() && col->dictionary_page_offset() > 0 && col_start > col->dictionary_page_offset()) {
+    if (col->has_dictionary_page() && 
+        col->dictionary_page_offset() > 0 && col_start > col->dictionary_page_offset()) {
       col_start = col->dictionary_page_offset();
     }
 


### PR DESCRIPTION
…equal to data_page_offset.